### PR TITLE
Enforce Agent.mcp_toolset through runtime CLIs + MCP e2e matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,13 @@ test-e2e-fast:
 test-e2e-tools:
 	uv run pytest tests/e2e/test_agent_tools.py -v -m "tool_matrix"
 
+# MCP-enforcement matrix — ~14 real sessions across runtimes.
+# Requires FAIRY_API_TOKEN. The /test-mcp endpoint is served by the Fairy
+# deployment when DEBUG=True or FAIRY_TESTING=1; set MCP_TEST_URL to override
+# with a different test server.
+test-e2e-mcp:
+	uv run pytest tests/e2e/test_mcp_enforcement.py -v -m "mcp_matrix"
+
 # Run everything — unit + e2e. E2E auto-skips if FAIRY_API_TOKEN is unset.
 test-all:
 	uv run pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -74,6 +74,28 @@ Configurations are accepted silently even when unenforceable on the selected
 runtime. For full behavioral guarantees, use `claude` or `gemini`; `codex` is
 best-effort.
 
+### MCP servers and mcp_toolset
+
+Agents also accept `mcp_servers` (an array of URL/stdio MCP endpoints) and
+`mcp_toolset` entries inside `tools` (per-server allow/deny lists). The
+runtime translation surface:
+
+| Scenario | claude / claude-oauth | codex | gemini |
+| --- | --- | --- | --- |
+| Server declared, no restriction | ✓ (always) | ✓ (always) | ✓ (always) |
+| `mcp_toolset default_config.enabled=false` (deny server) | ✓ via `~/.claude/settings.json` `permissions.deny` | ✓ via `enabled = false` on `[mcp_servers.<name>]` | ✓ via `includeTools=[]` |
+| `mcp_toolset configs[].enabled=false` (deny one tool) | ✓ via `permissions.deny` with `mcp__<server>__<tool>` | ✓ via `disabled_tools` | ✓ via `excludeTools` |
+| `default_config.enabled=false` + allow one tool | ✓ (deny server + allow specific) | ✓ via `enabled_tools` | ✓ via `includeTools` |
+
+Claude MCP tool names in `--disallowedTools` are silently ignored in `-p` mode
+(upstream [claude-code#12863](https://github.com/anthropics/claude-code/issues/12863)),
+so Fairy writes `~/.claude/settings.json` `permissions.deny` rules instead.
+Restrictions reapply on every `POST /sessions/{id}/prompt` because the wrapper
+script is rebuilt per call.
+
+Unknown `mcp_toolset.mcp_server_name` values — referencing a server not in the
+agent's `mcp_servers` — are rejected with `422`.
+
 ## Testing
 
 ### Unit / integration tests
@@ -117,6 +139,12 @@ FAIRY_API_TOKEN=<token> make test-e2e
 
 # tool-enforcement matrix — ~11 sessions verifying tools flow through per runtime
 FAIRY_API_TOKEN=<token> E2E_RUNTIMES=claude,codex,gemini make test-e2e-tools
+
+# MCP-enforcement matrix — ~14 sessions verifying mcp_servers + mcp_toolset
+# are respected. Fairy must be running with DEBUG=True or FAIRY_TESTING=1 so
+# the /test-mcp endpoint is live; set MCP_TEST_URL to point at a different
+# test server.
+FAIRY_API_TOKEN=<token> E2E_RUNTIMES=claude,codex,gemini make test-e2e-mcp
 
 # single class
 FAIRY_API_TOKEN=<token> \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,4 +31,5 @@ pythonpath = ["src"]
 markers = [
     "slow: tests that create real agent sessions (may take minutes)",
     "tool_matrix: verifies agent tool enforcement across runtimes",
+    "mcp_matrix: verifies MCP server + mcp_toolset enforcement across runtimes",
 ]

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -7,6 +7,8 @@ SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "dev-insecure-key-change-in-pro
 
 DEBUG = os.environ.get("DJANGO_DEBUG", "true").lower() == "true"
 
+TESTING = os.environ.get("FAIRY_TESTING", "").lower() in ("1", "true")
+
 ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "*").split(",")
 
 INSTALLED_APPS = [

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -1,7 +1,10 @@
 from django.contrib import admin
 from django.urls import include, path
 
+from fairy.test_mcp import mcp_streamable_http
+
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("test-mcp", mcp_streamable_http),
     path("", include("fairy.urls")),
 ]

--- a/src/fairy/sprites_exec.py
+++ b/src/fairy/sprites_exec.py
@@ -36,6 +36,41 @@ class McpServerSpec:
     env: dict[str, str] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class McpToolsetRules:
+    """Normalized mcp_toolset restrictions for a single server.
+
+    default_enabled: default for tools not listed in per_tool (True = allow-by-default).
+    per_tool: {tool_name: enabled} — overrides default for specific tools.
+    """
+    default_enabled: bool
+    per_tool: dict[str, bool] = field(default_factory=dict)
+
+
+def _build_mcp_toolset_rules(tools: list[dict]) -> dict[str, McpToolsetRules]:
+    """Extract per-server rules from mcp_toolset tool entries.
+
+    Servers without an mcp_toolset entry are absent from the result (no restrictions).
+    An entry with no default_config and no configs keeps default_enabled=True and
+    empty per_tool, producing a no-op rules record that runtime writers may skip.
+    """
+    rules: dict[str, McpToolsetRules] = {}
+    for t in tools:
+        if not isinstance(t, dict) or t.get("type") != "mcp_toolset":
+            continue
+        name = t.get("mcp_server_name")
+        if not name:
+            continue
+        default_enabled = t.get("default_config", {}).get("enabled", True)
+        per_tool = {
+            c["name"]: c.get("enabled", True)
+            for c in t.get("configs", [])
+            if isinstance(c, dict) and "name" in c
+        }
+        rules[name] = McpToolsetRules(default_enabled=default_enabled, per_tool=per_tool)
+    return rules
+
+
 PACKAGE_MANAGER_ORDER = ["apt", "cargo", "gem", "go", "npm", "pip"]
 
 
@@ -117,8 +152,16 @@ def _build_clone_section(repos: list[RepoSpec]) -> str:
     return "\n".join(lines)
 
 
-def _build_mcp_claude(servers: list[McpServerSpec]) -> str:
-    """Generate Claude MCP config JSON and write command."""
+def _build_mcp_claude(
+    servers: list[McpServerSpec],
+    rules: dict[str, McpToolsetRules] | None = None,  # noqa: ARG001 — Phase 4 reads this
+) -> str:
+    """Generate Claude MCP config JSON and write command.
+
+    The rules parameter is threaded through for signature parity with codex/gemini,
+    but Claude applies MCP allow/deny via a separate `~/.claude/settings.json`
+    writer (`_tool_files_claude_mcp`), not inside this file.
+    """
     config: dict[str, dict] = {}
     for s in servers:
         if s.type == "url":
@@ -170,9 +213,11 @@ def _codex_top_level_keys(tools: list[dict]) -> list[str]:
 def _build_mcp_codex(
     servers: list[McpServerSpec],
     tools: list[dict] | None = None,
+    rules: dict[str, McpToolsetRules] | None = None,
 ) -> str:
     """Generate Codex config TOML (MCP servers + tool enforcement keys)."""
     tools = tools or []
+    rules = rules or {}
     top_level = _codex_top_level_keys(tools)
 
     if not servers and not top_level:
@@ -186,6 +231,19 @@ def _build_mcp_codex(
             lines.append("")
     for s in servers:
         lines.append(f"[mcp_servers.{s.name}]")
+        server_rules = rules.get(s.name)
+        if server_rules is not None:
+            if not server_rules.default_enabled and not server_rules.per_tool:
+                lines.append("enabled = false")
+            else:
+                allowed = [t for t, e in server_rules.per_tool.items() if e]
+                denied = [t for t, e in server_rules.per_tool.items() if not e]
+                if not server_rules.default_enabled and allowed:
+                    allow_list = ", ".join(f'"{t}"' for t in allowed)
+                    lines.append(f"enabled_tools = [{allow_list}]")
+                if denied:
+                    deny_list = ", ".join(f'"{t}"' for t in denied)
+                    lines.append(f"disabled_tools = [{deny_list}]")
         if s.type == "url":
             lines.append(f'url = "{s.url}"')
             for key, val in s.headers.items():
@@ -210,20 +268,46 @@ def _build_mcp_codex(
     return "\n".join(lines)
 
 
-def _build_mcp_gemini(servers: list[McpServerSpec]) -> str:
-    """Generate Gemini MCP config JSON and write command."""
+def _build_mcp_gemini(
+    servers: list[McpServerSpec],
+    rules: dict[str, McpToolsetRules] | None = None,
+) -> str:
+    """Generate Gemini MCP config JSON and write command.
+
+    MCP tool allow/deny is emitted as includeTools/excludeTools on each mcpServers
+    entry — not via the Policy Engine TOML that `_tool_files_gemini` writes for
+    built-in tools. Policy Engine uses single-underscore `mcp_{server}_{tool}`
+    naming which misparses server aliases containing underscores, so we keep MCP
+    rules localized to the settings.json file that this function already writes.
+    """
+    rules = rules or {}
     config: dict[str, dict] = {}
     for s in servers:
         if s.type == "url":
             entry: dict = {"httpUrl": s.url, "trust": True}
             if s.headers:
                 entry["headers"] = s.headers
-            config[s.name] = entry
         elif s.type == "stdio":
             entry = {"command": s.command, "args": s.args, "trust": True}
             if s.env:
                 entry["env"] = s.env
-            config[s.name] = entry
+        else:
+            continue
+
+        server_rules = rules.get(s.name)
+        if server_rules is not None:
+            if not server_rules.default_enabled and not server_rules.per_tool:
+                entry["includeTools"] = []
+            else:
+                allowed = [t for t, e in server_rules.per_tool.items() if e]
+                denied = [t for t, e in server_rules.per_tool.items() if not e]
+                if not server_rules.default_enabled and allowed:
+                    entry["includeTools"] = allowed
+                if denied:
+                    entry["excludeTools"] = denied
+
+        config[s.name] = entry
+
     content = json.dumps({"mcpServers": config}, indent=2)
     return (
         "# MCP server configuration\n"
@@ -237,21 +321,25 @@ def _build_mcp_section(
     runtime_name: str,
     servers: list[McpServerSpec],
     tools: list[dict] | None = None,
+    rules: dict[str, McpToolsetRules] | None = None,
 ) -> str:
     """Build MCP config section for the wrapper script.
 
     Codex folds tool-enforcement keys into the same config.toml it uses for MCP,
     so `tools` is threaded through here. Other runtimes emit tool enforcement via
     the separate `_tool_files_*` path.
+
+    `rules` carries per-server mcp_toolset allow/deny. Codex and gemini consume it
+    inside their MCP config; claude consumes it via `_tool_files_claude_mcp`.
     """
     if runtime_name == "codex":
-        return _build_mcp_codex(servers, tools=tools)
+        return _build_mcp_codex(servers, tools=tools, rules=rules)
     if not servers:
         return ""
     if runtime_name in ("claude", "claude-oauth"):
-        return _build_mcp_claude(servers)
+        return _build_mcp_claude(servers, rules=rules)
     if runtime_name == "gemini":
-        return _build_mcp_gemini(servers)
+        return _build_mcp_gemini(servers, rules=rules)
     return ""
 
 
@@ -392,10 +480,51 @@ def _tool_files_gemini(tools: list[dict]) -> dict[str, str]:
     return {GEMINI_POLICY_PATH: "\n\n".join(rules) + "\n"}
 
 
+CLAUDE_SETTINGS_PATH = "/home/sprite/.claude/settings.json"
+
+
+def _tool_files_claude_mcp(
+    rules: dict[str, McpToolsetRules],
+) -> dict[str, str]:
+    """Write ~/.claude/settings.json with permissions.allow/deny for MCP tools.
+
+    Claude `-p` mode silently ignores MCP names in `--disallowedTools` (upstream
+    issue #12863). The only working deny path in headless mode is `permissions.deny`
+    in a settings file. Tool names use double-underscore `mcp__<server>[__<tool>]`.
+    """
+    deny: list[dict[str, str]] = []
+    allow: list[dict[str, str]] = []
+    for server_name, r in rules.items():
+        if not r.default_enabled and not r.per_tool:
+            deny.append({"tool": f"mcp__{server_name}"})
+            continue
+        if not r.default_enabled:
+            deny.append({"tool": f"mcp__{server_name}"})
+            for tool_name, enabled in r.per_tool.items():
+                if enabled:
+                    allow.append({"tool": f"mcp__{server_name}__{tool_name}"})
+        else:
+            for tool_name, enabled in r.per_tool.items():
+                if not enabled:
+                    deny.append({"tool": f"mcp__{server_name}__{tool_name}"})
+
+    if not deny and not allow:
+        return {}
+
+    permissions: dict[str, list] = {}
+    if allow:
+        permissions["allow"] = allow
+    if deny:
+        permissions["deny"] = deny
+
+    return {CLAUDE_SETTINGS_PATH: json.dumps({"permissions": permissions}, indent=2) + "\n"}
+
+
 def _build_tool_flags(
     runtime_name: str,
     tools: list[dict],
     mcp_server_names: list[str],
+    rules: dict[str, McpToolsetRules] | None = None,
 ) -> tuple[str, dict[str, str]]:
     """Translate Agent.tools into runtime-specific enforcement.
 
@@ -406,10 +535,13 @@ def _build_tool_flags(
     Codex folds its tool enforcement into the MCP config.toml instead of using
     this path — it returns ("", {}) here. See `_build_mcp_codex`.
     """
-    if not tools:
+    rules = rules or {}
+    if not tools and not rules:
         return "", {}
     if runtime_name in ("claude", "claude-oauth"):
-        return _tool_flags_claude(tools, mcp_server_names), {}
+        flags = _tool_flags_claude(tools, mcp_server_names)
+        files = _tool_files_claude_mcp(rules)
+        return flags, files
     if runtime_name == "gemini":
         return "", _tool_files_gemini(tools)
     return "", {}
@@ -457,11 +589,16 @@ def build_wrapper_script(
         packages_section = _build_packages_section(environment.packages)
         setup_section = _build_setup_script_section(environment.setup_script)
 
-    mcp_section = _build_mcp_section(config.name, mcp_servers or [], tools=tools)
+    mcp_rules = _build_mcp_toolset_rules(tools or [])
+    mcp_section = _build_mcp_section(
+        config.name, mcp_servers or [], tools=tools, rules=mcp_rules,
+    )
     mcp_flags = _mcp_cmd_flags(config.name, mcp_servers or [])
 
     mcp_names = [s.name for s in (mcp_servers or [])]
-    tool_flags, tool_files = _build_tool_flags(config.name, tools or [], mcp_names)
+    tool_flags, tool_files = _build_tool_flags(
+        config.name, tools or [], mcp_names, rules=mcp_rules,
+    )
     tool_files_section = _format_tool_files_heredoc(tool_files)
 
     return f"""#!/bin/bash

--- a/src/fairy/test_mcp.py
+++ b/src/fairy/test_mcp.py
@@ -1,0 +1,146 @@
+"""Deterministic MCP test server for e2e MCP enforcement tests.
+
+Implements the MCP Streamable HTTP protocol (JSON-RPC over POST) with three
+tools: signal_tool, echo, dangerous_tool. Gated behind DEBUG or FAIRY_TESTING
+so it's never live in production.
+
+Do NOT rely on this endpoint from any non-test client.
+"""
+
+import json
+import os
+
+from django.conf import settings
+from django.http import HttpResponse, JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+
+PROTOCOL_VERSION = "2024-11-05"
+SERVER_INFO = {"name": "fairy-test-mcp", "version": "1.0.0"}
+
+TOOLS = [
+    {
+        "name": "signal_tool",
+        "description": (
+            "Returns 'MCP_SIGNAL_<token>'. Used by e2e tests to confirm the MCP "
+            "tool was actually invoked."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {"token": {"type": "string"}},
+            "required": ["token"],
+        },
+    },
+    {
+        "name": "echo",
+        "description": "Echoes the input message back verbatim.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"msg": {"type": "string"}},
+            "required": ["msg"],
+        },
+    },
+    {
+        "name": "dangerous_tool",
+        "description": (
+            "Returns 'SHOULD_NOT_BE_CALLED'. Used by e2e tests to verify deny "
+            "paths — if this response appears in output, the deny failed."
+        ),
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+]
+
+
+def _call_tool(name: str, arguments: dict) -> dict:
+    if name == "signal_tool":
+        token = arguments.get("token", "")
+        return {"content": [{"type": "text", "text": f"MCP_SIGNAL_{token}"}]}
+    if name == "echo":
+        return {"content": [{"type": "text", "text": str(arguments.get("msg", ""))}]}
+    if name == "dangerous_tool":
+        return {"content": [{"type": "text", "text": "SHOULD_NOT_BE_CALLED"}]}
+    return {
+        "content": [{"type": "text", "text": f"Unknown tool: {name}"}],
+        "isError": True,
+    }
+
+
+def _endpoint_enabled() -> bool:
+    return settings.DEBUG or getattr(settings, "TESTING", False)
+
+
+def _check_auth(request) -> bool:
+    expected = os.environ.get("MCP_TEST_TOKEN")
+    if not expected:
+        return True
+    auth = request.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        return False
+    return auth.removeprefix("Bearer ").strip() == expected
+
+
+def _handle_request(req: dict) -> dict | None:
+    """Dispatch a single JSON-RPC request. Returns None for notifications."""
+    method = req.get("method")
+    req_id = req.get("id")
+
+    if req_id is None:
+        return None
+
+    if method == "initialize":
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "serverInfo": SERVER_INFO,
+            },
+        }
+    if method == "tools/list":
+        return {"jsonrpc": "2.0", "id": req_id, "result": {"tools": TOOLS}}
+    if method == "tools/call":
+        params = req.get("params", {})
+        tool_name = params.get("name", "")
+        args = params.get("arguments", {}) or {}
+        return {"jsonrpc": "2.0", "id": req_id, "result": _call_tool(tool_name, args)}
+    if method == "ping":
+        return {"jsonrpc": "2.0", "id": req_id, "result": {}}
+
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "error": {"code": -32601, "message": f"Method not found: {method}"},
+    }
+
+
+@csrf_exempt
+@require_POST
+def mcp_streamable_http(request):
+    if not _endpoint_enabled():
+        return JsonResponse({"detail": "test-mcp disabled"}, status=403)
+    if not _check_auth(request):
+        return JsonResponse({"detail": "unauthorized"}, status=401)
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": "Parse error"},
+            },
+            status=400,
+        )
+
+    if isinstance(body, list):
+        responses = [r for r in (_handle_request(req) for req in body) if r is not None]
+        if not responses:
+            return HttpResponse(status=202)
+        return JsonResponse(responses, safe=False)
+
+    response = _handle_request(body)
+    if response is None:
+        return HttpResponse(status=202)
+    return JsonResponse(response)

--- a/src/fairy/views.py
+++ b/src/fairy/views.py
@@ -493,9 +493,48 @@ def _validate_tools(tools: list) -> list:
                 f"tools[{i}]: unknown type {tool['type']!r}. "
                 f"Must be one of: {sorted(VALID_TOOL_TYPES)}"
             )
-        if tool["type"] == "mcp_toolset" and "mcp_server_name" not in tool:
-            raise ValueError(f"tools[{i}] (mcp_toolset): missing required field: mcp_server_name")
+        if tool["type"] == "mcp_toolset":
+            if "mcp_server_name" not in tool:
+                raise ValueError(
+                    f"tools[{i}] (mcp_toolset): missing required field: mcp_server_name"
+                )
+            if "configs" in tool:
+                configs = tool["configs"]
+                if not isinstance(configs, list):
+                    raise ValueError(f"tools[{i}].configs must be a list")
+                for j, cfg in enumerate(configs):
+                    if not isinstance(cfg, dict):
+                        raise ValueError(f"tools[{i}].configs[{j}] must be an object")
+                    if "name" in cfg and not isinstance(cfg["name"], str):
+                        raise ValueError(f"tools[{i}].configs[{j}].name must be a string")
+                    if "enabled" in cfg and not isinstance(cfg["enabled"], bool):
+                        raise ValueError(
+                            f"tools[{i}].configs[{j}].enabled must be a boolean"
+                        )
+            if "default_config" in tool:
+                dc = tool["default_config"]
+                if not isinstance(dc, dict):
+                    raise ValueError(f"tools[{i}].default_config must be an object")
+                if "enabled" in dc and not isinstance(dc["enabled"], bool):
+                    raise ValueError(
+                        f"tools[{i}].default_config.enabled must be a boolean"
+                    )
     return tools
+
+
+def _cross_validate_tool_refs(tools: list, mcp_servers: list) -> None:
+    """Check that every mcp_toolset.mcp_server_name references a server in mcp_servers."""
+    server_names = {s["name"] for s in mcp_servers if isinstance(s, dict) and "name" in s}
+    for i, tool in enumerate(tools):
+        if not isinstance(tool, dict):
+            continue
+        if tool.get("type") != "mcp_toolset":
+            continue
+        name = tool.get("mcp_server_name")
+        if name and name not in server_names:
+            raise ValueError(
+                f"tools[{i}] (mcp_toolset) references unknown server: {name!r}"
+            )
 
 
 def _validate_mcp_servers(servers: list) -> list:
@@ -665,6 +704,11 @@ def agents_list_create(request):
         except ValidationError as e:
             return JsonResponse({"detail": e.errors(include_context=False)}, status=422)
 
+        try:
+            _cross_validate_tool_refs(req.tools, req.mcp_servers)
+        except ValueError as e:
+            return JsonResponse({"detail": str(e)}, status=422)
+
         if req.runtime not in RUNTIMES:
             return JsonResponse(
                 {"detail": f"Unknown runtime: {req.runtime}. Must be one of: {list(RUNTIMES)}"},
@@ -740,6 +784,13 @@ def agent_detail(request, agent_id):
                 {"detail": f"Unknown runtime: {req.runtime}. Must be one of: {list(RUNTIMES)}"},
                 status=400,
             )
+
+        effective_tools = req.tools if req.tools is not None else agent.tools
+        effective_mcp_servers = req.mcp_servers if req.mcp_servers is not None else agent.mcp_servers
+        try:
+            _cross_validate_tool_refs(effective_tools, effective_mcp_servers)
+        except ValueError as e:
+            return JsonResponse({"detail": str(e)}, status=422)
 
         # Detect changes
         changed = False

--- a/tests/e2e/test_mcp_enforcement.py
+++ b/tests/e2e/test_mcp_enforcement.py
@@ -1,0 +1,333 @@
+"""E2E tests verifying Agent.mcp_servers + mcp_toolset are enforced by each runtime.
+
+Per-rule translation is covered exhaustively by unit tests in tests/test_tools_mcp.py.
+These tests only prove the translation layer reaches the runtime end-to-end, using the
+Fairy-hosted /test-mcp server for deterministic tool signals.
+
+3 runtimes × 4 scenarios + 1 multi-turn = ~14 sessions per full run.
+
+Requirements:
+    FAIRY_API_TOKEN   valid API key
+    MCP_TEST_URL      URL of a reachable MCP test server. Defaults to
+                      $FAIRY_API_URL/test-mcp, which is served by Fairy when
+                      DEBUG=True or FAIRY_TESTING=1.
+
+Run: `make test-e2e-mcp`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from tests.e2e.conftest import (
+    RUNTIME_MODELS,
+    FairyClient,
+    _unique,
+    stream_all_output,
+)
+
+pytestmark = [pytest.mark.slow, pytest.mark.mcp_matrix]
+
+# No underscore in the server alias — avoids any parser ambiguity across runtimes.
+MCP_TEST_SERVER_NAME = "testmcp"
+MCP_TEST_TOOL_NAME = "signal_tool"
+MCP_TEST_SIGNAL_PREFIX = "MCP_SIGNAL_"
+MCP_TEST_SIGNAL_TOKEN = "OK"
+MCP_DANGEROUS_SENTINEL = "SHOULD_NOT_BE_CALLED"
+
+RUNTIME_MCP_TOOL_NAMES = {
+    "claude":       f"mcp__{MCP_TEST_SERVER_NAME}__{MCP_TEST_TOOL_NAME}",
+    "claude-oauth": f"mcp__{MCP_TEST_SERVER_NAME}__{MCP_TEST_TOOL_NAME}",
+    "codex":        f"mcp__{MCP_TEST_SERVER_NAME}__{MCP_TEST_TOOL_NAME}",
+    "gemini":       f"mcp__{MCP_TEST_SERVER_NAME}__{MCP_TEST_TOOL_NAME}",
+}
+
+PROMPT_INVOKE = (
+    f"Call the `{MCP_TEST_TOOL_NAME}` tool from the `{MCP_TEST_SERVER_NAME}` "
+    f"MCP server with argument token={MCP_TEST_SIGNAL_TOKEN!r}. Print the tool's "
+    f"exact response."
+)
+PROMPT_NO_MCP = (
+    "List any MCP tools you have access to. If you have no MCP tools available, "
+    "respond with NO_MCP_TOOLS."
+)
+
+
+# ---------------------------------------------------------------------------
+# Parsers: extract mcp__server__tool names from each runtime's stream events
+# ---------------------------------------------------------------------------
+
+def _parse_claude_mcp_tool_names(events: list[dict]) -> list[str]:
+    names: list[str] = []
+    for e in events:
+        if e.get("type") != "output":
+            continue
+        try:
+            obj = json.loads(e.get("data", ""))
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if obj.get("type") == "assistant":
+            for block in obj.get("message", {}).get("content", []):
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    name = block.get("name", "")
+                    if name.startswith("mcp__"):
+                        names.append(name)
+    return names
+
+
+def _parse_codex_mcp_tool_names(events: list[dict]) -> list[str]:
+    names: list[str] = []
+    for e in events:
+        if e.get("type") != "output":
+            continue
+        try:
+            obj = json.loads(e.get("data", ""))
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if obj.get("type") in ("item.started", "item.completed"):
+            item = obj.get("item", {})
+            if item.get("type") == "mcp_tool_call":
+                server = item.get("server", "")
+                tool = item.get("tool", "")
+                names.append(f"mcp__{server}__{tool}")
+    return names
+
+
+def _parse_gemini_mcp_tool_names(events: list[dict]) -> list[str]:
+    names: list[str] = []
+    for e in events:
+        if e.get("type") != "output":
+            continue
+        try:
+            obj = json.loads(e.get("data", ""))
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if obj.get("type") == "tool_use":
+            name = obj.get("tool_name") or obj.get("name") or ""
+            if name.startswith("mcp__"):
+                names.append(name)
+    return names
+
+
+def _mcp_tool_was_invoked(events: list[dict], runtime: str) -> bool:
+    target = RUNTIME_MCP_TOOL_NAMES[runtime]
+    if runtime in ("claude", "claude-oauth"):
+        return target in _parse_claude_mcp_tool_names(events)
+    if runtime == "codex":
+        return target in _parse_codex_mcp_tool_names(events)
+    if runtime == "gemini":
+        return target in _parse_gemini_mcp_tool_names(events)
+    return False
+
+
+def _any_mcp_tool_was_invoked(events: list[dict], runtime: str) -> bool:
+    if runtime in ("claude", "claude-oauth"):
+        return bool(_parse_claude_mcp_tool_names(events))
+    if runtime == "codex":
+        return bool(_parse_codex_mcp_tool_names(events))
+    if runtime == "gemini":
+        return bool(_parse_gemini_mcp_tool_names(events))
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Tool-restriction builders
+# ---------------------------------------------------------------------------
+
+def _allow_all_agent_tools() -> dict:
+    return {"type": "agent_toolset_20260401"}
+
+
+def _mcp_server_spec(url: str) -> dict:
+    return {"type": "url", "name": MCP_TEST_SERVER_NAME, "url": url}
+
+
+def _mcp_toolset_allow_server() -> dict:
+    return {"type": "mcp_toolset", "mcp_server_name": MCP_TEST_SERVER_NAME}
+
+
+def _mcp_toolset_deny_server() -> dict:
+    return {
+        "type": "mcp_toolset",
+        "mcp_server_name": MCP_TEST_SERVER_NAME,
+        "default_config": {"enabled": False},
+    }
+
+
+def _mcp_toolset_deny_one_tool() -> dict:
+    return {
+        "type": "mcp_toolset",
+        "mcp_server_name": MCP_TEST_SERVER_NAME,
+        "configs": [{"name": MCP_TEST_TOOL_NAME, "enabled": False}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def mcp_test_url(fairy_url):
+    override = os.environ.get("MCP_TEST_URL")
+    if override:
+        return override
+    return f"{fairy_url.rstrip('/')}/test-mcp"
+
+
+@pytest.fixture(scope="class", params=["claude", "codex", "gemini"])
+def runtime(request, e2e_runtimes):
+    if request.param not in e2e_runtimes:
+        pytest.skip(f"{request.param} not in E2E_RUNTIMES")
+    return request.param
+
+
+# ---------------------------------------------------------------------------
+# Matrix
+# ---------------------------------------------------------------------------
+
+class TestMcpServerToolInvocable:
+    """Server declared, no restrictions → agent invokes the MCP tool."""
+
+    def test_mcp_server_tool_is_invocable(
+        self, api: FairyClient, create_agent, create_session, runtime, mcp_test_url,
+    ):
+        agent = create_agent(
+            name=_unique(f"e2e-mcp-allow-{runtime}"),
+            model=RUNTIME_MODELS[runtime],
+            runtime=runtime,
+            tools=[_allow_all_agent_tools(), _mcp_toolset_allow_server()],
+            mcp_servers=[_mcp_server_spec(mcp_test_url)],
+        )
+        session = create_session(
+            agent_id=agent["id"], prompt=PROMPT_INVOKE, timeout=120,
+        )
+        final, events = api.run_session(session["id"])
+        output = stream_all_output(events)
+        assert final["status"] == "completed", (
+            f"Session status={final['status']} exit={final.get('exit_code')}\n"
+            f"Output: {output[:500]}"
+        )
+        assert _mcp_tool_was_invoked(events, runtime), (
+            f"Expected MCP tool {RUNTIME_MCP_TOOL_NAMES[runtime]!r} to be invoked.\n"
+            f"Output: {output[:500]}"
+        )
+        assert MCP_TEST_SIGNAL_PREFIX in output, (
+            f"Expected signal prefix {MCP_TEST_SIGNAL_PREFIX!r} in session output.\n"
+            f"Output: {output[:500]}"
+        )
+
+
+class TestMcpDenySpecificTool:
+    """mcp_toolset.configs denies one tool → tool is not invoked."""
+
+    def test_mcp_deny_specific_tool(
+        self, api: FairyClient, create_agent, create_session, runtime, mcp_test_url,
+    ):
+        agent = create_agent(
+            name=_unique(f"e2e-mcp-denytool-{runtime}"),
+            model=RUNTIME_MODELS[runtime],
+            runtime=runtime,
+            tools=[_allow_all_agent_tools(), _mcp_toolset_deny_one_tool()],
+            mcp_servers=[_mcp_server_spec(mcp_test_url)],
+        )
+        session = create_session(
+            agent_id=agent["id"], prompt=PROMPT_INVOKE, timeout=120,
+        )
+        _final, events = api.run_session(session["id"])
+        output = stream_all_output(events)
+        assert not _mcp_tool_was_invoked(events, runtime), (
+            f"MCP tool {MCP_TEST_TOOL_NAME!r} was invoked despite deny on {runtime}.\n"
+            f"Output: {output[:500]}"
+        )
+
+
+class TestMcpDenyEntireServer:
+    """mcp_toolset default_config.enabled=False → no MCP tool from the server callable."""
+
+    def test_mcp_deny_entire_server(
+        self, api: FairyClient, create_agent, create_session, runtime, mcp_test_url,
+    ):
+        agent = create_agent(
+            name=_unique(f"e2e-mcp-denyserver-{runtime}"),
+            model=RUNTIME_MODELS[runtime],
+            runtime=runtime,
+            tools=[_allow_all_agent_tools(), _mcp_toolset_deny_server()],
+            mcp_servers=[_mcp_server_spec(mcp_test_url)],
+        )
+        session = create_session(
+            agent_id=agent["id"], prompt=PROMPT_INVOKE, timeout=120,
+        )
+        _final, events = api.run_session(session["id"])
+        output = stream_all_output(events)
+        assert not _any_mcp_tool_was_invoked(events, runtime), (
+            f"An MCP tool was invoked despite deny-entire-server on {runtime}.\n"
+            f"Output: {output[:500]}"
+        )
+        assert MCP_DANGEROUS_SENTINEL not in output, (
+            f"Dangerous sentinel {MCP_DANGEROUS_SENTINEL!r} in output — deny leaked.\n"
+            f"Output: {output[:500]}"
+        )
+
+
+class TestNoMcpServerNoMcpTool:
+    """No mcp_servers → no mcp__* tool calls."""
+
+    def test_no_mcp_server_no_mcp_tool(
+        self, api: FairyClient, create_agent, create_session, runtime,
+    ):
+        agent = create_agent(
+            name=_unique(f"e2e-mcp-noserver-{runtime}"),
+            model=RUNTIME_MODELS[runtime],
+            runtime=runtime,
+            tools=[_allow_all_agent_tools()],
+            mcp_servers=[],
+        )
+        session = create_session(
+            agent_id=agent["id"], prompt=PROMPT_NO_MCP, timeout=90,
+        )
+        final, events = api.run_session(session["id"])
+        assert final["status"] == "completed", (
+            f"Session failed: {final['status']}\n"
+            f"Output: {stream_all_output(events)[:500]}"
+        )
+        assert not _any_mcp_tool_was_invoked(events, runtime), (
+            f"MCP tool invoked despite no mcp_servers on {runtime}.\n"
+            f"Output: {stream_all_output(events)[:500]}"
+        )
+
+
+class TestMcpDenyPersistsAcrossTurns:
+    """MCP restrictions must re-apply on POST /sessions/{id}/prompt.
+
+    Claude-only because multi-turn is exercised by other runtimes in test_sessions.py;
+    here we only need to prove the deny rules file is re-emitted on continue.
+    """
+
+    def test_mcp_deny_persists(
+        self, api: FairyClient, create_agent, create_session, e2e_runtimes, mcp_test_url,
+    ):
+        if "claude" not in e2e_runtimes:
+            pytest.skip("claude not in E2E_RUNTIMES")
+        agent = create_agent(
+            name=_unique("e2e-mcp-multiturn"),
+            model=RUNTIME_MODELS["claude"],
+            runtime="claude",
+            tools=[_allow_all_agent_tools(), _mcp_toolset_deny_server()],
+            mcp_servers=[_mcp_server_spec(mcp_test_url)],
+        )
+        session = create_session(
+            agent_id=agent["id"], prompt="Say 'hello'.", timeout=60,
+        )
+        api.run_session(session["id"])
+
+        resp = api.send_prompt(session["id"], prompt=PROMPT_INVOKE, timeout=120)
+        assert resp.status_code == 202
+
+        _final, events = api.run_session(session["id"])
+        assert not _any_mcp_tool_was_invoked(events, "claude"), (
+            "MCP tool invoked on turn 2 — server deny did not persist.\n"
+            f"Output: {stream_all_output(events)[:500]}"
+        )

--- a/tests/test_mcp_endpoint.py
+++ b/tests/test_mcp_endpoint.py
@@ -1,0 +1,176 @@
+"""Unit tests for the /test-mcp server used by the MCP e2e matrix."""
+
+import json
+
+import pytest
+from django.test import Client
+
+
+@pytest.fixture
+def anon_client():
+    return Client()
+
+
+@pytest.fixture
+def debug_on(settings):
+    """Force DEBUG=True so the /test-mcp view's enable check passes."""
+    settings.DEBUG = True
+    settings.TESTING = False
+    return settings
+
+
+def _rpc(client: Client, body: dict, **extra) -> dict:
+    resp = client.post(
+        "/test-mcp",
+        data=json.dumps(body),
+        content_type="application/json",
+        **extra,
+    )
+    assert resp.status_code == 200, resp.content
+    return resp.json()
+
+
+class TestTestMcpTools:
+    def test_initialize(self, anon_client: Client, debug_on):
+        result = _rpc(anon_client, {
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "clientInfo": {"name": "test", "version": "1"},
+                "capabilities": {},
+            },
+        })
+        assert result["id"] == 1
+        assert result["result"]["protocolVersion"] == "2024-11-05"
+        assert result["result"]["serverInfo"]["name"] == "fairy-test-mcp"
+        assert "tools" in result["result"]["capabilities"]
+
+    def test_tools_list_includes_three_tools(self, anon_client: Client, debug_on):
+        result = _rpc(anon_client, {
+            "jsonrpc": "2.0", "id": 2, "method": "tools/list",
+        })
+        names = {t["name"] for t in result["result"]["tools"]}
+        assert names == {"signal_tool", "echo", "dangerous_tool"}
+
+    def test_signal_tool_emits_prefix(self, anon_client: Client, debug_on):
+        result = _rpc(anon_client, {
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {"name": "signal_tool", "arguments": {"token": "OK"}},
+        })
+        assert result["result"]["content"][0]["text"] == "MCP_SIGNAL_OK"
+
+    def test_echo_returns_msg(self, anon_client: Client, debug_on):
+        result = _rpc(anon_client, {
+            "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+            "params": {"name": "echo", "arguments": {"msg": "hello"}},
+        })
+        assert result["result"]["content"][0]["text"] == "hello"
+
+    def test_dangerous_tool_returns_sentinel(self, anon_client: Client, debug_on):
+        result = _rpc(anon_client, {
+            "jsonrpc": "2.0", "id": 5, "method": "tools/call",
+            "params": {"name": "dangerous_tool", "arguments": {}},
+        })
+        assert result["result"]["content"][0]["text"] == "SHOULD_NOT_BE_CALLED"
+
+    def test_unknown_method_returns_error(self, anon_client: Client, debug_on):
+        result = _rpc(anon_client, {
+            "jsonrpc": "2.0", "id": 6, "method": "not_a_method",
+        })
+        assert result["error"]["code"] == -32601
+
+    def test_notification_returns_202(self, anon_client: Client, debug_on):
+        resp = anon_client.post(
+            "/test-mcp",
+            data=json.dumps({
+                "jsonrpc": "2.0", "method": "notifications/initialized",
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 202
+
+    def test_invalid_json_returns_parse_error(self, anon_client: Client, debug_on):
+        resp = anon_client.post(
+            "/test-mcp",
+            data="not-json",
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == -32700
+
+
+class TestTestMcpGated:
+    """The route is always registered; the view's _endpoint_enabled check gates it."""
+
+    def test_returns_403_when_debug_and_testing_off(
+        self, anon_client: Client, settings,
+    ):
+        settings.DEBUG = False
+        settings.TESTING = False
+        resp = anon_client.post(
+            "/test-mcp",
+            data=json.dumps({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/list",
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 403
+        assert "disabled" in resp.json()["detail"]
+
+    def test_enabled_when_testing_true(self, anon_client: Client, settings):
+        settings.DEBUG = False
+        settings.TESTING = True
+        resp = anon_client.post(
+            "/test-mcp",
+            data=json.dumps({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/list",
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+
+
+class TestTestMcpAuth:
+    def test_no_token_env_allows_unauth(
+        self, anon_client: Client, debug_on, monkeypatch,
+    ):
+        monkeypatch.delenv("MCP_TEST_TOKEN", raising=False)
+        result = _rpc(anon_client, {
+            "jsonrpc": "2.0", "id": 1, "method": "tools/list",
+        })
+        assert "result" in result
+
+    def test_token_env_requires_bearer(
+        self, anon_client: Client, debug_on, monkeypatch,
+    ):
+        monkeypatch.setenv("MCP_TEST_TOKEN", "secret")
+        resp = anon_client.post(
+            "/test-mcp",
+            data=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION="Bearer secret",
+        )
+        assert resp.status_code == 200
+
+    def test_token_env_rejects_wrong_token(
+        self, anon_client: Client, debug_on, monkeypatch,
+    ):
+        monkeypatch.setenv("MCP_TEST_TOKEN", "secret")
+        resp = anon_client.post(
+            "/test-mcp",
+            data=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION="Bearer wrong",
+        )
+        assert resp.status_code == 401
+
+    def test_token_env_rejects_missing_auth(
+        self, anon_client: Client, debug_on, monkeypatch,
+    ):
+        monkeypatch.setenv("MCP_TEST_TOKEN", "secret")
+        resp = anon_client.post(
+            "/test-mcp",
+            data=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 401

--- a/tests/test_tools_mcp.py
+++ b/tests/test_tools_mcp.py
@@ -6,7 +6,15 @@ from django.test import Client
 
 from fairy.models import Agent, AgentVersion, APIKey, UserRuntimeKey
 from fairy.runtimes import RUNTIMES
-from fairy.sprites_exec import McpServerSpec, _build_tool_flags, build_wrapper_script
+from fairy.sprites_exec import (
+    CLAUDE_SETTINGS_PATH,
+    McpServerSpec,
+    McpToolsetRules,
+    _build_mcp_toolset_rules,
+    _build_tool_flags,
+    _tool_files_claude_mcp,
+    build_wrapper_script,
+)
 
 
 # --- Fixtures ---
@@ -878,3 +886,414 @@ class TestCodexToolConfig:
         exec_line = next(line for line in script.splitlines() if line.startswith("exec "))
         assert "--tools" not in exec_line
         assert "--disallowedTools" not in exec_line
+
+
+# --- MCP toolset rules helper ---
+
+
+class TestBuildMcpToolsetRules:
+    def test_empty_tools_returns_empty(self):
+        assert _build_mcp_toolset_rules([]) == {}
+
+    def test_no_mcp_toolset_returns_empty(self):
+        tools = [{"type": "agent_toolset_20260401"}]
+        assert _build_mcp_toolset_rules(tools) == {}
+
+    def test_bare_mcp_toolset_keeps_default_allow(self):
+        tools = [{"type": "mcp_toolset", "mcp_server_name": "github"}]
+        rules = _build_mcp_toolset_rules(tools)
+        assert rules == {"github": McpToolsetRules(default_enabled=True, per_tool={})}
+
+    def test_default_config_disabled(self):
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "github",
+            "default_config": {"enabled": False},
+        }]
+        rules = _build_mcp_toolset_rules(tools)
+        assert rules["github"].default_enabled is False
+        assert rules["github"].per_tool == {}
+
+    def test_per_tool_configs_override_default(self):
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "github",
+            "default_config": {"enabled": True},
+            "configs": [
+                {"name": "create_issue", "enabled": False},
+                {"name": "list_issues", "enabled": True},
+            ],
+        }]
+        rules = _build_mcp_toolset_rules(tools)
+        assert rules["github"].default_enabled is True
+        assert rules["github"].per_tool == {"create_issue": False, "list_issues": True}
+
+    def test_multiple_servers_isolated(self):
+        tools = [
+            {"type": "mcp_toolset", "mcp_server_name": "github"},
+            {
+                "type": "mcp_toolset",
+                "mcp_server_name": "linear",
+                "default_config": {"enabled": False},
+            },
+        ]
+        rules = _build_mcp_toolset_rules(tools)
+        assert set(rules) == {"github", "linear"}
+        assert rules["linear"].default_enabled is False
+
+    def test_configs_missing_name_ignored(self):
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "github",
+            "configs": [{"enabled": False}],  # no 'name'
+        }]
+        rules = _build_mcp_toolset_rules(tools)
+        assert rules["github"].per_tool == {}
+
+
+# --- Codex MCP toolset rules emission ---
+
+
+class TestCodexMcpToolsetRules:
+    def _script(self, tools, servers):
+        return build_wrapper_script(
+            RUNTIMES["codex"], "k", "p", mcp_servers=servers, tools=tools,
+        )
+
+    def test_no_rules_no_tool_keys_in_server_block(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        tools = []
+        script = self._script(tools, servers)
+        assert "[mcp_servers.gh]" in script
+        assert "enabled_tools" not in script
+        assert "disabled_tools" not in script
+        assert "enabled = false" not in script
+
+    def test_default_disabled_no_configs_emits_enabled_false(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "gh",
+            "default_config": {"enabled": False},
+        }]
+        script = self._script(tools, servers)
+        assert "enabled = false" in script
+
+    def test_per_tool_deny_emits_disabled_tools(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "gh",
+            "configs": [{"name": "create_issue", "enabled": False}],
+        }]
+        script = self._script(tools, servers)
+        assert 'disabled_tools = ["create_issue"]' in script
+        assert "enabled = false" not in script
+
+    def test_default_disabled_with_allow_emits_enabled_tools(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "gh",
+            "default_config": {"enabled": False},
+            "configs": [{"name": "list_issues", "enabled": True}],
+        }]
+        script = self._script(tools, servers)
+        assert 'enabled_tools = ["list_issues"]' in script
+
+    def test_rules_for_other_server_do_not_leak(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "linear",  # validated away by view layer, ignored here
+            "default_config": {"enabled": False},
+        }]
+        script = self._script(tools, servers)
+        server_block = script.split("[mcp_servers.gh]")[1].split("MCP_EOF")[0]
+        assert "enabled = false" not in server_block
+
+
+# --- Gemini MCP toolset rules emission ---
+
+
+class TestGeminiMcpToolsetRules:
+    def _config(self, tools, servers):
+        script = build_wrapper_script(
+            RUNTIMES["gemini"], "k", "p", mcp_servers=servers, tools=tools,
+        )
+        # Extract the heredoc body between `<< 'MCP_EOF'\n` and `\nMCP_EOF`
+        start = script.index("cat > ~/.gemini/settings.json << 'MCP_EOF'\n") + len(
+            "cat > ~/.gemini/settings.json << 'MCP_EOF'\n"
+        )
+        end = script.index("\nMCP_EOF\n", start)
+        return json.loads(script[start:end])
+
+    def test_no_rules_no_include_exclude(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        cfg = self._config([], servers)
+        assert cfg["mcpServers"]["gh"]["httpUrl"] == "https://mcp.gh/mcp"
+        assert "includeTools" not in cfg["mcpServers"]["gh"]
+        assert "excludeTools" not in cfg["mcpServers"]["gh"]
+
+    def test_default_disabled_no_configs_emits_empty_include_tools(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "gh",
+            "default_config": {"enabled": False},
+        }]
+        cfg = self._config(tools, servers)
+        assert cfg["mcpServers"]["gh"]["includeTools"] == []
+
+    def test_per_tool_deny_emits_exclude_tools(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "gh",
+            "configs": [{"name": "create_issue", "enabled": False}],
+        }]
+        cfg = self._config(tools, servers)
+        assert cfg["mcpServers"]["gh"]["excludeTools"] == ["create_issue"]
+        assert "includeTools" not in cfg["mcpServers"]["gh"]
+
+    def test_default_disabled_with_allow_emits_include_tools(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "gh",
+            "default_config": {"enabled": False},
+            "configs": [{"name": "list_issues", "enabled": True}],
+        }]
+        cfg = self._config(tools, servers)
+        assert cfg["mcpServers"]["gh"]["includeTools"] == ["list_issues"]
+
+    def test_rules_coexist_with_trust_and_headers(self):
+        servers = [McpServerSpec(
+            name="gh", type="url", url="https://mcp.gh/mcp",
+            headers={"Authorization": "Bearer x"},
+        )]
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "gh",
+            "configs": [{"name": "create_issue", "enabled": False}],
+        }]
+        cfg = self._config(tools, servers)
+        entry = cfg["mcpServers"]["gh"]
+        assert entry["trust"] is True
+        assert entry["headers"] == {"Authorization": "Bearer x"}
+        assert entry["excludeTools"] == ["create_issue"]
+
+
+# --- Claude MCP settings.json writer ---
+
+
+class TestClaudeMcpToolsetRules:
+    def test_empty_rules_no_settings_file(self):
+        assert _tool_files_claude_mcp({}) == {}
+
+    def test_bare_allow_no_settings_file(self):
+        """Default-allow with no per-tool overrides produces no restrictions."""
+        rules = {"gh": McpToolsetRules(default_enabled=True, per_tool={})}
+        assert _tool_files_claude_mcp(rules) == {}
+
+    def test_whole_server_deny_emits_server_in_deny(self):
+        rules = {"gh": McpToolsetRules(default_enabled=False, per_tool={})}
+        files = _tool_files_claude_mcp(rules)
+        assert CLAUDE_SETTINGS_PATH in files
+        settings = json.loads(files[CLAUDE_SETTINGS_PATH])
+        assert settings == {"permissions": {"deny": [{"tool": "mcp__gh"}]}}
+
+    def test_per_tool_deny_emits_full_tool_name(self):
+        rules = {"gh": McpToolsetRules(
+            default_enabled=True, per_tool={"create_issue": False},
+        )}
+        files = _tool_files_claude_mcp(rules)
+        settings = json.loads(files[CLAUDE_SETTINGS_PATH])
+        assert settings == {
+            "permissions": {"deny": [{"tool": "mcp__gh__create_issue"}]},
+        }
+
+    def test_default_disabled_with_allow_emits_both(self):
+        rules = {"gh": McpToolsetRules(
+            default_enabled=False, per_tool={"list_issues": True},
+        )}
+        files = _tool_files_claude_mcp(rules)
+        settings = json.loads(files[CLAUDE_SETTINGS_PATH])
+        assert settings == {
+            "permissions": {
+                "allow": [{"tool": "mcp__gh__list_issues"}],
+                "deny": [{"tool": "mcp__gh"}],
+            },
+        }
+
+    def test_claude_wrapper_writes_settings_file_when_mcp_rules_active(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "gh",
+            "default_config": {"enabled": False},
+        }]
+        script = build_wrapper_script(
+            RUNTIMES["claude"], "k", "p", mcp_servers=servers, tools=tools,
+        )
+        assert CLAUDE_SETTINGS_PATH in script
+        assert '"tool": "mcp__gh"' in script
+
+    def test_claude_no_settings_file_when_no_rules(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        script = build_wrapper_script(
+            RUNTIMES["claude"], "k", "p", mcp_servers=servers, tools=[],
+        )
+        assert CLAUDE_SETTINGS_PATH not in script
+
+
+# --- mcp_toolset validation: new shape checks ---
+
+
+@pytest.mark.django_db
+class TestMcpToolsetValidation:
+    def test_unknown_server_name_rejected(self, client: Client, auth_headers):
+        resp = client.post(
+            "/agents",
+            data=json.dumps({
+                "name": "Bad",
+                "model": "claude-sonnet-4-6",
+                "runtime": "claude",
+                "mcp_servers": [{"name": "gh", "url": "https://mcp.gh/mcp"}],
+                "tools": [{"type": "mcp_toolset", "mcp_server_name": "nope"}],
+            }),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 422
+        assert "nope" in str(resp.json()["detail"])
+
+    def test_known_server_name_accepted(self, client: Client, auth_headers, runtime_key):
+        resp = client.post(
+            "/agents",
+            data=json.dumps({
+                "name": "Good",
+                "model": "claude-sonnet-4-6",
+                "runtime": "claude",
+                "mcp_servers": [{"name": "gh", "url": "https://mcp.gh/mcp"}],
+                "tools": [{"type": "mcp_toolset", "mcp_server_name": "gh"}],
+            }),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 201
+
+    def test_configs_non_list_rejected(self, client: Client, auth_headers):
+        resp = client.post(
+            "/agents",
+            data=json.dumps({
+                "name": "Bad",
+                "model": "claude-sonnet-4-6",
+                "runtime": "claude",
+                "mcp_servers": [{"name": "gh", "url": "https://mcp.gh/mcp"}],
+                "tools": [{
+                    "type": "mcp_toolset", "mcp_server_name": "gh",
+                    "configs": "not-a-list",
+                }],
+            }),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 422
+        assert "configs" in str(resp.json()["detail"])
+
+    def test_configs_entry_name_non_string_rejected(self, client: Client, auth_headers):
+        resp = client.post(
+            "/agents",
+            data=json.dumps({
+                "name": "Bad",
+                "model": "claude-sonnet-4-6",
+                "runtime": "claude",
+                "mcp_servers": [{"name": "gh", "url": "https://mcp.gh/mcp"}],
+                "tools": [{
+                    "type": "mcp_toolset", "mcp_server_name": "gh",
+                    "configs": [{"name": 42}],
+                }],
+            }),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 422
+
+    def test_configs_entry_enabled_non_bool_rejected(self, client: Client, auth_headers):
+        resp = client.post(
+            "/agents",
+            data=json.dumps({
+                "name": "Bad",
+                "model": "claude-sonnet-4-6",
+                "runtime": "claude",
+                "mcp_servers": [{"name": "gh", "url": "https://mcp.gh/mcp"}],
+                "tools": [{
+                    "type": "mcp_toolset", "mcp_server_name": "gh",
+                    "configs": [{"name": "x", "enabled": "yes"}],
+                }],
+            }),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 422
+
+    def test_default_config_non_dict_rejected(self, client: Client, auth_headers):
+        resp = client.post(
+            "/agents",
+            data=json.dumps({
+                "name": "Bad",
+                "model": "claude-sonnet-4-6",
+                "runtime": "claude",
+                "mcp_servers": [{"name": "gh", "url": "https://mcp.gh/mcp"}],
+                "tools": [{
+                    "type": "mcp_toolset", "mcp_server_name": "gh",
+                    "default_config": "on",
+                }],
+            }),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 422
+
+    def test_default_config_enabled_non_bool_rejected(self, client: Client, auth_headers):
+        resp = client.post(
+            "/agents",
+            data=json.dumps({
+                "name": "Bad",
+                "model": "claude-sonnet-4-6",
+                "runtime": "claude",
+                "mcp_servers": [{"name": "gh", "url": "https://mcp.gh/mcp"}],
+                "tools": [{
+                    "type": "mcp_toolset", "mcp_server_name": "gh",
+                    "default_config": {"enabled": "yes"},
+                }],
+            }),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 422
+
+    def test_update_rejects_toolset_for_removed_server(
+        self, client: Client, auth_headers, user, runtime_key,
+    ):
+        agent = Agent.objects.create(
+            user=user, name="Agent", model="claude-sonnet-4-6",
+            runtime="claude",
+            mcp_servers=[{"name": "gh", "url": "https://mcp.gh/mcp"}],
+            tools=[{"type": "mcp_toolset", "mcp_server_name": "gh"}],
+            version=1,
+        )
+        AgentVersion.objects.create(
+            agent=agent, version=1, name=agent.name,
+            model=agent.model, runtime=agent.runtime,
+            tools=agent.tools, mcp_servers=agent.mcp_servers,
+        )
+        resp = client.put(
+            f"/agents/{agent.id}",
+            data=json.dumps({"version": 1, "mcp_servers": []}),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 422
+        assert "gh" in str(resp.json()["detail"])

--- a/thoughts/plans/2026-04-17-agent-mcp-enforcement.md
+++ b/thoughts/plans/2026-04-17-agent-mcp-enforcement.md
@@ -1,0 +1,710 @@
+# Agent MCP Enforcement Implementation Plan
+
+## Overview
+
+Wire Fairy's `mcp_toolset` tool entries through to the coding-agent runtime CLIs so that MCP tools declared as disabled in the Managed-Agents spec are actually not invocable by the running agent, and add a focused e2e test suite that proves the translation works end-to-end.
+
+Today, `Agent.mcp_servers` is correctly wired (each runtime receives the server list + auth headers), but `mcp_toolset` entries — the allow/deny surface for MCP tools — are only partially consulted. Only claude's allowlist path (`default_config.enabled=False`) reads them; claude's denylist, codex, and gemini all ignore `mcp_toolset` entirely. Per-tool filtering via `configs[].name` is validated as optional and never wired anywhere. This is the direct MCP analog of the built-in tool-enforcement gap that commit [`4c3b9cc`](https://github.com/ravi-hq/fairy/commit/4c3b9cc1e5e7871436bdec48c063c76d47db30a0) closed.
+
+This plan closes that gap per-runtime and adds a focused e2e matrix that uses a new Fairy-hosted test MCP endpoint to prove the claim.
+
+## Research Summary
+
+Research conducted by agent team with 5 specialist tracks — full document at `thoughts/research/2026-04-17-mcp-enforcement-e2e.md`.
+
+- **Fairy wiring audit**: `mcp_toolset.mcp_server_name` reaches runtime only via claude `_tool_flags_claude` allowlist path. `configs[].name` + `default_config.enabled` on `mcp_toolset` are stored, returned, ignored.
+- **Per-runtime gating**: Claude `--disallowedTools` silently ignores MCP names in `-p` mode (upstream #12863). Claude fix path is file-based `permissions.deny` in `settings.json`. Codex has rich config: `enabled_tools` + `disabled_tools` + `enabled` + `required`. Gemini has two options — Policy Engine single-underscore `mcp_{server}_{tool}` rules, or `excludeTools` in the `mcpServers` settings entry (no naming trap).
+- **Test infrastructure**: Sprites have unrestricted outbound network — a Fairy-hosted `/test-mcp` Django view using the `mcp` Python SDK (FastMCP) is the cleanest option. Three deterministic tools: `signal_tool`, `echo`, `dangerous_tool`.
+- **Matrix design**: 3 runtimes × 4 scenarios + 1 multi-turn = ~14 sessions/run at haiku/o4-mini/gemini-flash ≈ $0.30–0.70.
+- **Managed Agents parity**: vaults deferred (API not GA, Fairy has no vault model). Inline `headers` on `Agent.mcp_servers` are sufficient for this effort. Plaintext headers + returned-in-responses is a separate hardening item.
+
+### Key Discoveries
+
+- MCP tool-call events are parseable on all 3 runtimes: Claude `tool_use` block with `name="mcp__<server>__<tool>"`, Codex `item.type="mcp_tool_call"` with `item.server` + `item.tool`, Gemini `tool_use` with `tool_name="mcp__<server>__<tool>"` (`thoughts/research/2026-04-17-mcp-enforcement-e2e.md`, Track 2).
+- Codex `item.type="mcp_tool_call"` parsing is already present at `tests/e2e/test_agent_tools.py:89-92` and can be reused directly.
+- `_tool_files_gemini` at `src/fairy/sprites_exec.py:342-392` is NOT the right pattern for MCP gemini deny — Policy Engine uses single-underscore naming and trips on server aliases containing underscores. `excludeTools` inside the `mcpServers` entry (written by `_build_mcp_gemini`) is the chosen path.
+- Fairy already supports `stdio`-type MCP servers end-to-end (`src/fairy/views.py:501-523` + all three `_build_mcp_*` writers). This plan uses `type="url"` only since stdio can't test bearer-auth headers.
+- `send_prompt` at `src/fairy/views.py:378-395` already re-passes `mcp_servers` + `tools` on every turn — multi-turn persistence is free.
+- `RUNTIME_MODELS` at `tests/e2e/conftest.py:20-27` pins cheapest models — same pins that the tool matrix uses.
+
+## Current State Analysis
+
+`Agent.mcp_servers` flows end-to-end. `Agent.tools` with `mcp_toolset` entries flows partially:
+
+- `src/fairy/models.py:222-223` defines `tools` + `mcp_servers` as plain JSONFields.
+- `src/fairy/views.py:485-498` (`_validate_tools`) — `mcp_toolset` entries require only `mcp_server_name`; `configs[].name` and `default_config.enabled` are accepted as optional shape but never validated for type/meaning. No validation that `mcp_server_name` references an actual server on the agent.
+- `src/fairy/views.py:501-523` (`_validate_mcp_servers`) — url/stdio types, max 20, name uniqueness. Headers accepted as arbitrary dict.
+- `src/fairy/views.py:595-613` (`_serialize_agent`) returns full `mcp_servers` including `headers` containing bearer tokens.
+- `src/fairy/sprites_exec.py:120-140` (`_build_mcp_claude`) writes `/tmp/mcp.json`.
+- `src/fairy/sprites_exec.py:170-210` (`_build_mcp_codex`) writes `~/.codex/config.toml` — only `url` + `bearer_token_env_var` + `required`; no allow/deny keys.
+- `src/fairy/sprites_exec.py:213-233` (`_build_mcp_gemini`) writes `~/.gemini/settings.json` — no `excludeTools`/`includeTools`.
+- `src/fairy/sprites_exec.py:286-321` (`_tool_flags_claude`) — `mcp_toolset` consulted only in allowlist path (`default_config.enabled=False`); denylist path ignores MCP entirely.
+- `tests/test_tools_mcp.py` — unit tests cover MCP config generation and validation, but no MCP deny-path tests because no deny path exists.
+- `tests/e2e/test_agent_tools.py` — covers built-in tools only; MCP e2e coverage was explicitly deferred in `thoughts/plans/2026-04-16-agent-tool-enforcement.md:63`.
+
+A user can declare `mcp_toolset: {mcp_server_name: "github", default_config: {enabled: false}}` expecting the github MCP server to be blocked — and Fairy will happily emit a wrapper that lets the agent call every tool on that server. That's the gap.
+
+## Desired End State
+
+- Creating a session from an agent with `mcp_toolset` tool entries produces a wrapper script that actually constrains MCP tool availability per-runtime.
+- For **claude/claude-oauth**: deny entries translate to `permissions.deny` rules in a Fairy-written `~/.claude/settings.json` (new writer). Allow entries continue to use `--tools "mcp__<server>"` as today.
+- For **codex**: deny entries translate to `enabled_tools`/`disabled_tools`/`enabled` keys on `[mcp_servers.<name>]` blocks in `~/.codex/config.toml`.
+- For **gemini**: deny entries translate to `excludeTools` arrays on the `mcpServers` entry in `~/.gemini/settings.json` (extends existing `_build_mcp_gemini`, does NOT touch `_tool_files_gemini` Policy Engine).
+- `_validate_tools` at `src/fairy/views.py:485-498` tightens `mcp_toolset` validation: require that `mcp_server_name` references an actual server on the agent (422 otherwise), validate optional `configs[].name` (string) + `configs[].enabled` (bool), validate optional `default_config.enabled` (bool).
+- New Django view `/test-mcp` served by `src/fairy/test_mcp.py` implementing MCP Streamable HTTP. Gated behind `settings.DEBUG or settings.TESTING`. Tools: `signal_tool`, `echo`, `dangerous_tool`. Optional bearer check via `MCP_TEST_TOKEN` env.
+- E2E test `tests/e2e/test_mcp_enforcement.py` — 3 runtimes × 4 scenarios + 1 multi-turn = ~14 sessions per full run. New marker `mcp_matrix`. New `make test-e2e-mcp` target.
+- `README.md` includes a per-runtime MCP-enforcement capability table.
+
+### Verification
+
+- `make test` passes (new unit tests green, existing tests still pass).
+- `make test-e2e-mcp E2E_RUNTIMES=claude` passes against a running Fairy — all claude-path MCP tests green.
+- `make test-e2e-mcp` with all runtimes runs ~14 sessions, completes under $0.70, all asserted behaviors enforced.
+- `make lint` + `make test-e2e-fast` continue to pass unchanged.
+- `make test-e2e-tools` (prior tool matrix) continues to pass unchanged.
+
+## What We're NOT Doing
+
+- **Vaults**: no session-level `vault_ids` model, no vault resource, no OAuth+refresh MCP auth. Inline `headers` on `Agent.mcp_servers` only. Tracked in research doc as future work.
+- **`Agent.mcp_servers[].headers` encryption**: separate security-hardening ticket. Plaintext at rest + returned-in-responses is a known gap but orthogonal to this enforcement work. Test fixtures use fake sentinel tokens.
+- **422 on unenforceable combinations**: a `mcp_toolset` deny against a server that isn't in `mcp_servers[]` is a 422 (name-must-resolve), but all other combinations are accepted silently. Per-tool `configs[].name` entries that don't match any tool the server actually exposes are accepted silently (we can't know what tools a remote server exposes at validation time).
+- **Gemini Policy Engine for MCP**: we use `excludeTools` in `mcpServers` settings entry, not Policy Engine rules. Single-underscore Policy Engine naming is a footgun for user-chosen server aliases.
+- **Claude `permissions.deny` for built-in tools**: stays on existing `--disallowedTools` CLI flag path. The new `settings.json` writer is scoped to MCP rules only.
+- **stdio MCP server in e2e**: URL-type only. stdio can't test bearer-auth headers and adds no coverage we don't already have from HTTP.
+- **Stream-event auth failure assertions**: no runtime emits a structured MCP auth-failure event reliably. Auth tests use tool-absence assertions only.
+
+## Implementation Approach
+
+Six phases. Phases 1–4 are strictly sequential (they all touch `sprites_exec.py` or `views.py`). Phase 5 (test MCP server) can overlap with Phase 4. Phase 6 (e2e) depends on 1–5. Unit tests land alongside each runtime phase. E2E tests land only once all runtime paths + test server are wired.
+
+## File Ownership Map
+
+Designed for parallel execution via `team-implement`. Because phases 1–4 serialize on `sprites_exec.py`/`views.py`, all backend work in these phases is a single track.
+
+| Phase | Files | Owner Track | Change Type |
+|-------|-------|-------------|-------------|
+| 1 | `src/fairy/views.py` | backend | modify — tighten `_validate_tools` for `mcp_toolset` |
+| 1 | `src/fairy/sprites_exec.py` | backend | modify — `_build_mcp_*` accept `mcp_toolset_rules`, no behavior yet |
+| 1 | `tests/test_tools_mcp.py` | backend | modify — validation tests for new 422 cases |
+| 2 | `src/fairy/sprites_exec.py` | backend | modify — codex `enabled`/`enabled_tools`/`disabled_tools` |
+| 2 | `tests/test_tools_mcp.py` | backend | modify — codex unit tests |
+| 3 | `src/fairy/sprites_exec.py` | backend | modify — gemini `excludeTools` in `_build_mcp_gemini` |
+| 3 | `tests/test_tools_mcp.py` | backend | modify — gemini unit tests |
+| 4 | `src/fairy/sprites_exec.py` | backend | modify — new `_tool_files_claude_mcp` settings.json writer |
+| 4 | `tests/test_tools_mcp.py` | backend | modify — claude unit tests |
+| 5 | `src/fairy/test_mcp.py` | tests-infra | create — FastMCP Django view |
+| 5 | `src/config/urls.py` | tests-infra | modify — mount `/test-mcp` behind DEBUG/TESTING |
+| 5 | `src/config/settings.py` | tests-infra | modify — `TESTING` flag |
+| 5 | `pyproject.toml` | tests-infra | modify — add `mcp` to `[project.optional-dependencies].e2e` |
+| 6 | `tests/e2e/test_mcp_enforcement.py` | tests | create |
+| 6 | `tests/e2e/conftest.py` | tests | modify — `mcp_test_url` fixture |
+| 6 | `pyproject.toml` | tests | modify — register `mcp_matrix` marker |
+| 6 | `Makefile` | tests | modify — `test-e2e-mcp` target |
+| 6 | `README.md` | tests | modify — MCP capability table |
+
+**Conflict-free guarantee**: Phases 1–4 all touch `sprites_exec.py` and are strictly sequential (single backend track). Phases 5 and 6 touch disjoint files and can run in parallel after Phase 4 lands, with Phase 6 depending on Phase 5 for the test server endpoint.
+
+---
+
+## Phase 1: Validator tightening + MCP toolset dispatcher foundation
+
+### Overview
+
+Tighten `_validate_tools` to properly validate `mcp_toolset` structure and require `mcp_server_name` references resolve to an actual server on the agent. Introduce a pure helper `_build_mcp_toolset_rules(tools, mcp_servers) -> dict[str, ToolsetRules]` that the runtime-specific `_build_mcp_*` functions will consume in Phases 2–4. At the end of Phase 1 the rules helper exists but no runtime reads it — only validation behavior changes.
+
+### Changes Required
+
+#### 1. `src/fairy/views.py` — tighten `_validate_tools`
+
+Extend `_validate_tools` to:
+- Require `configs` is a list of dicts if present; each dict has optional `name: str` + `enabled: bool`.
+- Require `default_config` is a dict if present, with optional `enabled: bool`.
+- Require `mcp_server_name` resolves to a server in the agent's `mcp_servers[]`. 422 otherwise with `detail: "mcp_toolset references unknown server: <name>"`.
+
+Touch both CREATE and UPDATE paths (the existing `_validate_tools` is shared).
+
+#### 2. `src/fairy/sprites_exec.py` — add `_build_mcp_toolset_rules`
+
+Add a new pure helper that converts `tools` + `mcp_servers` into a structured per-server rules dict:
+
+```python
+@dataclass(frozen=True)
+class McpToolsetRules:
+    """Normalized MCP toolset restrictions for a single server."""
+    server_enabled: bool  # False → whole server blocked
+    default_enabled: bool  # default for tools not listed in configs
+    per_tool: dict[str, bool]  # {tool_name: enabled}
+
+
+def _build_mcp_toolset_rules(
+    tools: list[dict],
+    mcp_servers: list[McpServerSpec],
+) -> dict[str, McpToolsetRules]:
+    """
+    Returns {server_name: McpToolsetRules} for every server that has
+    an mcp_toolset entry. Servers without an mcp_toolset entry are absent
+    from the dict (meaning: no restrictions).
+
+    Default semantics:
+      - No mcp_toolset for server X → X absent from result → fully allowed
+      - mcp_toolset with no default_config → default_enabled=True
+      - mcp_toolset with default_config.enabled=False → server_enabled=True, default_enabled=False
+      - configs[].enabled overrides default for that specific tool name
+    """
+    rules: dict[str, McpToolsetRules] = {}
+    for t in tools:
+        if t.get("type") != "mcp_toolset":
+            continue
+        name = t.get("mcp_server_name")
+        if not name:
+            continue
+        default_enabled = t.get("default_config", {}).get("enabled", True)
+        per_tool = {c["name"]: c.get("enabled", True) for c in t.get("configs", []) if "name" in c}
+        rules[name] = McpToolsetRules(
+            server_enabled=True,  # presence of entry = server registered
+            default_enabled=default_enabled,
+            per_tool=per_tool,
+        )
+    return rules
+```
+
+Pass `rules` into each `_build_mcp_<runtime>` via a new parameter, but have each `_build_mcp_*` ignore it for now (Phases 2–4 fill them in).
+
+Extend `_build_mcp_section` and the call site in `build_wrapper_script` to thread `rules` through. No behavior change yet.
+
+#### 3. `tests/test_tools_mcp.py` — validation test cases
+
+Add test cases to `TestAgentMcpValidation` / `TestCreateAgentWithTools`:
+
+- `test_mcp_toolset_unknown_server_rejected_with_422` — `mcp_toolset` with `mcp_server_name` not in `mcp_servers[]`
+- `test_mcp_toolset_configs_non_list_rejected` — `configs: "not-a-list"`
+- `test_mcp_toolset_configs_name_non_string_rejected` — `configs: [{"name": 42}]`
+- `test_mcp_toolset_configs_enabled_non_bool_rejected`
+- `test_mcp_toolset_default_config_enabled_non_bool_rejected`
+- `test_mcp_toolset_rules_helper_empty_when_no_toolset` — unit test of `_build_mcp_toolset_rules` returning `{}` when no mcp_toolset in `tools`
+- `test_mcp_toolset_rules_helper_merges_configs_and_default` — unit test with representative spec
+
+### Success Criteria
+
+#### Automated:
+- [ ] `make test` passes (new validation tests green, existing tests unchanged)
+- [ ] `make lint` passes
+- [ ] Unit tests for `_build_mcp_toolset_rules` cover: no toolset, server-level deny only, per-tool deny only, mixed
+
+#### Manual:
+- [ ] POST /agents with `mcp_toolset.mcp_server_name: "doesnotexist"` returns 422 with a clear error message
+- [ ] PUT /agents/{id} with the same error returns 422
+
+**Gate**: Pause for review before Phase 2.
+
+---
+
+## Phase 2: Codex per-tool + per-server MCP deny
+
+### Overview
+
+Extend `_build_mcp_codex` in `src/fairy/sprites_exec.py:170-210` to consume `rules: dict[str, McpToolsetRules]` and emit the corresponding `[mcp_servers.<name>]` keys: `enabled`, `enabled_tools`, `disabled_tools`.
+
+### Changes Required
+
+#### 1. `src/fairy/sprites_exec.py` — extend `_build_mcp_codex`
+
+```python
+def _build_mcp_codex(
+    servers: list[McpServerSpec],
+    tools: list[dict] | None = None,
+    rules: dict[str, McpToolsetRules] | None = None,
+) -> str:
+    """Generate Codex config TOML (MCP servers + tool enforcement keys)."""
+    tools = tools or []
+    rules = rules or {}
+    top_level = _codex_top_level_keys(tools)
+
+    if not servers and not top_level:
+        return ""
+
+    lines = ["# Codex configuration (MCP + tool enforcement)", "mkdir -p ~/.codex"]
+    lines.append("cat > ~/.codex/config.toml << 'MCP_EOF'")
+    if top_level:
+        lines.extend(top_level)
+        if servers:
+            lines.append("")
+
+    for s in servers:
+        lines.append(f"[mcp_servers.{s.name}]")
+        server_rules = rules.get(s.name)
+
+        # Whole-server toggle
+        if server_rules and not server_rules.default_enabled and not server_rules.per_tool:
+            # default_enabled=False with no per-tool overrides → disable whole server
+            lines.append("enabled = false")
+        elif server_rules:
+            # Per-tool allow/deny
+            allowed = [t for t, e in server_rules.per_tool.items() if e]
+            denied = [t for t, e in server_rules.per_tool.items() if not e]
+            if not server_rules.default_enabled and allowed:
+                # default deny, selective allow
+                lines.append("enabled_tools = [" + ", ".join(f'"{t}"' for t in allowed) + "]")
+            if denied:
+                lines.append("disabled_tools = [" + ", ".join(f'"{t}"' for t in denied) + "]")
+
+        # Existing url/stdio/auth emission unchanged
+        if s.type == "url":
+            lines.append(f'url = "{s.url}"')
+            for key, val in s.headers.items():
+                if key.lower() == "authorization" and val.startswith("Bearer "):
+                    token = val.removeprefix("Bearer ").strip()
+                    if token.startswith("${") and token.endswith("}"):
+                        lines.append(f'bearer_token_env_var = "{token[2:-1]}"')
+            lines.append("required = true")
+        elif s.type == "stdio":
+            # unchanged
+            ...
+        lines.append("")
+    lines.append("MCP_EOF")
+    return "\n".join(lines)
+```
+
+Note: `default_enabled=False` with no per-tool overrides emits `enabled = false`. If there are per-tool overrides, emit `enabled_tools`/`disabled_tools` instead (matching codex's allowlist-then-denylist semantics).
+
+#### 2. `tests/test_tools_mcp.py` — codex unit tests
+
+Add to a new class `TestCodexMcpToolsetRules`:
+- `test_codex_no_rules_emits_current_behavior` — baseline, no change
+- `test_codex_default_disabled_no_configs_emits_enabled_false`
+- `test_codex_default_enabled_with_denied_tool_emits_disabled_tools`
+- `test_codex_default_disabled_with_allowed_tool_emits_enabled_tools`
+- `test_codex_mixed_allow_deny` — both enabled_tools and disabled_tools emitted
+- `test_codex_rules_do_not_affect_server_not_in_rules` — only referenced server gets config
+- `test_codex_rules_preserve_bearer_token_env_var` — auth still works
+
+### Success Criteria
+
+#### Automated:
+- [ ] `make test` passes
+- [ ] New unit tests cover each `McpToolsetRules` → TOML path
+- [ ] `make lint` passes
+
+#### Manual:
+- [ ] Create a codex agent with mcp_toolset denying a tool; inspect the wrapper script (via a fake sprite run or direct unit-test output) and confirm `disabled_tools` appears
+
+**Gate**: Pause for review before Phase 3.
+
+---
+
+## Phase 3: Gemini MCP deny via `excludeTools` in settings.json
+
+### Overview
+
+Extend `_build_mcp_gemini` in `src/fairy/sprites_exec.py:213-233` to emit `excludeTools` arrays on each `mcpServers` entry based on `rules`. We do NOT touch `_tool_files_gemini` (built-in tool Policy Engine) — MCP gets its own mechanism in the same settings.json file that `_build_mcp_gemini` already writes.
+
+### Why `excludeTools` over Policy Engine
+
+Gemini Policy Engine uses `mcp_{server}_{tool}` single-underscore rule names. A user-picked server alias containing an underscore (`my_github`) will misparse. `excludeTools` lives on the `mcpServers` entry and takes tool names directly (no naming transform). Co-locating MCP config with MCP restrictions also reduces file-writer sprawl.
+
+### Changes Required
+
+#### 1. `src/fairy/sprites_exec.py` — extend `_build_mcp_gemini`
+
+```python
+def _build_mcp_gemini(
+    servers: list[McpServerSpec],
+    rules: dict[str, McpToolsetRules] | None = None,
+) -> str:
+    rules = rules or {}
+    config: dict[str, dict] = {}
+    for s in servers:
+        if s.type == "url":
+            entry: dict = {"httpUrl": s.url, "trust": True}
+            if s.headers:
+                entry["headers"] = s.headers
+        elif s.type == "stdio":
+            entry = {"command": s.command, "args": s.args, "trust": True}
+            if s.env:
+                entry["env"] = s.env
+
+        server_rules = rules.get(s.name)
+        if server_rules:
+            if not server_rules.default_enabled and not server_rules.per_tool:
+                # whole server blocked: include an empty includeTools to deny all
+                entry["includeTools"] = []
+            else:
+                denied = [t for t, e in server_rules.per_tool.items() if not e]
+                allowed = [t for t, e in server_rules.per_tool.items() if e]
+                if not server_rules.default_enabled and allowed:
+                    entry["includeTools"] = allowed
+                if denied:
+                    entry["excludeTools"] = denied
+
+        config[s.name] = entry
+
+    content = json.dumps({"mcpServers": config}, indent=2)
+    return (
+        "# MCP server configuration\n"
+        "cat > ~/.gemini/settings.json << 'MCP_EOF'\n"
+        f"{content}\n"
+        "MCP_EOF\n"
+    )
+```
+
+Whole-server deny uses `includeTools: []` (empty allowlist). Per-tool deny uses `excludeTools`. Default-deny with allowlist uses `includeTools`.
+
+#### 2. `tests/test_tools_mcp.py` — gemini unit tests
+
+Add to a new class `TestGeminiMcpToolsetRules`:
+- `test_gemini_no_rules_emits_current_behavior`
+- `test_gemini_default_disabled_no_configs_emits_empty_include_tools`
+- `test_gemini_default_enabled_with_denied_tool_emits_exclude_tools`
+- `test_gemini_default_disabled_with_allowed_tool_emits_include_tools`
+- `test_gemini_rules_coexist_with_trust_and_headers`
+- `test_gemini_rules_for_nonexistent_server_ignored` — defensive: rule keyed on a server not in servers[] should not leak into config
+
+### Success Criteria
+
+#### Automated:
+- [ ] `make test` passes
+- [ ] New unit tests cover each `McpToolsetRules` → JSON path
+- [ ] `make lint` passes
+
+#### Manual:
+- [ ] Emitted `settings.json` validates as valid JSON
+- [ ] Inspect emitted JSON for a deny case and confirm `excludeTools` or `includeTools: []` present
+
+**Gate**: Pause for review before Phase 4.
+
+---
+
+## Phase 4: Claude MCP deny via `settings.json` `permissions.deny`
+
+### Overview
+
+Add a new writer `_tool_files_claude_mcp` that emits `~/.claude/settings.json` with `permissions.deny` rules for MCP tools. This is a new file pattern for claude (the existing tool-enforcement path uses CLI flags only). Invoked via `_build_tool_flags` when the runtime is `claude`/`claude-oauth` and `rules` contains non-empty entries.
+
+Built-in tool deny via `--disallowedTools` stays unchanged — this writer is scoped to MCP rules only.
+
+### Why a new writer
+
+`--disallowedTools "mcp__server__tool"` silently fails in `-p` mode (Claude Code #12863). `--allowedTools "mcp__server__*"` wildcard also fails (#13077). The only working deny path is `settings.json` with `permissions.deny` entries shaped as `{"tool": "mcp__<server>__<tool>"}` or `{"tool": "mcp__<server>"}`.
+
+### Changes Required
+
+#### 1. `src/fairy/sprites_exec.py` — new `_tool_files_claude_mcp`
+
+```python
+CLAUDE_SETTINGS_PATH = "/home/sprite/.claude/settings.json"
+
+
+def _tool_files_claude_mcp(
+    rules: dict[str, McpToolsetRules],
+) -> dict[str, str]:
+    """Write ~/.claude/settings.json with permissions.deny rules for MCP tools."""
+    if not rules:
+        return {}
+
+    deny: list[dict[str, str]] = []
+    allow: list[dict[str, str]] = []
+    for server_name, r in rules.items():
+        if not r.default_enabled and not r.per_tool:
+            # whole server blocked
+            deny.append({"tool": f"mcp__{server_name}"})
+            continue
+        if not r.default_enabled:
+            # default deny, selective allow
+            deny.append({"tool": f"mcp__{server_name}"})
+            for tool_name, enabled in r.per_tool.items():
+                if enabled:
+                    allow.append({"tool": f"mcp__{server_name}__{tool_name}"})
+        else:
+            # default allow, selective deny
+            for tool_name, enabled in r.per_tool.items():
+                if not enabled:
+                    deny.append({"tool": f"mcp__{server_name}__{tool_name}"})
+
+    if not deny and not allow:
+        return {}
+
+    settings: dict = {"permissions": {}}
+    if allow:
+        settings["permissions"]["allow"] = allow
+    if deny:
+        settings["permissions"]["deny"] = deny
+
+    return {CLAUDE_SETTINGS_PATH: json.dumps(settings, indent=2) + "\n"}
+```
+
+#### 2. `src/fairy/sprites_exec.py` — thread rules through `_build_tool_flags`
+
+```python
+def _build_tool_flags(
+    runtime_name: str,
+    tools: list[dict],
+    mcp_server_names: list[str],
+    mcp_rules: dict[str, McpToolsetRules],
+) -> tuple[str, dict[str, str]]:
+    if not tools and not mcp_rules:
+        return "", {}
+    if runtime_name in ("claude", "claude-oauth"):
+        flags = _tool_flags_claude(tools, mcp_server_names)
+        files = _tool_files_claude_mcp(mcp_rules)
+        return flags, files
+    if runtime_name == "gemini":
+        # gemini MCP deny is handled inside _build_mcp_gemini
+        return "", _tool_files_gemini(tools)
+    return "", {}
+```
+
+Note: deny rules for `mcp__<server>` (whole-server) must take priority over `--tools "mcp__<server>"` allowlist from `_tool_flags_claude`. Claude's documented precedence is `deny > allow`, so the combination is safe.
+
+#### 3. `tests/test_tools_mcp.py` — claude unit tests
+
+Add to a new class `TestClaudeMcpToolsetRules`:
+- `test_claude_no_rules_emits_no_settings_file`
+- `test_claude_whole_server_deny_emits_mcp_server_in_deny_list`
+- `test_claude_per_tool_deny_emits_full_tool_name_in_deny_list`
+- `test_claude_default_disabled_with_allow_emits_both_allow_and_deny`
+- `test_claude_settings_json_is_valid_json`
+- `test_claude_mcp_rules_coexist_with_disallowed_tools_cli_flag` — both paths active, no conflict
+
+### Success Criteria
+
+#### Automated:
+- [ ] `make test` passes
+- [ ] Unit tests cover each `McpToolsetRules` → settings.json path
+- [ ] `make lint` passes
+
+#### Manual:
+- [ ] Run a manual claude session with a test MCP server and a `permissions.deny` rule; confirm the denied tool is absent from the init event's visible toolset
+
+**Gate**: Pause for review before Phase 5.
+
+---
+
+## Phase 5: Fairy-hosted test MCP server endpoint
+
+### Overview
+
+Implement a Django view at `/test-mcp` that serves the MCP Streamable HTTP protocol via the `mcp` Python SDK's `FastMCP` class. Gated behind `settings.DEBUG or settings.TESTING`. Three tools: `signal_tool`, `echo`, `dangerous_tool`. Optional bearer-token check via `MCP_TEST_TOKEN` env var.
+
+### Changes Required
+
+#### 1. `pyproject.toml` — add `mcp` dependency
+
+Add `mcp>=1.0` to `[project.optional-dependencies].e2e`. Also add to `[project.optional-dependencies].dev` so developers can run the endpoint locally.
+
+#### 2. `src/fairy/test_mcp.py` — FastMCP Django view
+
+```python
+"""MCP test server mounted at /test-mcp when DEBUG or TESTING.
+
+Deterministic tools for e2e tests. DO NOT enable in production.
+"""
+
+import os
+from mcp.server.fastmcp import FastMCP
+from django.http import HttpResponseForbidden
+from django.conf import settings
+
+mcp = FastMCP("fairy-test-mcp")
+
+
+@mcp.tool()
+def signal_tool(token: str) -> str:
+    """Echoes a signal string for allow-list assertions."""
+    return f"MCP_SIGNAL_{token}"
+
+
+@mcp.tool()
+def echo(msg: str) -> str:
+    """Returns the input message verbatim."""
+    return msg
+
+
+@mcp.tool()
+def dangerous_tool() -> str:
+    """Returns a sentinel string for deny-list assertions. Test tool only."""
+    return "SHOULD_NOT_BE_CALLED"
+
+
+def mcp_streamable_http_view(request):
+    if not (settings.DEBUG or getattr(settings, "TESTING", False)):
+        return HttpResponseForbidden("test-mcp disabled")
+
+    expected = os.environ.get("MCP_TEST_TOKEN")
+    if expected is not None:
+        auth = request.headers.get("Authorization", "")
+        if not auth.startswith("Bearer ") or auth.removeprefix("Bearer ") != expected:
+            return HttpResponseForbidden("bad MCP token")
+
+    return mcp.handle_streamable_http(request)  # exact binding TBD — see note below
+```
+
+Note: the exact Django ↔ `mcp` Python SDK binding depends on whether `FastMCP` exposes a direct ASGI/WSGI handler or requires a shim. If needed, a small WSGI wrapper lives in the same file.
+
+#### 3. `src/config/urls.py` — mount behind DEBUG/TESTING
+
+```python
+if settings.DEBUG or getattr(settings, "TESTING", False):
+    from fairy.test_mcp import mcp_streamable_http_view
+    urlpatterns += [path("test-mcp", mcp_streamable_http_view)]
+```
+
+#### 4. `src/config/settings.py` — add `TESTING` flag
+
+```python
+TESTING = os.environ.get("FAIRY_TESTING", "").lower() in ("1", "true")
+```
+
+Set `FAIRY_TESTING=1` in the e2e Makefile target so the test endpoint is live for the test run on the Fairy server.
+
+### Success Criteria
+
+#### Automated:
+- [ ] `curl -i http://localhost:8777/test-mcp -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"test","version":"1"},"capabilities":{}}}'` returns a valid MCP initialize response when `FAIRY_TESTING=1`
+- [ ] Same curl returns 403 when `FAIRY_TESTING` is unset and `DEBUG=False`
+- [ ] `tools/list` returns `signal_tool`, `echo`, `dangerous_tool`
+- [ ] `tools/call` with `signal_tool(token="abc")` returns `"MCP_SIGNAL_abc"`
+- [ ] `tools/call` with valid `Authorization: Bearer <token>` succeeds when `MCP_TEST_TOKEN` is set
+- [ ] Same call with wrong token returns 403
+
+#### Manual:
+- [ ] In `make dev` mode (DEBUG=True), visit `/test-mcp` and confirm the endpoint responds
+
+**Gate**: Pause for review before Phase 6. Phase 5 can overlap with Phase 4 if you spin up a second workstream.
+
+---
+
+## Phase 6: E2E matrix
+
+### Overview
+
+Create `tests/e2e/test_mcp_enforcement.py` with 5 test classes × up-to-3 runtimes = ~14 sessions. Register `mcp_matrix` marker, add `test-e2e-mcp` Makefile target, update README with the MCP enforcement capability table. Depends on Phases 1–5.
+
+### Changes Required
+
+#### 1. `tests/e2e/conftest.py` — `mcp_test_url` fixture
+
+```python
+@pytest.fixture(scope="session")
+def mcp_test_url(fairy_url):
+    url = os.environ.get("MCP_TEST_URL")
+    if url:
+        return url
+    # Default: assume the Fairy under test has /test-mcp mounted
+    return f"{fairy_url.rstrip('/')}/test-mcp"
+```
+
+#### 2. `tests/e2e/test_mcp_enforcement.py` — full matrix
+
+File skeleton follows the structure in `thoughts/research/2026-04-17-mcp-enforcement-e2e.md` Track 4 (see research doc for the complete code). Key elements:
+
+- `pytestmark = [pytest.mark.slow, pytest.mark.mcp_matrix]`
+- Constants: `MCP_TEST_SERVER_NAME = "testmcp"` (no underscore — avoids gemini Policy Engine parse issue that `_build_mcp_gemini` doesn't hit but belt-and-suspenders), `MCP_TEST_TOOL_NAME = "signal_tool"`, `MCP_TEST_TOOL_RESPONSE_PREFIX = "MCP_SIGNAL_"`.
+- Parsers: three `_parse_<runtime>_mcp_tool_names` functions that reuse the existing `test_agent_tools.py` parse patterns and filter on `mcp__` prefix.
+- Helpers: `_mcp_server_spec(url)`, `_mcp_toolset_allow_server()`, `_mcp_toolset_deny_server()`, `_mcp_toolset_deny_one_tool()`.
+- Fixture: class-scoped `runtime = claude | codex | gemini` matching `E2E_RUNTIMES`.
+
+**Test classes:**
+
+| Class | Scenario | Runtimes | Sessions |
+|---|---|---|---|
+| `TestMcpServerToolInvocable` | server declared, no restriction → tool invoked + signal in output | claude, codex, gemini | 3 |
+| `TestMcpDenySpecificTool` | `configs` denies `signal_tool` → not invoked | claude, codex, gemini | 3 |
+| `TestMcpDenyEntireServer` | `default_config.enabled=False` → no mcp tool at all | claude, codex, gemini | 3 |
+| `TestNoMcpServerNoMcpTool` | no `mcp_servers` → no `mcp__*` calls | claude, codex, gemini | 3 |
+| `TestMcpDenyPersistsAcrossTurns` | deny persists on POST /prompt | claude only | 2 |
+
+Total: ~14 sessions.
+
+**Assertion shapes:**
+
+- Allow: `_mcp_tool_was_invoked(events, runtime)` is True AND `MCP_SIGNAL_` substring in `stream_all_output(events)`.
+- Deny: `not _any_mcp_tool_was_invoked(events, runtime)` AND `"SHOULD_NOT_BE_CALLED"` NOT in output.
+- Absence: `not _any_mcp_tool_was_invoked(events, runtime)`.
+
+#### 3. `pyproject.toml` — register marker
+
+```toml
+[tool.pytest.ini_options]
+markers = [
+    "slow: tests that create real agent sessions (may take minutes)",
+    "tool_matrix: verifies agent tool enforcement across runtimes",
+    "mcp_matrix: verifies MCP server + mcp_toolset enforcement across runtimes",
+]
+```
+
+#### 4. `Makefile` — `test-e2e-mcp` target
+
+```makefile
+test-e2e-mcp:
+	uv run pytest tests/e2e/test_mcp_enforcement.py -v -m "mcp_matrix"
+```
+
+Follow the pattern in `test-e2e-tools`: default `FAIRY_API_URL=http://localhost:8777`, require `FAIRY_API_TOKEN`, respect `E2E_RUNTIMES`.
+
+#### 5. `README.md` — MCP enforcement capability table
+
+Add a new subsection to the existing `## Tools` / `### Enforcement per runtime` area:
+
+```markdown
+### MCP tool enforcement per runtime
+
+| Scenario | claude / claude-oauth | codex | gemini |
+| --- | --- | --- | --- |
+| Server declared, no restriction | ✓ | ✓ | ✓ |
+| `mcp_toolset default_config.enabled=false` (deny server) | ✓ via settings.json | ✓ via `enabled = false` | ✓ via `includeTools=[]` |
+| `mcp_toolset configs[].enabled=false` (deny specific tool) | ✓ via settings.json | ✓ via `disabled_tools` | ✓ via `excludeTools` |
+| `default_config.enabled=false` + allow specific tool | ✓ via settings.json | ✓ via `enabled_tools` | ✓ via `includeTools` |
+
+All MCP enforcement reapplies on multi-turn prompts (`POST /sessions/{id}/prompt`) because the wrapper script is rebuilt every call.
+```
+
+### Success Criteria
+
+#### Automated:
+- [ ] `make test-e2e-mcp E2E_RUNTIMES=claude` passes — 4 sessions green
+- [ ] `make test-e2e-mcp E2E_RUNTIMES=claude,codex,gemini` passes — ~14 sessions green
+- [ ] `make test-e2e-mcp` full-matrix total cost under $0.70 (check via cost logging in session result)
+- [ ] `make test-e2e-tools` still passes unchanged
+- [ ] `make lint` passes
+
+#### Manual:
+- [ ] Run `E2E_RUNTIMES=claude make test-e2e-mcp` against a local Fairy and visually confirm the test output shows the expected allow/deny outcomes per test
+- [ ] Review README capability table renders correctly in GitHub
+
+**Gate**: Ready to merge.
+
+---
+
+## Testing Strategy
+
+### Automated
+
+- **Unit tests** (Phases 1–4, `tests/test_tools_mcp.py`): exhaustively cover `_build_mcp_toolset_rules` and each runtime's emission path. No dollar cost. Every `McpToolsetRules` configuration (default-allow, default-deny, mixed, empty) has a test per runtime.
+- **API validation tests** (Phase 1, `tests/test_tools_mcp.py`): cover the tightened `_validate_tools` for `mcp_toolset` — 422 cases for unknown server name, bad types, malformed configs.
+- **Test server tests** (Phase 5): direct curl / unit tests against the FastMCP view, no agent sessions.
+- **E2E matrix** (Phase 6): ~14 real agent sessions. Gated behind `FAIRY_API_TOKEN`, `MCP_TEST_URL` (defaults to `$FAIRY_API_URL/test-mcp`), and `mcp_matrix` marker.
+
+### Manual
+
+1. Create an agent with `mcp_servers: [{name: "testmcp", url: "$FAIRY_URL/test-mcp"}]` and `tools: [{type: "mcp_toolset", mcp_server_name: "testmcp", default_config: {enabled: false}}]`.
+2. Create a session. Stream the output. Prompt the agent to "use the signal_tool from the testmcp server."
+3. Confirm: the runtime init event shows the server registered; the stream contains no `mcp__testmcp__signal_tool` invocation; the session completes successfully with the model declining or unable to use the tool.
+4. Repeat across claude, codex, gemini.
+5. POST a second prompt to the session. Confirm the restriction still holds.
+
+## Performance Considerations
+
+- Each phase's unit tests run in the existing pytest suite — no added runtime cost (translation helpers are pure functions).
+- E2E matrix adds ~14 sessions per full `test-e2e-mcp` run. Cost: ~$0.30–0.70 on haiku/o4-mini/gemini-flash. This is about 2× the `test-e2e-tools` cost because there are 14 sessions instead of 11.
+- Test MCP server endpoint is stateless and ~10ms per tool call. No concern for the test load.
+- `FAIRY_TESTING=1` in `make dev` would expose `/test-mcp` locally — safe for developers. Production deployments must not set it.
+
+## References
+
+- Research: [`thoughts/research/2026-04-17-mcp-enforcement-e2e.md`](../research/2026-04-17-mcp-enforcement-e2e.md)
+- Sibling plan (tool enforcement, shipped as `4c3b9cc`): [`thoughts/plans/2026-04-16-agent-tool-enforcement.md`](./2026-04-16-agent-tool-enforcement.md)
+- Built-in tool matrix test (pattern to mirror): `tests/e2e/test_agent_tools.py:1-217`
+- Existing MCP emission: `src/fairy/sprites_exec.py:120-233`
+- `_tool_files_gemini` Policy Engine writer (pattern for new settings.json writer): `src/fairy/sprites_exec.py:342-392`
+- Codex `mcp_tool_call` stream parsing: `tests/e2e/test_agent_tools.py:89-92`
+- Claude upstream MCP denial bugs: [#12863](https://github.com/anthropics/claude-code/issues/12863), [#13077](https://github.com/anthropics/claude-code/issues/13077)

--- a/thoughts/research/2026-04-17-mcp-enforcement-e2e.md
+++ b/thoughts/research/2026-04-17-mcp-enforcement-e2e.md
@@ -1,0 +1,275 @@
+---
+date: 2026-04-17T09:42:00-07:00
+researcher: Claude Code (team-research skill)
+git_commit: 4c3b9cc1e5e7871436bdec48c063c76d47db30a0
+branch: agent-tool-enforcement
+repository: ravi-hq/fairy
+topic: "E2E test suite verifying coding agents respect Agent.mcp_servers + mcp_toolset"
+tags: [research, team-research, e2e, mcp, claude-cli, codex, gemini, enforcement]
+status: complete
+method: agent-team
+team_size: 5
+tracks: [fairy-wiring-audit, runtime-gating, test-infra, matrix-design, managed-agents-parity]
+last_updated: 2026-04-17
+last_updated_by: Claude Code
+---
+
+# Research: E2E test suite verifying MCP servers + mcp_toolset are respected by coding agents
+
+**Date**: 2026-04-17
+**Researcher**: Claude Code (team-research)
+**Git Commit**: [`4c3b9cc`](https://github.com/ravi-hq/fairy/commit/4c3b9cc1e5e7871436bdec48c063c76d47db30a0)
+**Branch**: `agent-tool-enforcement`
+**Repository**: ravi-hq/fairy
+**Method**: Agent team (5 specialist researchers)
+
+## Research Question
+
+Build an e2e test suite that verifies `Agent.mcp_servers` + `mcp_toolset` are respected by the coding agent runtimes (claude, codex, gemini). Fairy's MCP shape is modeled on Anthropic's Managed Agents API (`mcp_servers` at agent-level, `vault_ids` at session-level). Each runtime has its own translation, and tests must prove the translation actually reaches the running agent and gates tool availability.
+
+## Summary
+
+This effort is the MCP analog of the tool-enforcement work landed in commit [`4c3b9cc`](https://github.com/ravi-hq/fairy/commit/4c3b9cc1e5e7871436bdec48c063c76d47db30a0). The gap structure is the same shape as what that commit closed for built-in tools: **Fairy validates `mcp_toolset` entries but only the `mcp_server_name` field is actually wired through to a runtime, and only for claude's allowlist path.** `mcp_toolset.configs[]` (per-tool filter) and `mcp_toolset.default_config.enabled` (server-level toggle) are stored, returned, and ignored end-to-end (`src/fairy/views.py:485-498`, `src/fairy/sprites_exec.py:286-321`).
+
+Per-runtime, the story gets more complicated than for built-in tools:
+
+- **Claude**: `--disallowedTools` **silently ignores MCP tool names** in `-p` (headless) mode — upstream Claude Code issue #12863, closed-as-not-planned. `--allowedTools "mcp__server__*"` wildcard also silently fails (#13077). The only working claude-side deny path is file-based `permissions.deny` in `settings.json` — Fairy has no writer for that today. The allow path via `--tools "mcp__<server>"` works correctly and is what `_tool_flags_claude` already emits.
+- **Codex**: `[mcp_servers.<name>]` config supports `enabled_tools` (allowlist), `disabled_tools` (denylist applied after allowlist), `enabled` (whole-server toggle), `required` (fail if unreachable). Fairy's `_build_mcp_codex` only emits `url` + `bearer_token_env_var` + `required = true` — none of the allow/deny keys are wired.
+- **Gemini**: Policy Engine TOML (`~/.gemini/policies/*.toml`) uses **single-underscore** `mcp_{server}_{tool}` naming (NOT double like claude/codex). `includeTools`/`excludeTools` on the `mcpServers` entry in `settings.json` also works. Neither is wired in Fairy today.
+
+The Managed Agents vault model (agent-level servers + session-level `vault_ids` for credentials) is **out of scope** for this effort — Anthropic's vaults API is not GA, Fairy has no vault resource, and inline headers on `Agent.mcp_servers` are sufficient to prove "a bearer token reaches the MCP server" end-to-end. Flagged as a future security-hardening item: `Agent.mcp_servers[].headers` is plaintext at rest and returned in API responses, inconsistent with how Fairy treats `env_vars` or session tokens.
+
+For the test MCP server, the recommendation is **Option B: a Fairy-hosted `/test-mcp` endpoint** using the `mcp` Python SDK. Sprites have unrestricted outbound network by default, so they can reach Fairy's public URL. Three deterministic tools (`signal_tool`, `echo`, `dangerous_tool`) drive simple grep assertions. Estimated cost of a full matrix run: $0.30–0.70 at haiku/o4-mini/gemini-flash rates.
+
+**Critical implication for the implementation plan**: the draft matrix skeleton includes `test_mcp_deny_specific_tool` and `test_mcp_deny_entire_server`, both of which **would not pass against Fairy today** — the enforcement doesn't exist. A pre-test wiring phase (mirroring how `4c3b9cc` closed the tool-enforcement gap) is required before the deny-polarity tests can meaningfully land. The allow-polarity tests and the "no server declared → no mcp_* tools invoked" test can land against current Fairy.
+
+## Research Tracks
+
+### Track 1: Current Fairy MCP wiring audit
+**Researcher**: `fairy-mcp-auditor`
+**Scope**: `src/fairy/models.py`, `src/fairy/views.py`, `src/fairy/sprites_exec.py`, `src/fairy/runtimes.py`, existing unit + e2e tests
+
+#### Findings:
+
+1. **`mcp_servers` entry shape** — Validated in `_validate_mcp_servers` ([`views.py:501-523`](../../src/fairy/views.py)). Required: `name` (string, unique within array). Optional: `type` (`"url"` | `"stdio"`, defaults to `"url"`). For `type="url"`: `url` required. For `type="stdio"`: `command` required. Optional on all: `headers` (dict), `args` (list), `env` (dict). Max 20 servers per agent. No validation of header values, URL format, or command path.
+
+2. **`mcp_toolset` entry shape is minimal** — `_validate_tools` at [`views.py:485-498`](../../src/fairy/views.py) requires only `mcp_server_name` on `mcp_toolset` entries. No validation that the referenced server name exists in the agent's `mcp_servers` array — a dangling reference is accepted silently. The `name` field (tool-level filter), `configs[]`, and `default_config.enabled` are NOT validated or required and are **never read by any runtime translation path**. These only have semantics on `agent_toolset_20260401` entries.
+
+3. **Runtime-specific MCP emission** ([`sprites_exec.py`](../../src/fairy/sprites_exec.py)):
+   - Claude ([`:120-140`](../../src/fairy/sprites_exec.py)): writes `/tmp/mcp.json` heredoc with `{"mcpServers": {name: {type, url, headers}}}`. Headers pass through verbatim.
+   - Codex ([`:170-210`](../../src/fairy/sprites_exec.py)): writes `~/.codex/config.toml` with `[mcp_servers.<name>]` blocks. Only `Authorization: Bearer ${VAR}` headers are supported — extracted to `bearer_token_env_var = "VAR"`. All other headers silently dropped.
+   - Gemini ([`:213-233`](../../src/fairy/sprites_exec.py)): writes `~/.gemini/settings.json` with `{"mcpServers": {name: {httpUrl, trust: true, headers}}}`. Headers pass through verbatim.
+   - `mcp_toolset` entries **do not affect MCP config emission** in any runtime.
+
+4. **CLI flags** — Claude/claude-oauth ([`:258-264`, `:293-321`](../../src/fairy/sprites_exec.py)): appends `--mcp-config /tmp/mcp.json --strict-mcp-config`. `mcp_toolset` contributes `mcp__<server>` to `--tools` allowlist only when `default_config.enabled=False` on an `agent_toolset_20260401` entry; when `default_config.enabled=True`, `mcp_toolset` is ignored. Codex: no MCP CLI flags. Gemini: no MCP CLI flags.
+
+5. **`--continue` path re-emits MCP config** — `send_prompt` at [`views.py:378-395`](../../src/fairy/views.py) fetches the agent's current `mcp_servers`, converts to specs, and passes them to `build_wrapper_script(continue_session=True, mcp_servers=..., tools=...)`. `build_wrapper_script` emits the MCP section and flags unconditionally, so MCP config is re-written every turn. Correct behavior since sprite filesystem is overwritten each turn.
+
+6. **Test coverage gaps** — What IS covered: `tests/test_tools_mcp.py` covers unit-level MCP config generation (`TestWrapperScriptMcp`), CRUD validation (`TestAgentMcpValidation`), and session+MCP integration with mock sprites. `tests/e2e/test_agents.py::TestAgentTools` covers API-level CRUD validation for `mcp_servers`. What is NOT covered: (a) no e2e test that spawns a real session with an MCP server and verifies the runtime actually connects and calls tools; (b) no test that `mcp_toolset.mcp_server_name` referencing a non-existent server is rejected; (c) no codex `bearer_token_env_var` round-trip test; (d) `TestMcpToolset` e2e class is `@skip` pending a live MCP test server (tracked in [`thoughts/plans/2026-04-16-agent-tool-enforcement.md`](../plans/2026-04-16-agent-tool-enforcement.md)).
+
+7. **`mcp_toolset` runtime influence is one line of code** — Only `_tool_flags_claude` at [`sprites_exec.py:286-321`](../../src/fairy/sprites_exec.py) reads `mcp_toolset` entries, and only in the allowlist path (when an `agent_toolset_20260401` sets `default_config.enabled=False`). `_codex_top_level_keys` ([`sprites_exec.py:143-167`](../../src/fairy/sprites_exec.py)) and `_tool_files_gemini` ([`sprites_exec.py:342-392`](../../src/fairy/sprites_exec.py)) never consult `mcp_toolset`.
+
+8. **Deferred test** — `TestMcpToolset` referenced in [`thoughts/plans/2026-04-16-agent-tool-enforcement.md:63`](../plans/2026-04-16-agent-tool-enforcement.md) was marked "`@skip` pending a live MCP test server — separate future work." No other MCP `@skip`/`@xfail` markers exist.
+
+---
+
+### Track 2: Per-runtime MCP gating surfaces
+**Researcher**: `runtime-gating-researcher`
+**Scope**: Claude Code, Codex, Gemini CLI docs + source; stream-event shapes
+
+#### Findings:
+
+9. **Claude `--disallowedTools` silently ignores MCP tool names in `-p` mode** — Upstream Claude Code issue **#12863**, closed-as-not-planned. Built-in tools (`Bash`, `Read`, `WebFetch`, etc.) are correctly blocked, but `mcp__server__tool` names passed to `--disallowedTools` have no effect. This is an upstream limitation, not a Fairy bug.
+
+10. **`--allowedTools "mcp__server__*"` wildcard also silently fails** — Upstream Claude Code issue **#13077**. Only explicit per-tool listing works in `--allowedTools`. Server-wide `--tools "mcp__<server>"` allowlist DOES work.
+
+11. **Claude file-based deny path** — The only working deny mechanism for MCP tools in headless claude is `permissions.deny` rules in `~/.claude/settings.json` (or a custom path via `--config-dir`). Example: `{"permissions": {"deny": [{"tool": "mcp__server__tool"}]}}`. Fairy has no writer for this file — the gemini `_tool_files_gemini` TOML writer is the closest pattern.
+
+12. **Codex MCP config keys** ([config.toml](https://github.com/openai/codex)):
+    - `enabled_tools = ["a", "b"]` — explicit allowlist
+    - `disabled_tools = ["x"]` — denylist applied after allowlist
+    - `enabled = true|false` — whole-server toggle
+    - `required = true` — session fails if server unreachable
+    - `bearer_token_env_var = "VAR"` — auth by env-var indirection (only auth shape Fairy supports for codex today)
+    - `codex resume` reloads `config.toml` every invocation — same as init
+
+13. **Gemini per-MCP-tool enforcement** — Two mechanisms:
+    - `~/.gemini/policies/*.toml` Policy Engine rules. Tool names use **single-underscore** `mcp_{server}_{tool}`, NOT double. This differs from Claude/Codex. Rules shape: `[[policies]] name = "mcp_server_tool" action = "deny"`.
+    - `includeTools` / `excludeTools` on the `mcpServers` entry in `settings.json`.
+    - `--resume` re-reads `settings.json` on each invocation.
+    - Single-underscore naming means MCP server aliases with underscores (e.g. `test_server`) will misparse in the Policy Engine.
+
+14. **Stream-event shapes for MCP tool calls**:
+    - **Claude**: Regular `tool_use` block in `assistant` message content. `name` field contains the full `mcp__<server>__<tool>` string. Example: `{"type":"tool_use","name":"mcp__testmcp__signal_tool","input":{...}}`. MCP servers appear in the `system` init event's `mcp_servers` array.
+    - **Codex**: `item.started` / `item.completed` events with `item.type = "mcp_tool_call"`. Fields: `item.server` and `item.tool`. Already parsed at [`tests/e2e/test_agent_tools.py:89-92`](../../tests/e2e/test_agent_tools.py). Reconstruct name as `mcp__{server}__{tool}`.
+    - **Gemini**: `tool_use` event with `tool_name` field containing `mcp__<server>__<tool>` (stream output uses double-underscore even though Policy Engine uses single — confirmed separately).
+
+15. **Auth passthrough** — Claude: arbitrary `headers` dict in `mcpServers` entry, passed verbatim. Codex: only `bearer_token_env_var` — the env var must be exported by the wrapper script before invocation. Gemini: arbitrary `headers` dict in `mcpServers` entry, passed verbatim. On 401: claude emits no structured event (tool just fails with error result); codex surfaces as MCP initialization error on session start; gemini surfaces as tool failure.
+
+16. **Server name uniqueness** — No runtime cares about agent-to-agent collisions. Names are scoped within a single wrapper script / session.
+
+---
+
+### Track 3: Test MCP server infrastructure
+**Researcher**: `mcp-test-infra-researcher`
+**Scope**: Sprites networking, MCP SDK options, auth testing, CI-friendliness
+
+#### Findings:
+
+17. **Sprites have unrestricted outbound network by default** — Network policies (DNS-based allow/deny rules) are opt-in only. A sprite session can reach Fairy's public URL without any tunneling. This is the key enabler for Option B (Fairy-hosted test MCP endpoint).
+
+18. **Fairy supports `stdio` MCP type end-to-end** — `_validate_mcp_servers` at [`views.py:501-523`](../../src/fairy/views.py) accepts `type="stdio"`, and all three runtime writers handle it. But stdio can't test bearer-auth headers, so it's useful only for non-auth tests.
+
+19. **Decision matrix** (from test-infra research):
+
+| Option | Determinism | Network Feasibility | Impl Cost | Auth Testing | CI Friendly |
+|---|---|---|---|---|---|
+| A. Public hosted (deepwiki/context7) | Low — non-deterministic | High | None | No | Low — rate limits |
+| **B. Fairy-hosted `/test-mcp`** | **High** | **High** | Medium (~100 LOC) | **Yes** | **High** |
+| C. Conftest-spawned FastMCP subprocess | High | Low — needs tunnel | Medium | Yes (local) | Low — tunneling flaky |
+| D. stdio server inside Sprite | High | N/A | Low | No (no HTTP) | Medium |
+| E. Hybrid stdio + public HTTP | Medium | Mixed | High | Partial | Low |
+
+20. **Recommendation: Option B (Fairy-hosted `/test-mcp`)** — Django view implementing MCP Streamable HTTP protocol via the `mcp` Python SDK (`FastMCP` class). Three deterministic tools: `signal_tool(token: str) -> f"MCP_SIGNAL_{token}"`, `echo(msg: str) -> msg`, `dangerous_tool() -> "SHOULD_NOT_BE_CALLED"`. Optional bearer-token check via `MCP_TEST_TOKEN` env var. Gated behind `DEBUG or TESTING` so it's never active in prod.
+
+21. **Cost estimate** — 3 runtimes × 4–5 scenarios = ~12–15 sessions/run at haiku/o4-mini/gemini-flash rates ≈ **$0.30–0.70 per full run**. Under the $1.00 ceiling.
+
+22. **Conftest fixture shape**:
+    ```python
+    @pytest.fixture(scope="session")
+    def mcp_test_url():
+        url = os.environ.get("MCP_TEST_URL", "")
+        if not url:
+            pytest.skip("MCP_TEST_URL not set")
+        return url
+    ```
+
+---
+
+### Track 4: E2E matrix design & test scaffolding
+**Researcher**: `matrix-designer`
+**Scope**: Pattern-mirror `tests/e2e/test_agent_tools.py`, design scenarios + parsers + Makefile/pyproject wiring
+
+#### Findings:
+
+23. **Proposed matrix** (3 runtimes × 4 scenarios + 1 multi-turn = ~14 sessions):
+
+    | Test class | Scenario | Runtimes | Enforceable today? |
+    |---|---|---|---|
+    | `TestMcpServerToolInvocable` | server declared, no restriction → tool invoked | claude, codex, gemini | **Yes** |
+    | `TestMcpDenySpecificTool` | `mcp_toolset.configs` denies one tool | claude, codex*, gemini | **No** — needs wiring |
+    | `TestMcpDenyEntireServer` | `default_config.enabled=False` → whole server blocked | claude, codex, gemini | **Partial** — claude allowlist path only |
+    | `TestNoMcpServerNoMcpTool` | no `mcp_servers` → no `mcp__*` tools invoked | claude, codex, gemini | **Yes** |
+    | `TestMcpMultiTurnPersistence` | deny persists across `POST /prompt` | claude only | Depends on deny path |
+
+24. **Parsers fully derivable today** — Claude and Codex parsers are straight extensions of the existing `_parse_claude_tool_names` / `_parse_codex_tool_names` in [`tests/e2e/test_agent_tools.py`](../../tests/e2e/test_agent_tools.py) — filter on `name.startswith("mcp__")` for claude, and the `mcp_tool_call` item type is already parsed at lines 89–92. Gemini parser filters on `tool_name.startswith("mcp__")` in stream `tool_use` events.
+
+25. **Markers**: Add `mcp_matrix` to `[tool.pytest.ini_options].markers` in `pyproject.toml`, matching the existing `tool_matrix` marker.
+
+26. **Makefile target**:
+    ```makefile
+    test-e2e-mcp:
+        uv run pytest tests/e2e/test_mcp_enforcement.py -v -m "mcp_matrix"
+    ```
+
+27. **Fast-path for iteration**: `E2E_RUNTIMES=claude make test-e2e-mcp` = 4 sessions, ~$0.05.
+
+28. **Skeleton gaps that became code-changes**: The `_mcp_toolset_deny_one_tool()` helper uses `configs: [{"name": ..., "enabled": false}]` — a shape the Fairy validator accepts but silently discards. The `_mcp_toolset_deny_server()` helper uses `default_config: {"enabled": false}` — same story. Both tests would not pass today because Fairy has no enforcement path for either.
+
+---
+
+### Track 5: Managed Agents API parity & vault scope
+**Researcher**: `managed-agents-parity-researcher`
+**Scope**: Anthropic vault model, Fairy's current auth plumbing, scope decision
+
+#### Findings:
+
+29. **Scope decision: punt vaults; use inline `headers` for this effort** — Anthropic's vault API endpoint returns 404 (not GA). Fairy has no vault model. Inline headers on `Agent.mcp_servers` are sufficient to prove "a bearer token reaches the MCP server" end-to-end. The scope line: *"E2E MCP tests use inline `headers` on agent-level `mcp_servers`. A future `vaults` model (analogous to Anthropic's session-time `vault_ids`) will supersede this; auth-rotation tests are deferred until then."*
+
+30. **Managed Agents split** — Agent-level `mcp_servers[]: {type, name, url}` carries no auth. Session-level `vault_ids[]` references vault resources containing credentials. Credential types: `mcp_oauth` (OAuth + refresh), `mcp_bearer` (static token). Vault fields are write-only — tokens cannot be read back via the API. The split is intentional: "what servers exist" is reusable, "how to auth to them" is per-session.
+
+31. **Fairy is inconsistent with its own crypto pattern** — `Agent.mcp_servers` is an unencrypted `JSONField` ([`models.py:223`](../../src/fairy/models.py)). `_serialize_agent` at [`views.py:595-613`](../../src/fairy/views.py) returns full `mcp_servers` blob including `headers` containing bearer tokens. Compare to `Environment.env_vars` (encrypted via [`crypto.py:14-19`](../../src/fairy/crypto.py), never returned) and `SessionResource.encrypted_token`. User-scoping mitigates exposure (only the agent owner can read), but plaintext-at-rest + plaintext-in-response is a hardening gap.
+
+32. **E2E auth coverage (in-scope)**:
+    - `test_mcp_tool_invoked_with_valid_auth` — valid sentinel token → MCP tool appears in stream
+    - `test_mcp_tool_absent_with_invalid_auth` — invalid header → MCP tool does NOT appear (absence assertion only — no runtime emits a structured auth-failure event)
+    - Out of scope: `vault_ids`, OAuth + refresh, `session.error` structured events, encrypted-at-rest headers.
+
+33. **Auth in test fixtures**: Use fake/sentinel tokens only. Fairy returns `headers` in API responses, so any real token in a test fixture will land in CI logs.
+
+## Cross-Track Discoveries
+
+These findings only emerged from connections between tracks:
+
+- **The MCP enforcement gap is the direct analog of the tool enforcement gap closed by [`4c3b9cc`](https://github.com/ravi-hq/fairy/commit/4c3b9cc1e5e7871436bdec48c063c76d47db30a0)** (Track 1 + Track 2). `mcp_toolset.configs` and `default_config.enabled` are validated but not wired. For each runtime, the fix path mirrors what `4c3b9cc` did for `agent_toolset_20260401`: add a new writer function (or extend existing MCP writers) to emit runtime-specific allow/deny config from `mcp_toolset` entries.
+
+- **Claude's headless MCP deny path requires a settings.json writer Fairy doesn't have** (Track 1 + Track 2). The `_tool_files_*` pattern introduced in `4c3b9cc` for gemini Policy Engine is the template — a new `_tool_files_claude_permissions` function that writes `~/.claude/settings.json` with `permissions.deny` rules. The claude-CLI test for `TestMcpDenySpecificTool` and `TestMcpDenyEntireServer` cannot pass without this writer.
+
+- **Codex has the richest built-in MCP enforcement surface, but Fairy uses the least of it** (Track 1 + Track 2). Codex `[mcp_servers.<name>]` supports `enabled_tools` + `disabled_tools` + `enabled` + `required`. Fairy's `_build_mcp_codex` only emits `url` + `bearer_token_env_var` + `required`. Adding the allow/deny keys to `_build_mcp_codex` (keyed on `mcp_toolset.configs`) would unlock codex per-tool deny without new writer functions.
+
+- **Gemini server names must avoid underscores** (Track 2 + Track 3 + Track 4). Gemini Policy Engine uses single-underscore `mcp_{server}_{tool}` naming, so an alias like `test_server` misparses. The Fairy-hosted `/test-mcp` server should use a simple alias like `testmcp` (no underscore) in fixtures to avoid this.
+
+- **The "deny" polarity tests are blocked on Fairy wiring, not on the test server or the runtimes** (Track 1 + Track 4). Options for the implementation plan: (a) ship e2e tests for the allow/absence polarity only now and xfail/skip deny tests pending wiring; (b) precede the e2e suite with a wiring phase analogous to `4c3b9cc` that adds per-runtime MCP deny writers; (c) scope this effort exclusively to the wiring + e2e bundle. Recommendation: (c) — the value of e2e tests is proving the wiring, so splitting them defeats the purpose.
+
+- **`Agent.mcp_servers[].headers` plaintext exposure is orthogonal to this effort but should be tracked** (Track 1 + Track 5). Not a blocker; flag as a hardening item. The fix (encrypt + strip from serialization) mirrors the `env_vars` pattern.
+
+## Code References
+
+| File | Lines | Finding | Notes |
+|------|-------|---------|-------|
+| `src/fairy/models.py` | 222–223 | `Agent.tools` + `mcp_servers` are plain JSONFields | Tools wired by `4c3b9cc`; MCP still partial |
+| `src/fairy/views.py` | 485–498 | `_validate_tools` accepts `mcp_toolset` with only `mcp_server_name` required | `configs` / `default_config` not validated |
+| `src/fairy/views.py` | 501–523 | `_validate_mcp_servers` — url/stdio types, 20-max, name-unique | No header-value validation |
+| `src/fairy/views.py` | 595–613 | `_serialize_agent` returns full `mcp_servers` incl. headers | **Security gap** |
+| `src/fairy/views.py` | 378–395 | `send_prompt` re-passes `mcp_servers` on continue | Multi-turn persistence works |
+| `src/fairy/sprites_exec.py` | 120–140 | `_build_mcp_claude` → `/tmp/mcp.json` | Headers verbatim |
+| `src/fairy/sprites_exec.py` | 143–167 | `_codex_top_level_keys` — tool enforcement only | Never reads `mcp_toolset` |
+| `src/fairy/sprites_exec.py` | 170–210 | `_build_mcp_codex` — url + bearer only | **No `enabled_tools` / `disabled_tools`** |
+| `src/fairy/sprites_exec.py` | 213–233 | `_build_mcp_gemini` → `~/.gemini/settings.json` | **No `includeTools` / `excludeTools`** |
+| `src/fairy/sprites_exec.py` | 258–264 | `_mcp_cmd_flags` — claude `--mcp-config --strict-mcp-config` | |
+| `src/fairy/sprites_exec.py` | 286–321 | `_tool_flags_claude` — reads `mcp_toolset` in allowlist path only | **Denylist path ignores it** |
+| `src/fairy/sprites_exec.py` | 342–392 | `_tool_files_gemini` — Policy Engine writer | Template for a new `_tool_files_claude_permissions` |
+| `tests/e2e/test_agents.py` | 241–355 | `TestAgentTools` — CRUD validation for tools + mcp_servers | Pattern for validation-only tests |
+| `tests/e2e/test_agent_tools.py` | 61–113 | `_parse_claude_tool_names` / `_parse_codex_tool_names` / `_parse_gemini_tool_names` | Extend for `mcp__*` filter |
+| `tests/e2e/test_agent_tools.py` | 89–92 | Codex `mcp_tool_call` item parsing | Reuse verbatim |
+| `tests/e2e/test_agent_tools.py` | 144–177 | `TestToolEnforcement` matrix fixture | Mirror for `TestMcpEnforcement` |
+| `tests/e2e/conftest.py` | 20–27 | `RUNTIME_MODELS` pinned-cheap-model map | Use as-is |
+
+## Architecture Insights
+
+- **The `_tool_files_<runtime>` pattern introduced in `4c3b9cc` is extensible.** It produces `(cli_flags, files_to_write)` for each runtime. Adding MCP-specific deny wiring means either (a) adding a `_mcp_files_<runtime>` function with the same contract, or (b) extending `_tool_files_<runtime>` to also read `mcp_toolset` entries. Option (b) keeps everything tools-related in one function per runtime and matches the existing contract of `_build_tool_flags` which already takes `mcp_server_names`.
+
+- **Codex is uniquely suited to per-tool MCP deny** — it's the only runtime with a first-class per-tool config key (`disabled_tools`). Claude needs a settings.json writer; Gemini needs a Policy Engine writer. Codex just needs extra keys in the same `config.toml` block it already emits.
+
+- **Stream-event parsing is cheap to extend to MCP.** Codex parsing was already MCP-aware at [`test_agent_tools.py:89-92`](../../tests/e2e/test_agent_tools.py). Claude and Gemini just need a `name.startswith("mcp__")` filter on the same event shapes the existing tool-enforcement tests use.
+
+- **Multi-turn MCP enforcement is free.** Fairy rebuilds the wrapper script on every turn (`continue_session=True` path re-calls `_build_mcp_section` and `_tool_flags_*`). Claude's continue-path non-persistence bug (from the tool-enforcement research) is also a non-issue here because Fairy re-emits everything.
+
+## Historical Context
+
+Relevant prior research in `thoughts/research/`:
+
+- [`2026-04-16-agent-tool-enforcement-e2e.md`](./2026-04-16-agent-tool-enforcement-e2e.md) — the sibling research doc that led to `4c3b9cc`. The `_tool_files_*` pattern, stream-event shapes, and matrix structure are all directly transferable.
+- [`2026-04-16-agent-tools-and-mcp.md`](./2026-04-16-agent-tools-and-mcp.md) — original research that shaped `Agent.tools` + `mcp_servers` fields. Documents the Managed Agents API mapping.
+- [`2026-04-15-sprites-platform-research.md`](./2026-04-15-sprites-platform-research.md) and [`2026-04-16-sprites-deep-dive.md`](./2026-04-16-sprites-deep-dive.md) — confirm Sprites has unrestricted outbound network (key for the Fairy-hosted `/test-mcp` decision).
+
+Relevant plans:
+- [`thoughts/plans/2026-04-16-agent-tool-enforcement.md`](../plans/2026-04-16-agent-tool-enforcement.md) — the plan that shipped in `4c3b9cc`. Its "What We're NOT Doing" section explicitly scopes MCP enforcement out; this research picks up that thread.
+
+## Open Questions
+
+- **Should the e2e suite land as a bundle with Fairy wiring changes, or incrementally?** Recommendation: bundle. Allow-polarity and absence tests alone don't prove the high-value claim ("denying an MCP tool actually denies it"). An e2e file with 4 xfails + 1 passing test provides less signal than a coordinated wiring + e2e landing.
+
+- **Claude settings.json writer: new file or extend `_tool_files_*`?** `_tool_files_claude` doesn't exist yet (claude uses CLI flags only today). Introducing it for MCP deny via `permissions.deny` would mirror gemini's `_tool_files_gemini`. Decide whether to also migrate built-in tool denial to settings.json or keep the current `--disallowedTools` path for built-ins.
+
+- **Does Fairy want to expose `codex disabled_tools` / `gemini excludeTools` per-tool semantics in `mcp_toolset.configs`, or only server-level enable/disable?** Per-tool gives the richer API but requires validator changes to actually read `configs[].name` + `enabled`. Minimum viable wiring: server-level only (via `default_config.enabled`).
+
+- **Is the Fairy-hosted `/test-mcp` endpoint dev-only, or should it persist in prod as a health-check?** Recommendation: dev-only (gate behind `DEBUG` or a `FAIRY_TESTING` env). A persistent test endpoint in prod is a small but real supply-chain vector if any tool does more than echo.
+
+- **Security-hardening follow-up**: should `mcp_servers[].headers` encryption (and strip-from-response) land before or after this e2e work? These are orthogonal — this research doesn't block on it — but the plaintext exposure is worth a dedicated ticket.
+
+## Related Research
+
+- [`2026-04-16-agent-tool-enforcement-e2e.md`](./2026-04-16-agent-tool-enforcement-e2e.md) — direct sibling, identical structure for built-in tools
+- [`2026-04-16-agent-tools-and-mcp.md`](./2026-04-16-agent-tools-and-mcp.md) — Agent model API design research
+- [`2026-04-16-sprites-deep-dive.md`](./2026-04-16-sprites-deep-dive.md) — Sprites network reachability


### PR DESCRIPTION
## Summary

Closes the MCP enforcement gap analogous to what PR #5 closed for built-in
tools. Stacked on `agent-tool-enforcement` — rebase to `main` once #5 lands.

- Wires `mcp_toolset.configs[]` + `default_config.enabled` to every runtime:
  codex `enabled`/`enabled_tools`/`disabled_tools`, gemini
  `includeTools`/`excludeTools`, claude via a new `~/.claude/settings.json`
  `permissions.allow/deny` writer (needed because `--disallowedTools`
  silently ignores MCP names in `-p` mode —
  [claude-code#12863](https://github.com/anthropics/claude-code/issues/12863)).
- Tightens `_validate_tools`: `configs`/`default_config` shape checks, and
  rejects `mcp_toolset` entries referencing unknown servers with 422.
- Adds a Fairy-hosted `/test-mcp` endpoint (MCP Streamable HTTP, pure Django,
  no `mcp` SDK dep) gated on `DEBUG or FAIRY_TESTING`. Deterministic tools
  `signal_tool`, `echo`, `dangerous_tool` power the e2e assertions.
- New `mcp_matrix` pytest marker + `make test-e2e-mcp` target — 14 real
  sessions across claude/codex/gemini proving allow/deny/absence paths. README
  gains an MCP capability table.

Research: `thoughts/research/2026-04-17-mcp-enforcement-e2e.md`.
Plan: `thoughts/plans/2026-04-17-agent-mcp-enforcement.md`.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 232 unit tests pass (27 new for MCP rules, 14 for /test-mcp)
- [x] Live smoke: `FAIRY_TESTING=1 manage.py runserver` → `/test-mcp`
  `tools/list` + `tools/call signal_tool` return expected JSON-RPC
- [ ] `FAIRY_API_TOKEN=<token> make test-e2e-mcp` — 4 claude sessions green
- [ ] `FAIRY_API_TOKEN=<token> E2E_RUNTIMES=claude,codex,gemini make test-e2e-mcp` —
  ~14 sessions green under $0.70
- [ ] `make test-e2e-tools` still passes unchanged
- [ ] Manually verify that `mcp_toolset` referencing an unknown server returns 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)