### PR TITLE
Enforce Agent.tools: baseline + claude

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,11 @@ test-e2e:
 test-e2e-fast:
 	uv run pytest tests/e2e -v -n $(E2E_WORKERS) --dist loadfile -m "not slow"
 
+# Tool-enforcement matrix — ~11 real sessions across runtimes.
+# Requires FAIRY_API_TOKEN. Respects E2E_RUNTIMES to subset runtimes.
+test-e2e-tools:
+	uv run pytest tests/e2e/test_agent_tools.py -v -m "tool_matrix"
+
 # Run everything — unit + e2e. E2E auto-skips if FAIRY_API_TOKEN is unset.
 test-all:
 	uv run pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Configurations are accepted silently even when unenforceable on the selected
 runtime. For full behavioral guarantees, use `claude` or `gemini`; `codex` is
 best-effort.
 
+See [`docs/tools-and-mcp-examples.md`](docs/tools-and-mcp-examples.md) for
+copy-pasteable curl examples of agents configured with tools and MCP
+servers.
+
 ## Testing
 
 ### Unit / integration tests

--- a/README.md
+++ b/README.md
@@ -50,6 +50,30 @@ families:
 
 Full list in `src/fairy/runtimes.py`.
 
+## Tools
+
+Agents accept a `tools` field modeled on Anthropic's Managed Agents
+`agent_toolset_20260401` spec. Canonical tool names are `bash`, `read`, `write`,
+`edit`, `glob`, `grep`, `web_fetch`, `web_search`. Each runtime translates this
+spec to its own CLI flags / config files.
+
+### Enforcement per runtime
+
+| Canonical tool | claude / claude-oauth | codex                            | gemini                                       |
+| -------------- | --------------------- | -------------------------------- | -------------------------------------------- |
+| `bash`         | ✓                     | not enforceable                  | ✓                                            |
+| `read`         | ✓                     | not enforceable                  | ✓                                            |
+| `write`        | ✓                     | ✓ (only when `edit` also off)    | ✓ (denies both `write_file` and `replace`)   |
+| `edit`         | ✓                     | not enforceable                  | ✓                                            |
+| `glob`         | ✓                     | not enforceable                  | ✓                                            |
+| `grep`         | ✓                     | not enforceable                  | ✓                                            |
+| `web_fetch`    | ✓                     | no codex equivalent (no-op)      | ✓                                            |
+| `web_search`   | ✓                     | ✓                                | ✓                                            |
+
+Configurations are accepted silently even when unenforceable on the selected
+runtime. For full behavioral guarantees, use `claude` or `gemini`; `codex` is
+best-effort.
+
 ## Testing
 
 ### Unit / integration tests
@@ -90,6 +114,9 @@ FAIRY_API_TOKEN=<token> make test-e2e-fast
 
 # full suite
 FAIRY_API_TOKEN=<token> make test-e2e
+
+# tool-enforcement matrix — ~11 sessions verifying tools flow through per runtime
+FAIRY_API_TOKEN=<token> E2E_RUNTIMES=claude,codex,gemini make test-e2e-tools
 
 # single class
 FAIRY_API_TOKEN=<token> \

--- a/docs/tools-and-mcp-examples.md
+++ b/docs/tools-and-mcp-examples.md
@@ -1,0 +1,172 @@
+# Agents with tools and MCP servers — curl examples
+
+Copy-pasteable `curl` calls for every meaningful shape of `tools` and
+`mcp_servers` on `POST /agents`. Aimed at humans who want to see the request
+body, not fully-scripted clients.
+
+Set these once per shell:
+
+```bash
+export FAIRY_URL=http://localhost:8777   # what `make dev` serves
+export FAIRY_TOKEN=<your-api-token>
+```
+
+All examples below target the running dev server. Enforcement per runtime is
+summarised in the capability table in the main `README.md`.
+
+## Built-in toolset (`agent_toolset_20260401`)
+
+Canonical tool names: `bash`, `read`, `write`, `edit`, `glob`, `grep`,
+`web_fetch`, `web_search`. Omit `tools` entirely to get the runtime default
+(everything on).
+
+### 1. Allow all built-in tools (explicit)
+
+Equivalent to omitting `tools`. Good starting shape.
+
+```bash
+curl -sS -X POST "$FAIRY_URL/agents" \
+  -H "Authorization: Bearer $FAIRY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "unrestricted",
+    "model": "claude-sonnet-4-6",
+    "runtime": "claude",
+    "tools": [{"type": "agent_toolset_20260401"}]
+  }'
+```
+
+### 2. Deny all built-in tools
+
+Sandboxed agent with no file/shell/web access. Useful for pure-reasoning
+agents or agents whose only capability is a single MCP server.
+
+```bash
+curl -sS -X POST "$FAIRY_URL/agents" \
+  -H "Authorization: Bearer $FAIRY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "sandboxed",
+    "model": "claude-sonnet-4-6",
+    "runtime": "claude",
+    "tools": [{
+      "type": "agent_toolset_20260401",
+      "default_config": {"enabled": false}
+    }]
+  }'
+```
+
+### 3. Allowlist: only `bash`, `read`, `grep`
+
+`default_config.enabled=false` flips the policy to deny-by-default; `configs`
+entries with `enabled:true` punch holes in the deny wall.
+
+```bash
+curl -sS -X POST "$FAIRY_URL/agents" \
+  -H "Authorization: Bearer $FAIRY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "read-only-shell",
+    "model": "claude-sonnet-4-6",
+    "runtime": "claude",
+    "tools": [{
+      "type": "agent_toolset_20260401",
+      "default_config": {"enabled": false},
+      "configs": [
+        {"name": "bash",  "enabled": true},
+        {"name": "read",  "enabled": true},
+        {"name": "grep",  "enabled": true}
+      ]
+    }]
+  }'
+```
+
+### 4. Denylist: everything except web access
+
+Default allow, disable the code-manipulation tools individually. Useful for a
+research agent that shouldn't touch files.
+
+```bash
+curl -sS -X POST "$FAIRY_URL/agents" \
+  -H "Authorization: Bearer $FAIRY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "researcher",
+    "model": "claude-sonnet-4-6",
+    "runtime": "claude",
+    "tools": [{
+      "type": "agent_toolset_20260401",
+      "configs": [
+        {"name": "bash",  "enabled": false},
+        {"name": "edit",  "enabled": false},
+        {"name": "write", "enabled": false},
+        {"name": "glob",  "enabled": false},
+        {"name": "grep",  "enabled": false},
+        {"name": "read",  "enabled": false}
+      ]
+    }]
+  }'
+```
+
+## Updating tools on an existing agent
+
+`PUT /agents/{id}` requires the current `version` for optimistic concurrency.
+The response returns the bumped version; re-sending with the stale `version`
+returns `409`.
+
+```bash
+curl -sS -X PUT "$FAIRY_URL/agents/$AGENT_ID" \
+  -H "Authorization: Bearer $FAIRY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "version": 1,
+    "tools": [{
+      "type": "agent_toolset_20260401",
+      "default_config": {"enabled": false},
+      "configs": [{"name": "read", "enabled": true}]
+    }]
+  }'
+```
+
+Only fields present in the body are changed; others are left alone. To clear
+tools, send `"tools": []`.
+
+## Validation errors
+
+Each of the following returns `422 Unprocessable Entity`. Copy-paste and
+compare the `detail` message to confirm your client's error handling works.
+
+### A. Unknown tool type (including `custom`, which was removed)
+
+`custom` tools were accepted in prior versions but are no longer valid.
+
+```bash
+curl -sS -X POST "$FAIRY_URL/agents" \
+  -H "Authorization: Bearer $FAIRY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "bad",
+    "model": "claude-sonnet-4-6",
+    "runtime": "claude",
+    "tools": [{
+      "type": "custom",
+      "name": "get_weather",
+      "description": "...",
+      "input_schema": {"type": "object"}
+    }]
+  }'
+```
+
+### B. `mcp_toolset` missing `mcp_server_name`
+
+```bash
+curl -sS -X POST "$FAIRY_URL/agents" \
+  -H "Authorization: Bearer $FAIRY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "bad",
+    "model": "claude-sonnet-4-6",
+    "runtime": "claude",
+    "tools": [{"type": "mcp_toolset"}]
+  }'
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,4 +30,5 @@ DJANGO_SETTINGS_MODULE = "config.settings"
 pythonpath = ["src"]
 markers = [
     "slow: tests that create real agent sessions (may take minutes)",
+    "tool_matrix: verifies agent tool enforcement across runtimes",
 ]

--- a/src/fairy/auth.py
+++ b/src/fairy/auth.py
@@ -1,5 +1,4 @@
 import functools
-from datetime import timezone
 
 from django.http import JsonResponse
 from django.utils import timezone as tz

--- a/src/fairy/sprites_exec.py
+++ b/src/fairy/sprites_exec.py
@@ -215,6 +215,98 @@ def _mcp_cmd_flags(runtime_name: str, servers: list[McpServerSpec]) -> str:
     return ""
 
 
+_CLAUDE_TOOL_NAMES: dict[str, str] = {
+    "bash": "Bash",
+    "read": "Read",
+    "write": "Write",
+    "edit": "Edit",
+    "glob": "Glob",
+    "grep": "Grep",
+    "web_fetch": "WebFetch",
+    "web_search": "WebSearch",
+}
+
+
+def _find_agent_toolset(tools: list[dict]) -> dict | None:
+    for t in tools:
+        if t.get("type") == "agent_toolset_20260401":
+            return t
+    return None
+
+
+def _tool_flags_claude(tools: list[dict], mcp_server_names: list[str]) -> str:
+    """Translate Managed-Agents tools spec → claude CLI flags.
+
+    default_config.enabled=False → `--tools "<enabled>"` allowlist (empty string disables all)
+    default_config.enabled=True (or missing) with per-tool disabled → `--disallowedTools "..."`
+    mcp_toolset entries extend the allowlist with `mcp__<server>`.
+    """
+    toolset = _find_agent_toolset(tools)
+    mcp_refs = [
+        t["mcp_server_name"] for t in tools
+        if t.get("type") == "mcp_toolset" and "mcp_server_name" in t
+    ]
+
+    if toolset is None:
+        return ""
+
+    default_enabled = toolset.get("default_config", {}).get("enabled", True)
+    configs = {c["name"]: c.get("enabled", True) for c in toolset.get("configs", [])}
+
+    if not default_enabled:
+        enabled_tools = [
+            _CLAUDE_TOOL_NAMES[name]
+            for name in _CLAUDE_TOOL_NAMES
+            if configs.get(name, False)
+        ]
+        enabled_tools += [f"mcp__{name}" for name in mcp_refs]
+        return f' --tools "{",".join(enabled_tools)}"'
+
+    disabled_tools = [
+        _CLAUDE_TOOL_NAMES[name]
+        for name, enabled in configs.items()
+        if name in _CLAUDE_TOOL_NAMES and not enabled
+    ]
+    if not disabled_tools:
+        return ""
+    return f' --disallowedTools "{",".join(disabled_tools)}"'
+
+
+def _build_tool_flags(
+    runtime_name: str,
+    tools: list[dict],
+    mcp_server_names: list[str],
+) -> tuple[str, dict[str, str]]:
+    """Translate Agent.tools into runtime-specific enforcement.
+
+    Returns (cli_flags, files):
+      cli_flags — extra flags appended to the exec line (leading space if non-empty)
+      files     — {absolute_path: content} to write as heredoc blocks before exec
+
+    Runtimes without a per-tool enforcement path (codex, gemini) return ("", {}).
+    Subsequent PRs land those translations.
+    """
+    if not tools:
+        return "", {}
+    if runtime_name in ("claude", "claude-oauth"):
+        return _tool_flags_claude(tools, mcp_server_names), {}
+    return "", {}
+
+
+def _format_tool_files_heredoc(files: dict[str, str]) -> str:
+    """Render file writes as mkdir + heredoc blocks for the wrapper script."""
+    if not files:
+        return ""
+    blocks: list[str] = ["# Tool enforcement files"]
+    for path, content in files.items():
+        parent = path.rsplit("/", 1)[0] if "/" in path else "."
+        blocks.append(f"mkdir -p {shlex.quote(parent)}")
+        blocks.append(f"cat > {shlex.quote(path)} << 'TOOLFILE_EOF'")
+        blocks.append(content.rstrip("\n"))
+        blocks.append("TOOLFILE_EOF")
+    return "\n".join(blocks)
+
+
 def build_wrapper_script(
     config: RuntimeConfig,
     api_key: str,
@@ -224,6 +316,7 @@ def build_wrapper_script(
     repos: list[RepoSpec] | None = None,
     environment: EnvironmentSetup | None = None,
     mcp_servers: list[McpServerSpec] | None = None,
+    tools: list[dict] | None = None,
 ) -> str:
     """Build a shell script that exports the API key and runs the agent.
 
@@ -244,6 +337,10 @@ def build_wrapper_script(
 
     mcp_section = _build_mcp_section(config.name, mcp_servers or [])
     mcp_flags = _mcp_cmd_flags(config.name, mcp_servers or [])
+
+    mcp_names = [s.name for s in (mcp_servers or [])]
+    tool_flags, tool_files = _build_tool_flags(config.name, tools or [], mcp_names)
+    tool_files_section = _format_tool_files_heredoc(tool_files)
 
     return f"""#!/bin/bash
 set -euo pipefail
@@ -268,5 +365,7 @@ fi
 
 {mcp_section}
 
-exec {cmd}{mcp_flags}
+{tool_files_section}
+
+exec {cmd}{mcp_flags}{tool_flags}
 """

--- a/src/fairy/views.py
+++ b/src/fairy/views.py
@@ -222,9 +222,11 @@ def create_session(request):
             )
 
         mcp_specs = _mcp_servers_to_specs(agent_obj.mcp_servers) if agent_obj else []
+        agent_tools = agent_obj.tools if agent_obj else []
         script = build_wrapper_script(
             config, api_key, effective_prompt,
             repos=repo_specs, environment=env_setup, mcp_servers=mcp_specs,
+            tools=agent_tools,
         )
         (fs / "run-agent.sh").write_text(script)
         sprite.command("chmod", "+x", "/run-agent.sh").run()
@@ -373,9 +375,24 @@ def send_prompt(request, session_id):
     except SpriteError as e:
         return JsonResponse({"detail": f"Sprite not found: {e}"}, status=404)
 
+    agent_tools: list = []
+    mcp_specs: list = []
+    if session.agent_id:
+        try:
+            agent_obj = Agent.objects.get(pk=session.agent_id)
+            agent_tools = agent_obj.tools
+            mcp_specs = _mcp_servers_to_specs(agent_obj.mcp_servers)
+        except Agent.DoesNotExist:
+            pass
+
     try:
         fs = sprite.filesystem()
-        script = build_wrapper_script(config, api_key, req.prompt, continue_session=True)
+        script = build_wrapper_script(
+            config, api_key, req.prompt,
+            continue_session=True,
+            mcp_servers=mcp_specs,
+            tools=agent_tools,
+        )
         (fs / "run-agent.sh").write_text(script)
     except SpriteError as e:
         return JsonResponse({"detail": f"Failed to prepare Sprite: {e}"}, status=502)
@@ -461,7 +478,7 @@ def delete_session(request, session_id):
 AGENT_VERSIONED_FIELDS = ("name", "description", "system", "model", "runtime", "environment", "skills", "tools", "mcp_servers", "metadata")
 
 
-VALID_TOOL_TYPES = {"agent_toolset_20260401", "mcp_toolset", "custom"}
+VALID_TOOL_TYPES = {"agent_toolset_20260401", "mcp_toolset"}
 VALID_MCP_SERVER_TYPES = {"url", "stdio"}
 
 
@@ -476,10 +493,6 @@ def _validate_tools(tools: list) -> list:
                 f"tools[{i}]: unknown type {tool['type']!r}. "
                 f"Must be one of: {sorted(VALID_TOOL_TYPES)}"
             )
-        if tool["type"] == "custom":
-            for field_name in ("name", "description", "input_schema"):
-                if field_name not in tool:
-                    raise ValueError(f"tools[{i}] (custom): missing required field: {field_name}")
         if tool["type"] == "mcp_toolset" and "mcp_server_name" not in tool:
             raise ValueError(f"tools[{i}] (mcp_toolset): missing required field: mcp_server_name")
     return tools

--- a/tests/e2e/test_agent_tools.py
+++ b/tests/e2e/test_agent_tools.py
@@ -1,0 +1,222 @@
+"""E2E tests verifying Agent.tools is enforced by each runtime CLI.
+
+Tight matrix — per-tool translation is covered exhaustively by unit tests in
+tests/test_tools_mcp.py. These tests only prove the translation layer works
+end-to-end against a real Fairy deployment. One representative tool per runtime.
+
+Run: `make test-e2e-tools`.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.e2e.conftest import (
+    RUNTIME_MODELS,
+    FairyClient,
+    _unique,
+    stream_all_output,
+)
+
+pytestmark = [pytest.mark.slow, pytest.mark.tool_matrix]
+
+REPRESENTATIVE_TOOL = {
+    "claude": "web_fetch",
+    "claude-oauth": "web_fetch",
+}
+
+RUNTIME_TOOL_NAMES = {
+    "claude": {"web_fetch": "WebFetch"},
+    "claude-oauth": {"web_fetch": "WebFetch"},
+}
+
+PROMPTS = {
+    "web_fetch": (
+        "Use your web fetch tool to fetch https://httpbin.org/get and print the "
+        "response body. Do not use shell."
+    ),
+}
+
+
+def _parse_claude_tool_names(events: list[dict]) -> list[str]:
+    names: list[str] = []
+    for e in events:
+        if e.get("type") != "output":
+            continue
+        try:
+            obj = json.loads(e.get("data", ""))
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if obj.get("type") == "assistant":
+            for block in obj.get("message", {}).get("content", []):
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    name = block.get("name")
+                    if name:
+                        names.append(name)
+    return names
+
+
+def _tool_was_invoked(events: list[dict], runtime: str, tool: str) -> bool:
+    target = RUNTIME_TOOL_NAMES[runtime][tool]
+    if runtime in ("claude", "claude-oauth"):
+        return target in _parse_claude_tool_names(events)
+    return False
+
+
+def _any_tool_was_invoked(events: list[dict], runtime: str) -> bool:
+    if runtime in ("claude", "claude-oauth"):
+        return bool(_parse_claude_tool_names(events))
+    return False
+
+
+def _allow_only(tool: str) -> list[dict]:
+    return [{
+        "type": "agent_toolset_20260401",
+        "default_config": {"enabled": False},
+        "configs": [{"name": tool, "enabled": True}],
+    }]
+
+
+def _deny(tool: str) -> list[dict]:
+    return [{
+        "type": "agent_toolset_20260401",
+        "default_config": {"enabled": True},
+        "configs": [{"name": tool, "enabled": False}],
+    }]
+
+
+def _deny_all() -> list[dict]:
+    return [{"type": "agent_toolset_20260401", "default_config": {"enabled": False}}]
+
+
+@pytest.fixture(scope="class", params=["claude"])
+def runtime(request, e2e_runtimes):
+    if request.param not in e2e_runtimes:
+        pytest.skip(f"{request.param} not in E2E_RUNTIMES")
+    return request.param
+
+
+class TestToolEnforcement:
+    """Per-runtime matrix. Subsequent PRs widen the `runtime` fixture params."""
+
+    def test_allow_tool_is_invocable(
+        self, api: FairyClient, create_agent, create_session, runtime,
+    ):
+        tool = REPRESENTATIVE_TOOL[runtime]
+        agent = create_agent(
+            name=_unique(f"e2e-allow-{runtime}"),
+            model=RUNTIME_MODELS[runtime],
+            runtime=runtime,
+            tools=_allow_only(tool),
+        )
+        session = create_session(
+            agent_id=agent["id"], prompt=PROMPTS[tool], timeout=120,
+        )
+        final, events = api.run_session(session["id"])
+        assert final["status"] == "completed", (
+            f"Session failed: status={final['status']}, "
+            f"exit_code={final.get('exit_code')}\n"
+            f"Output: {stream_all_output(events)[:500]}"
+        )
+        assert _tool_was_invoked(events, runtime, tool), (
+            f"Expected '{tool}' ({RUNTIME_TOOL_NAMES[runtime][tool]}) to be "
+            f"invoked.\nOutput: {stream_all_output(events)[:500]}"
+        )
+
+    def test_deny_tool_not_invoked(
+        self, api: FairyClient, create_agent, create_session, runtime,
+    ):
+        tool = REPRESENTATIVE_TOOL[runtime]
+        agent = create_agent(
+            name=_unique(f"e2e-deny-{runtime}"),
+            model=RUNTIME_MODELS[runtime],
+            runtime=runtime,
+            tools=_deny(tool),
+        )
+        session = create_session(
+            agent_id=agent["id"], prompt=PROMPTS[tool], timeout=120,
+        )
+        _final, events = api.run_session(session["id"])
+        assert not _tool_was_invoked(events, runtime, tool), (
+            f"Tool '{tool}' was invoked despite being disabled.\n"
+            f"Output: {stream_all_output(events)[:500]}"
+        )
+
+    def test_deny_all_blocks_everything(
+        self, api: FairyClient, create_agent, create_session, runtime,
+    ):
+        agent = create_agent(
+            name=_unique(f"e2e-denyall-{runtime}"),
+            model=RUNTIME_MODELS[runtime],
+            runtime=runtime,
+            tools=_deny_all(),
+        )
+        session = create_session(
+            agent_id=agent["id"],
+            prompt="Run `echo hello`, read /etc/hostname, and list /tmp files.",
+            timeout=120,
+        )
+        _final, events = api.run_session(session["id"])
+        assert not _any_tool_was_invoked(events, runtime), (
+            f"Tool was invoked despite deny-all on {runtime}.\n"
+            f"Output: {stream_all_output(events)[:500]}"
+        )
+
+
+class TestClaudeOAuthSmoke:
+    """Prove the claude-oauth path receives the same tool flags as claude."""
+
+    def test_oauth_agent_respects_deny(
+        self, api: FairyClient, create_agent, create_session, e2e_runtimes,
+    ):
+        if "claude-oauth" not in e2e_runtimes:
+            pytest.skip("claude-oauth not in E2E_RUNTIMES")
+        agent = create_agent(
+            name=_unique("e2e-oauth-smoke"),
+            model=RUNTIME_MODELS["claude-oauth"],
+            runtime="claude-oauth",
+            tools=_deny("web_fetch"),
+        )
+        session = create_session(
+            agent_id=agent["id"], prompt=PROMPTS["web_fetch"], timeout=120,
+        )
+        _final, events = api.run_session(session["id"])
+        assert not _tool_was_invoked(events, "claude-oauth", "web_fetch"), (
+            f"web_fetch ran despite deny on claude-oauth.\n"
+            f"Output: {stream_all_output(events)[:500]}"
+        )
+
+
+class TestMultiTurnPersistence:
+    """Restrictions must re-apply on POST /sessions/{id}/prompt.
+
+    Claude --continue does not persist CLI flags; Fairy rebuilds the wrapper
+    script per call. This test proves the continue path re-emits flags.
+    """
+
+    def test_deny_persists_across_turns(
+        self, api: FairyClient, create_agent, create_session, e2e_runtimes,
+    ):
+        if "claude" not in e2e_runtimes:
+            pytest.skip("claude not in E2E_RUNTIMES")
+        agent = create_agent(
+            name=_unique("e2e-multi-turn"),
+            model=RUNTIME_MODELS["claude"],
+            runtime="claude",
+            tools=_deny("web_fetch"),
+        )
+        session = create_session(
+            agent_id=agent["id"], prompt="Say hello.", timeout=60,
+        )
+        api.run_session(session["id"])
+
+        resp = api.send_prompt(
+            session["id"], prompt=PROMPTS["web_fetch"], timeout=120,
+        )
+        assert resp.status_code == 202
+        _final, events = api.run_session(session["id"])
+        assert not _tool_was_invoked(events, "claude", "web_fetch"), (
+            "web_fetch ran on turn 2 — restrictions did not persist."
+        )

--- a/tests/test_tools_mcp.py
+++ b/tests/test_tools_mcp.py
@@ -1,5 +1,4 @@
 import json
-import uuid
 
 import pytest
 from django.contrib.auth.models import User
@@ -7,7 +6,7 @@ from django.test import Client
 
 from fairy.models import Agent, AgentVersion, APIKey, UserRuntimeKey
 from fairy.runtimes import RUNTIMES
-from fairy.sprites_exec import McpServerSpec, build_wrapper_script
+from fairy.sprites_exec import McpServerSpec, _build_tool_flags, build_wrapper_script
 
 
 # --- Fixtures ---
@@ -201,7 +200,7 @@ class TestCreateAgentWithTools:
         assert len(data["mcp_servers"]) == 1
         assert data["mcp_servers"][0]["name"] == "github"
 
-    def test_create_with_custom_tool(self, client: Client, auth_headers):
+    def test_custom_tool_type_rejected(self, client: Client, auth_headers):
         resp = client.post(
             "/agents",
             data=json.dumps({
@@ -224,9 +223,8 @@ class TestCreateAgentWithTools:
             content_type="application/json",
             **auth_headers,
         )
-        assert resp.status_code == 201
-        data = resp.json()
-        assert data["tools"][0]["name"] == "get_weather"
+        assert resp.status_code == 422
+        assert "unknown type" in str(resp.json()["detail"]).lower()
 
     def test_create_without_tools_defaults_empty(self, client: Client, auth_headers):
         resp = client.post(
@@ -276,21 +274,6 @@ class TestAgentToolsValidation:
         )
         assert resp.status_code == 422
         assert "type" in str(resp.json()["detail"]).lower()
-
-    def test_custom_tool_missing_fields(self, client: Client, auth_headers):
-        resp = client.post(
-            "/agents",
-            data=json.dumps({
-                "name": "Bad",
-                "model": "claude-sonnet-4-6",
-                "runtime": "claude",
-                "tools": [{"type": "custom", "name": "foo"}],
-            }),
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert resp.status_code == 422
-        assert "description" in str(resp.json()["detail"]).lower()
 
     def test_mcp_toolset_missing_server_name(self, client: Client, auth_headers):
         resp = client.post(
@@ -540,3 +523,164 @@ class TestSessionMcpIntegration:
         written_script = mock_fs.write_text.call_args[0][0]
         assert "Authorization" in written_script
         assert "Bearer ${SECRET}" in written_script
+
+
+# --- Wrapper script tool-enforcement wiring (Phase 1 — scaffolding only) ---
+
+
+class TestWrapperScriptToolPlumbing:
+    @pytest.mark.parametrize("runtime_name", ["claude", "claude-oauth", "codex", "gemini"])
+    def test_build_tool_flags_empty_returns_empty(self, runtime_name):
+        flags, files = _build_tool_flags(runtime_name, [], [])
+        assert flags == ""
+        assert files == {}
+
+    @pytest.mark.parametrize("runtime_name", ["claude", "claude-oauth", "codex", "gemini"])
+    def test_wrapper_script_accepts_tools_kwarg(self, runtime_name):
+        config = RUNTIMES[runtime_name]
+        tools = [{"type": "agent_toolset_20260401"}]
+        script = build_wrapper_script(config, "sk-test", "hello", tools=tools)
+        assert script.startswith("#!/bin/bash")
+
+    def test_wrapper_script_tools_default_is_none(self):
+        config = RUNTIMES["claude"]
+        script = build_wrapper_script(config, "sk-test", "hello")
+        assert "exec claude" in script
+        # No tool flags emitted when no tools passed
+        assert "--tools" not in script
+        assert "--disallowedTools" not in script
+
+    def test_wrapper_script_empty_tools_no_flags(self):
+        config = RUNTIMES["claude"]
+        script = build_wrapper_script(config, "sk-test", "hello", tools=[])
+        assert "--tools" not in script
+        assert "--disallowedTools" not in script
+
+
+# --- Phase 2: Claude tool flag translation ---
+
+
+class TestClaudeToolFlags:
+    def _flags(self, tools, mcp_refs=None):
+        from fairy.sprites_exec import _tool_flags_claude
+        return _tool_flags_claude(tools, mcp_refs or [])
+
+    def test_empty_returns_empty(self):
+        assert self._flags([]) == ""
+
+    def test_only_mcp_toolset_no_agent_toolset_returns_empty(self):
+        """mcp_toolset alone doesn't restrict built-ins; needs an agent_toolset."""
+        tools = [{"type": "mcp_toolset", "mcp_server_name": "github"}]
+        assert self._flags(tools, ["github"]) == ""
+
+    def test_default_enabled_true_no_overrides_returns_empty(self):
+        tools = [{"type": "agent_toolset_20260401", "default_config": {"enabled": True}}]
+        assert self._flags(tools) == ""
+
+    def test_default_enabled_missing_treated_as_true(self):
+        """Absent default_config defaults to enabled=True (no flags)."""
+        tools = [{"type": "agent_toolset_20260401"}]
+        assert self._flags(tools) == ""
+
+    def test_default_enabled_false_no_overrides_disables_all(self):
+        tools = [{"type": "agent_toolset_20260401", "default_config": {"enabled": False}}]
+        assert self._flags(tools) == ' --tools ""'
+
+    def test_default_enabled_false_with_allowlist(self):
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": False},
+            "configs": [
+                {"name": "bash", "enabled": True},
+                {"name": "read", "enabled": True},
+            ],
+        }]
+        # Order follows _CLAUDE_TOOL_NAMES insertion order (bash, read first)
+        assert self._flags(tools) == ' --tools "Bash,Read"'
+
+    def test_default_enabled_true_with_denylist(self):
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [
+                {"name": "web_fetch", "enabled": False},
+                {"name": "web_search", "enabled": False},
+            ],
+        }]
+        flags = self._flags(tools)
+        # Order matches configs input order
+        assert flags == ' --disallowedTools "WebFetch,WebSearch"'
+
+    @pytest.mark.parametrize("canonical,pascal", [
+        ("bash", "Bash"), ("read", "Read"), ("write", "Write"),
+        ("edit", "Edit"), ("glob", "Glob"), ("grep", "Grep"),
+        ("web_fetch", "WebFetch"), ("web_search", "WebSearch"),
+    ])
+    def test_every_canonical_name_maps_correctly(self, canonical, pascal):
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [{"name": canonical, "enabled": False}],
+        }]
+        assert self._flags(tools) == f' --disallowedTools "{pascal}"'
+
+    def test_mcp_toolset_included_in_allowlist(self):
+        tools = [
+            {"type": "agent_toolset_20260401", "default_config": {"enabled": False}},
+            {"type": "mcp_toolset", "mcp_server_name": "slack"},
+        ]
+        assert self._flags(tools, ["slack"]) == ' --tools "mcp__slack"'
+
+    def test_mcp_toolset_combined_with_built_in_allowlist(self):
+        tools = [
+            {
+                "type": "agent_toolset_20260401",
+                "default_config": {"enabled": False},
+                "configs": [{"name": "read", "enabled": True}],
+            },
+            {"type": "mcp_toolset", "mcp_server_name": "github"},
+        ]
+        assert self._flags(tools, ["github"]) == ' --tools "Read,mcp__github"'
+
+    def test_unknown_tool_name_in_configs_is_ignored(self):
+        """If user passes a name not in the canonical map, skip it."""
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [{"name": "not_a_real_tool", "enabled": False}],
+        }]
+        assert self._flags(tools) == ""
+
+    def test_wrapper_script_claude_includes_tool_flags(self):
+        config = RUNTIMES["claude"]
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [{"name": "web_fetch", "enabled": False}],
+        }]
+        script = build_wrapper_script(config, "key", "prompt", tools=tools)
+        assert '--disallowedTools "WebFetch"' in script
+
+    def test_wrapper_script_claude_oauth_includes_tool_flags(self):
+        config = RUNTIMES["claude-oauth"]
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": False},
+        }]
+        script = build_wrapper_script(config, "key", "prompt", tools=tools)
+        assert '--tools ""' in script
+
+    def test_claude_continue_session_includes_tool_flags(self):
+        """Restrictions don't persist on --continue — must re-emit flags."""
+        config = RUNTIMES["claude"]
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [{"name": "bash", "enabled": False}],
+        }]
+        script = build_wrapper_script(
+            config, "key", "prompt", continue_session=True, tools=tools
+        )
+        assert '--disallowedTools "Bash"' in script
+        assert "--continue" in script
+

--- a/thoughts/plans/2026-04-16-agent-tool-enforcement.md
+++ b/thoughts/plans/2026-04-16-agent-tool-enforcement.md
@@ -1,0 +1,1163 @@
+# Agent Tool Enforcement Implementation Plan
+
+## Overview
+
+Wire Fairy's `Agent.tools` field through to the coding-agent runtime CLIs so that tools declared as disabled in the Managed-Agents spec are actually not invocable by the running agent. Add a focused e2e test suite that proves the translation works end-to-end.
+
+Today, `Agent.tools` is stored, validated, and returned in API responses but never passed to `claude` / `codex` / `gemini` invocations — `sprites_exec.py` only wires `mcp_servers`. This plan closes that gap per-runtime and adds a tight e2e matrix to keep it closed.
+
+## Research Summary
+
+Research conducted by agent team with 4 specialist tracks — full document at `thoughts/research/2026-04-16-agent-tool-enforcement-e2e.md`.
+
+- **Claude CLI**: clean flags — `--tools "Bash,Read"` (allowlist) / `--disallowedTools "WebFetch"` (denylist), PascalCase names, no structured denial event. `--continue` does not persist restrictions.
+- **Codex CLI**: coarse-grained only — `sandbox_mode` + per-MCP `enabled_tools`. Six of eight canonical tools have no per-tool enforcement; `web_search` is the only one with a dedicated on/off.
+- **Gemini CLI**: no usable CLI flag — must write `~/.gemini/policies/*.toml` Policy Engine rules. `write` maps to two tools (`write_file` + `replace`). `--resume` re-reads files on every invocation.
+- **Synthesis**: `Agent.tools` touches `sprites_exec.py:259` (`build_wrapper_script`), `views.py:225` (`create_session`), and the `send_prompt` continue path. Existing `_build_mcp_*` heredoc pattern is the template for the new `_tool_files_*` writers.
+
+### Key Discoveries
+
+- Tool-denial events are **universally absent** as structured stream types — assertion must check tool *absence*, never a denial event (`thoughts/research/2026-04-16-agent-tool-enforcement-e2e.md`).
+- Claude name casing translation is non-trivial: `bash → Bash`, `web_fetch → WebFetch`, etc. (`src/fairy/runtimes.py:5`).
+- Codex has no `web_fetch` equivalent at all and no per-tool disable for bash/read/write/edit/glob/grep. Six hard gaps. (`thoughts/research/2026-04-16-agent-tool-enforcement-e2e.md`, Track 2).
+- Gemini Policy Engine workspace-level policies are broken (upstream issue #18186) — must write to `~/.gemini/policies/` user-level.
+- Existing `_build_mcp_claude` / `_build_mcp_codex` / `_build_mcp_gemini` functions in `src/fairy/sprites_exec.py:120-206` are the pattern to follow for the new `_tool_files_*` functions.
+- `Agent.tools` is already validated in `src/fairy/views.py:468`; `VALID_TOOL_TYPES = {"agent_toolset_20260401", "mcp_toolset", "custom"}`. We'll remove `"custom"` as part of Phase 1.
+- Existing e2e suite at `tests/e2e/test_sessions.py:21-47` has the class-scoped `runtime` fixture pattern to reuse.
+- `RUNTIME_MODELS` in `tests/e2e/conftest.py:20-27` pins cheapest models — `claude-haiku-4-5`, `o4-mini`, `gemini-2.5-flash`, `claude-haiku-4-5` (for oauth).
+
+## Current State Analysis
+
+`Agent.tools` is stored, returned to clients, and carried through versioning — but not through execution. Specifically:
+
+- `src/fairy/models.py:222` defines `tools = models.JSONField(default=list, blank=True)`
+- `src/fairy/views.py:461` includes `tools` in `AGENT_VERSIONED_FIELDS`
+- `src/fairy/views.py:468-485` validates tool-list shape (`_validate_tools`)
+- `src/fairy/views.py:225` calls `build_wrapper_script(...)` with `mcp_servers=` but NOT `tools=`
+- `src/fairy/sprites_exec.py:259-293` (`build_wrapper_script`) has no `tools` parameter
+
+A user can create an agent with `tools: [{type: "agent_toolset_20260401", default_config: {enabled: false}}]` and Fairy will happily give them a session where every built-in tool is available. That's the gap.
+
+## Desired End State
+
+- Creating a session from an agent with `tools` configured produces a wrapper script that actually constrains the runtime.
+- For claude/claude-oauth: restrictions translate to `--tools` / `--disallowedTools` flags on both initial and continue invocations.
+- For gemini: restrictions translate to a `~/.gemini/policies/fairy.toml` file written alongside the existing settings.json.
+- For codex: restrictions translate to `sandbox_mode` / `web_search` / per-MCP keys in `~/.codex/config.toml`. Per-tool gaps for bash/read/write/edit/glob/grep/web_fetch are accepted silently and documented.
+- The `custom` tool type is removed from `VALID_TOOL_TYPES`. New creates with `{type: "custom"}` return 422.
+- E2E test `tests/e2e/test_agent_tools.py` runs ~11 sessions per full run and proves each runtime actually enforces (and denies) one representative tool plus deny-all.
+- Unit tests in `tests/test_sprites_exec.py` exhaustively cover the snake→PascalCase mapping, TOML generation, and codex config generation — at no per-test dollar cost.
+- `README.md` includes a per-runtime tool-enforcement capability table so users can see which tools are actually enforceable on each runtime.
+
+### Verification
+- `make test` passes (new unit tests green).
+- `make test-e2e-tools E2E_RUNTIMES=claude` passes against a running Fairy — all 4 claude-path tests green.
+- `make test-e2e-tools` with all runtimes runs ~11 sessions, completes under $0.15, all asserted behaviors enforced.
+- `make lint` + `make test-e2e-fast` continue to pass unchanged.
+
+## What We're NOT Doing
+
+- **Custom tools**: removing `{type: "custom"}` from the validator. Not adding any schema injection or per-runtime custom-tool translation.
+- **Validator 422s for unenforceable configs**: a codex agent with `web_fetch: enabled` in its tools spec is accepted silently. Documented capability gap, not an error.
+- **Exhaustive per-tool e2e matrix**: the 4 runtimes × 8 tools × 2 polarity = 64-session matrix is explicitly out. Unit tests exhaust the translation surface; e2e tests prove the integration claim with one representative tool per runtime.
+- **MCP tool enforcement e2e**: `TestMcpToolset` remains `@skip` pending a live MCP test server (separate future work).
+- **Partial enforcement for gemini's `read_many_files` / `list_directory`**: the `read` canonical name maps only to `read_file`. Users who need the other read-adjacent tools restricted need to use MCP-level or shell-level policies separately.
+
+## Implementation Approach
+
+Five phases, strictly sequential through Phase 4 (they all touch `sprites_exec.py`), then Phases 5 and 6 can overlap. Unit tests land alongside each runtime phase to keep the translation-layer changes grounded. E2E tests land only once all runtime paths are wired — they're the integration check, not the per-unit check.
+
+## File Ownership Map
+
+| Phase | Files | Owner Track | Change Type |
+|-------|-------|-------------|-------------|
+| 1 | `src/fairy/sprites_exec.py` | backend | modify — add `_build_tool_flags()` skeleton |
+| 1 | `src/fairy/views.py` | backend | modify — pass `tools` into `build_wrapper_script`; remove `"custom"` |
+| 1 | `tests/test_sprites_exec.py` | backend | create — scaffolding tests |
+| 2 | `src/fairy/sprites_exec.py` | backend | modify — claude implementation |
+| 2 | `tests/test_sprites_exec.py` | backend | modify — claude unit tests |
+| 3 | `src/fairy/sprites_exec.py` | backend | modify — gemini implementation |
+| 3 | `tests/test_sprites_exec.py` | backend | modify — gemini unit tests |
+| 4 | `src/fairy/sprites_exec.py` | backend | modify — codex implementation |
+| 4 | `tests/test_sprites_exec.py` | backend | modify — codex unit tests |
+| 5 | `tests/e2e/test_agent_tools.py` | tests | create |
+| 6 | `pyproject.toml` | meta | modify — register `tool_matrix` marker |
+| 6 | `Makefile` | meta | modify — add `test-e2e-tools` target |
+| 6 | `README.md` | meta | modify — capability table |
+
+**Conflict-free guarantee**: Phases 2–4 each modify `sprites_exec.py` and are strictly sequential. Phases 5 and 6 touch disjoint files and may run in parallel after Phase 4 merges.
+
+---
+
+## Phase 1: Wiring foundation + custom-tools descope
+
+### Overview
+
+Introduce `_build_tool_flags(runtime, tools) -> (cli_flags, files)` as a pure dispatcher that returns empty for every runtime. Thread it through `build_wrapper_script` and the two call sites in `views.py`. Also remove `"custom"` from `VALID_TOOL_TYPES`. At the end of Phase 1, `agent.tools` flows end-to-end but has no behavioral effect — only plumbing. This keeps the diff small and lets every subsequent runtime phase land independently.
+
+### Changes Required
+
+#### 1. `src/fairy/sprites_exec.py` — add dispatcher skeleton
+
+Add the new function with a per-runtime switch that returns empty for all runtimes:
+
+```python
+def _build_tool_flags(
+    runtime_name: str,
+    tools: list[dict],
+    mcp_server_names: list[str],
+) -> tuple[str, dict[str, str]]:
+    """
+    Translate Agent.tools into runtime-specific enforcement.
+
+    Returns (cli_flags, files):
+      cli_flags: extra flags appended to the exec line (claude only, for now)
+      files: {absolute_path: content} heredoc'd into the wrapper script
+    """
+    if not tools:
+        return "", {}
+    if runtime_name in ("claude", "claude-oauth"):
+        return _tool_flags_claude(tools, mcp_server_names), {}
+    if runtime_name == "codex":
+        return "", _tool_files_codex(tools)
+    if runtime_name == "gemini":
+        return "", _tool_files_gemini(tools)
+    return "", {}
+
+
+def _tool_flags_claude(tools: list[dict], mcp_server_names: list[str]) -> str:
+    """Phase 2 — returns empty for now."""
+    return ""
+
+
+def _tool_files_codex(tools: list[dict]) -> dict[str, str]:
+    """Phase 4 — returns empty for now."""
+    return {}
+
+
+def _tool_files_gemini(tools: list[dict]) -> dict[str, str]:
+    """Phase 3 — returns empty for now."""
+    return {}
+```
+
+Extend `build_wrapper_script` to accept `tools` and emit the returned files + flags:
+
+```python
+def build_wrapper_script(
+    config: RuntimeConfig,
+    api_key: str,
+    prompt: str,
+    *,
+    continue_session: bool = False,
+    repos: list[RepoSpec] | None = None,
+    environment: EnvironmentSetup | None = None,
+    mcp_servers: list[McpServerSpec] | None = None,
+    tools: list[dict] | None = None,
+) -> str:
+    cmd = config.continue_cmd if continue_session else config.cmd
+    mcp_section = _build_mcp_section(config.name, mcp_servers or [])
+    mcp_flags = _mcp_cmd_flags(config.name, mcp_servers or [])
+
+    mcp_names = [s.name for s in (mcp_servers or [])]
+    tool_flags, tool_files = _build_tool_flags(config.name, tools or [], mcp_names)
+    tool_files_section = _format_tool_files_heredoc(tool_files)
+
+    env_script = build_environment_script(environment=environment, repos=repos)
+    header = "#!/bin/bash\nset -euo pipefail\n"
+    body = env_script[len(header):]
+    agent_exports = (
+        f"export {config.env_var}={shlex.quote(api_key)}\n"
+        f"export PROMPT={shlex.quote(prompt)}\n"
+    )
+    return f"""{header}{agent_exports}{body}
+{mcp_section}
+{tool_files_section}
+
+exec {cmd}{mcp_flags}{tool_flags}
+"""
+```
+
+Add `_format_tool_files_heredoc(files)` helper that renders each `path: content` as a `mkdir -p $(dirname); cat > $path << 'EOF' ... EOF` block.
+
+#### 2. `src/fairy/views.py` — remove `"custom"`, pass `tools` through
+
+At `views.py:464`:
+
+```python
+VALID_TOOL_TYPES = {"agent_toolset_20260401", "mcp_toolset"}
+```
+
+Delete the `custom`-specific validation branch at `views.py:479-482`.
+
+At the two `build_wrapper_script(...)` call sites (line ~225 in `create_session`, and the equivalent in `send_prompt`), add `tools=agent_obj.tools`:
+
+```python
+script = build_wrapper_script(
+    config, api_key, effective_prompt,
+    repos=repo_specs,
+    environment=env_setup,
+    mcp_servers=mcp_specs,
+    tools=agent_obj.tools,
+)
+```
+
+For the `continue_session=True` path in `send_prompt`, ensure the same `tools=` kwarg is passed — restrictions do not persist on `--continue` in claude and need to be re-emitted.
+
+#### 3. `tests/test_sprites_exec.py` — create file, add scaffolding tests
+
+```python
+import pytest
+from fairy.sprites_exec import (
+    build_wrapper_script,
+    _build_tool_flags,
+)
+from fairy.runtimes import RUNTIMES
+
+
+def test_build_tool_flags_empty_tools_returns_empty():
+    flags, files = _build_tool_flags("claude", [], [])
+    assert flags == ""
+    assert files == {}
+
+
+@pytest.mark.parametrize("runtime", ["claude", "claude-oauth", "codex", "gemini"])
+def test_wrapper_script_accepts_tools_kwarg(runtime):
+    """Smoke: passing tools= does not break wrapper generation."""
+    config = RUNTIMES[runtime]
+    script = build_wrapper_script(config, "fake-key", "hello", tools=[])
+    assert script.startswith("#!/bin/bash")
+
+
+def test_wrapper_script_tools_default_is_none():
+    """Omitting tools= still works."""
+    config = RUNTIMES["claude"]
+    script = build_wrapper_script(config, "fake-key", "hello")
+    assert "exec claude" in script
+```
+
+#### 4. Update existing view-level tests
+
+`tests/test_agents.py` may have tests that create agents with `{type: "custom"}` — update those to use `agent_toolset_20260401` or delete the custom-specific tests. Grep first: `rg 'type.*custom' tests/`.
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `make lint` passes
+- [ ] `make test` passes (all existing + new scaffolding tests)
+- [ ] `rg 'custom' src/fairy/views.py` returns no tool-type references
+- [ ] `rg '"custom"' tests/` shows all custom-type test cases updated or removed
+
+#### Manual Verification
+- [ ] Creating an agent with `tools: [{"type": "custom", "name": "x"}]` returns 422 with message referring to allowed types
+- [ ] Creating an agent with `tools: [{"type": "agent_toolset_20260401"}]` still succeeds and a session can be spawned (behavior unchanged — just plumbed through)
+
+**Gate**: Pause before Phase 2. Confirm on a running Fairy that the existing e2e suite (`make test-e2e`) still passes.
+
+---
+
+## Phase 2: Claude runtime translation
+
+### Overview
+
+Implement `_tool_flags_claude(tools, mcp_server_names)`. Emits `--tools "Bash,Read"` for the default-off-allowlist case and `--disallowedTools "WebFetch,WebSearch"` for the default-on-denylist case. Handles the snake→PascalCase mapping and MCP tool references. Applies to both initial and `--continue` invocations automatically (wrapper script is rebuilt per call).
+
+### Changes Required
+
+#### 1. `src/fairy/sprites_exec.py` — claude translator
+
+Add a constant mapping table and the translator:
+
+```python
+_CLAUDE_TOOL_NAMES: dict[str, str] = {
+    "bash": "Bash",
+    "read": "Read",
+    "write": "Write",
+    "edit": "Edit",
+    "glob": "Glob",
+    "grep": "Grep",
+    "web_fetch": "WebFetch",
+    "web_search": "WebSearch",
+}
+
+
+def _tool_flags_claude(tools: list[dict], mcp_server_names: list[str]) -> str:
+    """
+    Translate Managed-Agents spec → claude CLI flags.
+
+    default_config.enabled=False + no configs  → --tools ""
+    default_config.enabled=False + some enabled → --tools "Bash,Read"
+    default_config.enabled=True  + some disabled → --disallowedTools "WebFetch"
+    default_config.enabled=True  + no configs   → no flag (all tools default)
+    mcp_toolset entries add mcp__<server>__* to the relevant list.
+    """
+    toolset = _find_agent_toolset(tools)
+    default_enabled = toolset.get("default_config", {}).get("enabled", True) if toolset else True
+    configs = {c["name"]: c.get("enabled", True) for c in (toolset or {}).get("configs", [])}
+
+    mcp_refs = [t["mcp_server_name"] for t in tools if t.get("type") == "mcp_toolset"]
+
+    if not default_enabled:
+        enabled_tools = [
+            _CLAUDE_TOOL_NAMES[name]
+            for name in _CLAUDE_TOOL_NAMES
+            if configs.get(name, False)
+        ]
+        enabled_tools += [f"mcp__{name}" for name in mcp_refs]
+        return f' --tools "{",".join(enabled_tools)}"'
+
+    disabled_tools = [
+        _CLAUDE_TOOL_NAMES[name]
+        for name, enabled in configs.items()
+        if name in _CLAUDE_TOOL_NAMES and not enabled
+    ]
+    if not disabled_tools:
+        return ""
+    return f' --disallowedTools "{",".join(disabled_tools)}"'
+
+
+def _find_agent_toolset(tools: list[dict]) -> dict | None:
+    for t in tools:
+        if t.get("type") == "agent_toolset_20260401":
+            return t
+    return None
+```
+
+#### 2. `tests/test_sprites_exec.py` — exhaustive claude unit tests
+
+```python
+import pytest
+from fairy.sprites_exec import _tool_flags_claude
+
+
+class TestClaudeToolFlags:
+    def test_empty_tools_returns_empty(self):
+        assert _tool_flags_claude([], []) == ""
+
+    def test_no_toolset_entry_returns_empty(self):
+        # Only mcp_toolset, no agent_toolset → no flags needed
+        assert _tool_flags_claude([{"type": "mcp_toolset", "mcp_server_name": "x"}], ["x"]) == ""
+
+    def test_default_enabled_true_no_overrides_returns_empty(self):
+        tools = [{"type": "agent_toolset_20260401", "default_config": {"enabled": True}}]
+        assert _tool_flags_claude(tools, []) == ""
+
+    def test_default_enabled_false_no_overrides_disables_all(self):
+        tools = [{"type": "agent_toolset_20260401", "default_config": {"enabled": False}}]
+        assert _tool_flags_claude(tools, []) == ' --tools ""'
+
+    def test_default_enabled_false_with_allowlist(self):
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": False},
+            "configs": [
+                {"name": "bash", "enabled": True},
+                {"name": "read", "enabled": True},
+            ],
+        }]
+        flags = _tool_flags_claude(tools, [])
+        # Order is deterministic: follows _CLAUDE_TOOL_NAMES insertion order
+        assert flags == ' --tools "Bash,Read"'
+
+    def test_default_enabled_true_with_denylist(self):
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [
+                {"name": "web_fetch", "enabled": False},
+                {"name": "web_search", "enabled": False},
+            ],
+        }]
+        flags = _tool_flags_claude(tools, [])
+        assert flags == ' --disallowedTools "WebFetch,WebSearch"'
+
+    @pytest.mark.parametrize("canonical,pascal", [
+        ("bash", "Bash"), ("read", "Read"), ("write", "Write"),
+        ("edit", "Edit"), ("glob", "Glob"), ("grep", "Grep"),
+        ("web_fetch", "WebFetch"), ("web_search", "WebSearch"),
+    ])
+    def test_every_canonical_name_maps_correctly(self, canonical, pascal):
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [{"name": canonical, "enabled": False}],
+        }]
+        assert _tool_flags_claude(tools, []) == f' --disallowedTools "{pascal}"'
+
+    def test_mcp_toolset_included_in_allowlist(self):
+        tools = [
+            {"type": "agent_toolset_20260401", "default_config": {"enabled": False}},
+            {"type": "mcp_toolset", "mcp_server_name": "slack"},
+        ]
+        flags = _tool_flags_claude(tools, ["slack"])
+        assert flags == ' --tools "mcp__slack"'
+```
+
+#### 3. Integration test in wrapper-script generation
+
+```python
+def test_wrapper_script_claude_includes_tool_flags():
+    config = RUNTIMES["claude"]
+    tools = [{
+        "type": "agent_toolset_20260401",
+        "default_config": {"enabled": True},
+        "configs": [{"name": "web_fetch", "enabled": False}],
+    }]
+    script = build_wrapper_script(config, "key", "prompt", tools=tools)
+    assert '--disallowedTools "WebFetch"' in script
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `make test` passes, including all new `TestClaudeToolFlags` cases
+- [ ] `rg '_CLAUDE_TOOL_NAMES' src/fairy/` shows exactly one definition
+- [ ] `rg '\-\-tools ' src/fairy/` shows the flag is emitted from `_tool_flags_claude` only
+
+#### Manual Verification
+- [ ] On a running Fairy, create an agent with `tools: [{type: "agent_toolset_20260401", default_config: {enabled: false}}]`; spawn a session asking it to read a file; session completes without the model using `Read` (inspect the stream)
+
+**Gate**: Human sanity-check that the Claude invocation actually gets the flag. `grep -o 'claude .*' run-agent.sh` inside a Sprite should show the emitted `--tools` / `--disallowedTools`.
+
+---
+
+## Phase 3: Gemini runtime translation
+
+### Overview
+
+Implement `_tool_files_gemini(tools)`. Returns a dict like `{"/root/.gemini/policies/fairy.toml": "<toml content>"}`. Handles the `write` → `write_file` + `replace` duplication and `read` → `read_file` mapping. The wrapper script's heredoc writer (added in Phase 1) will `mkdir -p ~/.gemini/policies` and write the file before `gemini` exec.
+
+### Changes Required
+
+#### 1. `src/fairy/sprites_exec.py` — gemini translator
+
+```python
+_GEMINI_TOOL_NAMES: dict[str, list[str]] = {
+    "bash": ["run_shell_command"],
+    "read": ["read_file"],
+    "write": ["write_file", "replace"],  # write maps to TWO gemini tools
+    "edit": ["replace"],
+    "glob": ["glob"],
+    "grep": ["grep_search"],
+    "web_fetch": ["web_fetch"],
+    "web_search": ["google_web_search"],
+}
+
+GEMINI_POLICY_PATH = "/home/sprite/.gemini/policies/fairy.toml"
+
+
+def _tool_files_gemini(tools: list[dict]) -> dict[str, str]:
+    toolset = _find_agent_toolset(tools)
+    if toolset is None:
+        return {}
+    default_enabled = toolset.get("default_config", {}).get("enabled", True)
+    configs = {c["name"]: c.get("enabled", True) for c in toolset.get("configs", [])}
+
+    rules: list[str] = []
+
+    if not default_enabled:
+        # Deny-all, then allow explicitly enabled
+        rules.append('[[rule]]\ntoolName = "*"\ndecision = "deny"\npriority = 1\ninteractive = false')
+        allowed_gemini_names: list[str] = []
+        for canonical, enabled in configs.items():
+            if enabled and canonical in _GEMINI_TOOL_NAMES:
+                allowed_gemini_names.extend(_GEMINI_TOOL_NAMES[canonical])
+        if allowed_gemini_names:
+            names_toml = ", ".join(f'"{n}"' for n in allowed_gemini_names)
+            rules.append(
+                f'[[rule]]\ntoolName = [{names_toml}]\n'
+                'decision = "allow"\npriority = 100\ninteractive = false'
+            )
+    else:
+        # Deny only explicitly disabled
+        for canonical, enabled in configs.items():
+            if enabled or canonical not in _GEMINI_TOOL_NAMES:
+                continue
+            names_toml = ", ".join(f'"{n}"' for n in _GEMINI_TOOL_NAMES[canonical])
+            rules.append(
+                f'[[rule]]\ntoolName = [{names_toml}]\n'
+                'decision = "deny"\ninteractive = false'
+            )
+
+    if not rules:
+        return {}
+    content = "\n\n".join(rules) + "\n"
+    return {GEMINI_POLICY_PATH: content}
+```
+
+Update `_format_tool_files_heredoc` (added in Phase 1) to emit:
+
+```bash
+mkdir -p /home/sprite/.gemini/policies
+cat > /home/sprite/.gemini/policies/fairy.toml << 'TOOLFILE_EOF'
+<content>
+TOOLFILE_EOF
+```
+
+#### 2. `tests/test_sprites_exec.py` — gemini unit tests
+
+```python
+class TestGeminiToolFiles:
+    def test_no_toolset_returns_empty(self):
+        from fairy.sprites_exec import _tool_files_gemini
+        assert _tool_files_gemini([]) == {}
+
+    def test_default_enabled_no_overrides_returns_empty(self):
+        from fairy.sprites_exec import _tool_files_gemini
+        tools = [{"type": "agent_toolset_20260401", "default_config": {"enabled": True}}]
+        assert _tool_files_gemini(tools) == {}
+
+    def test_write_disabled_denies_both_gemini_tools(self):
+        """Managed-Agents 'write' must deny both write_file AND replace."""
+        from fairy.sprites_exec import _tool_files_gemini, GEMINI_POLICY_PATH
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [{"name": "write", "enabled": False}],
+        }]
+        files = _tool_files_gemini(tools)
+        content = files[GEMINI_POLICY_PATH]
+        assert '"write_file"' in content
+        assert '"replace"' in content
+        assert 'decision = "deny"' in content
+
+    def test_default_enabled_false_emits_deny_all_rule(self):
+        from fairy.sprites_exec import _tool_files_gemini, GEMINI_POLICY_PATH
+        tools = [{"type": "agent_toolset_20260401", "default_config": {"enabled": False}}]
+        content = _tool_files_gemini(tools)[GEMINI_POLICY_PATH]
+        assert 'toolName = "*"' in content
+        assert 'decision = "deny"' in content
+
+    def test_default_off_with_allowlist(self):
+        from fairy.sprites_exec import _tool_files_gemini, GEMINI_POLICY_PATH
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": False},
+            "configs": [{"name": "bash", "enabled": True}],
+        }]
+        content = _tool_files_gemini(tools)[GEMINI_POLICY_PATH]
+        assert 'toolName = "*"' in content  # deny-all
+        assert '"run_shell_command"' in content  # allow bash
+        assert content.count("decision = \"deny\"") == 1
+        assert content.count("decision = \"allow\"") == 1
+
+    def test_interactive_false_set_on_every_rule(self):
+        """Fairy runs headless — rules must be scoped to headless mode."""
+        from fairy.sprites_exec import _tool_files_gemini, GEMINI_POLICY_PATH
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [{"name": "bash", "enabled": False}],
+        }]
+        content = _tool_files_gemini(tools)[GEMINI_POLICY_PATH]
+        assert "interactive = false" in content
+```
+
+#### 3. Integration test
+
+```python
+def test_wrapper_script_gemini_writes_policy_file():
+    config = RUNTIMES["gemini"]
+    tools = [{
+        "type": "agent_toolset_20260401",
+        "default_config": {"enabled": True},
+        "configs": [{"name": "bash", "enabled": False}],
+    }]
+    script = build_wrapper_script(config, "key", "prompt", tools=tools)
+    assert "/home/sprite/.gemini/policies/fairy.toml" in script
+    assert 'toolName = ["run_shell_command"]' in script
+    assert "TOOLFILE_EOF" in script  # heredoc wrapper
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `make test` passes, including all new `TestGeminiToolFiles` cases
+- [ ] `rg 'fairy.toml' src/` shows exactly one path definition
+- [ ] Integration test proving the heredoc wraps correctly
+
+#### Manual Verification
+- [ ] On a running Fairy, create a gemini agent with `tools: [{type: "agent_toolset_20260401", default_config: {enabled: true}, configs: [{name: "bash", enabled: false}]}]`; spawn a session asking it to run a shell command; session completes and the bash call is either absent from stream or appears as a `tool_result` with `error.message` containing "denied by policy"
+
+**Gate**: Confirm the TOML file actually lands on the Sprite — spawn a session, snapshot the wrapper script, verify the heredoc + mkdir emitted correctly.
+
+---
+
+## Phase 4: Codex runtime translation
+
+### Overview
+
+Implement `_tool_files_codex(tools)`. Extends the existing `~/.codex/config.toml` emission (currently only `[mcp_servers.*]` sections) with top-level `sandbox_mode` and `web_search` keys, plus per-MCP `enabled_tools` / `disabled_tools` if applicable. Six of the eight canonical tools cannot be enforced per-tool on codex — those are accepted silently and documented.
+
+### Changes Required
+
+#### 1. `src/fairy/sprites_exec.py` — codex translator
+
+Because `_build_mcp_codex` already generates the config.toml, we need to either (a) merge tool-config output into that function or (b) return a separate config-toml patch that `_format_tool_files_heredoc` concatenates. Approach (a) is cleaner — update `_build_mcp_codex` to accept `tools` and emit top-level keys before the `[mcp_servers.*]` sections.
+
+```python
+def _build_mcp_codex(
+    servers: list[McpServerSpec],
+    tools: list[dict] | None = None,
+) -> str:
+    tools = tools or []
+    toolset = _find_agent_toolset(tools)
+    default_enabled = (toolset or {}).get("default_config", {}).get("enabled", True) if toolset else True
+    configs = {c["name"]: c.get("enabled", True) for c in (toolset or {}).get("configs", [])}
+
+    lines = ["# MCP + tools configuration", "mkdir -p ~/.codex"]
+    lines.append("cat > ~/.codex/config.toml << 'CODEX_EOF'")
+
+    # Top-level codex tool enforcement keys
+    # web_search: the only per-tool enforceable canonical in codex
+    if not default_enabled and not configs.get("web_search", False):
+        lines.append('web_search = "disabled"')
+    elif default_enabled and configs.get("web_search") is False:
+        lines.append('web_search = "disabled"')
+
+    # sandbox_mode: coarse write protection — only if BOTH write and edit are disabled
+    # (edit on codex always collapses to shell, but we still respect the write signal)
+    write_disabled = (not default_enabled and not configs.get("write", False)) \
+        or (default_enabled and configs.get("write") is False)
+    edit_disabled = (not default_enabled and not configs.get("edit", False)) \
+        or (default_enabled and configs.get("edit") is False)
+    if write_disabled and edit_disabled:
+        lines.append('sandbox_mode = "read-only"')
+
+    # Existing MCP emission — unchanged
+    for s in servers:
+        lines.append(f"[mcp_servers.{s.name}]")
+        # ... (existing logic)
+        lines.append("")
+    lines.append("CODEX_EOF")
+    return "\n".join(lines)
+```
+
+Update the dispatcher `_build_mcp_section` and `_build_tool_flags` so codex's `tools` flows through `_build_mcp_codex` (rather than `_tool_files_codex`) — keeps the single config.toml source. Delete the `_tool_files_codex` stub; codex work happens in `_build_mcp_codex`.
+
+Update the single call site in `build_wrapper_script`:
+
+```python
+if config.name == "codex":
+    mcp_section = _build_mcp_codex(mcp_servers or [], tools=tools)
+else:
+    mcp_section = _build_mcp_section(config.name, mcp_servers or [])
+```
+
+#### 2. `tests/test_sprites_exec.py` — codex unit tests
+
+```python
+class TestCodexToolConfig:
+    def test_no_tools_no_mcp_returns_empty_config(self):
+        from fairy.sprites_exec import _build_mcp_codex
+        assert _build_mcp_codex([], tools=[]) == ""
+
+    def test_web_search_disabled_writes_key(self):
+        from fairy.sprites_exec import _build_mcp_codex
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [{"name": "web_search", "enabled": False}],
+        }]
+        content = _build_mcp_codex([], tools=tools)
+        assert 'web_search = "disabled"' in content
+
+    def test_write_and_edit_disabled_sets_read_only_sandbox(self):
+        from fairy.sprites_exec import _build_mcp_codex
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [
+                {"name": "write", "enabled": False},
+                {"name": "edit", "enabled": False},
+            ],
+        }]
+        content = _build_mcp_codex([], tools=tools)
+        assert 'sandbox_mode = "read-only"' in content
+
+    def test_only_write_disabled_does_not_set_sandbox(self):
+        """Sandbox mode is blunt — only flip it if both write AND edit are off."""
+        from fairy.sprites_exec import _build_mcp_codex
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [{"name": "write", "enabled": False}],
+        }]
+        content = _build_mcp_codex([], tools=tools)
+        assert "sandbox_mode" not in content
+
+    def test_default_off_no_configs_disables_web_search(self):
+        from fairy.sprites_exec import _build_mcp_codex
+        tools = [{"type": "agent_toolset_20260401", "default_config": {"enabled": False}}]
+        content = _build_mcp_codex([], tools=tools)
+        assert 'web_search = "disabled"' in content
+
+    def test_unenforceable_tools_are_silent(self):
+        """bash/read/glob/grep/web_fetch disable produces no config — accepted silently."""
+        from fairy.sprites_exec import _build_mcp_codex
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [
+                {"name": "bash", "enabled": False},
+                {"name": "read", "enabled": False},
+                {"name": "glob", "enabled": False},
+                {"name": "grep", "enabled": False},
+                {"name": "web_fetch", "enabled": False},
+            ],
+        }]
+        content = _build_mcp_codex([], tools=tools)
+        # No sandbox_mode (only write+edit triggers it), no web_search (it was default-on)
+        assert "sandbox_mode" not in content
+        assert "web_search" not in content
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `make test` passes, including all `TestCodexToolConfig` cases
+- [ ] Existing codex MCP tests still pass (the refactor of `_build_mcp_codex` shouldn't break them)
+
+#### Manual Verification
+- [ ] On a running Fairy, create a codex agent with `tools: [{type: "agent_toolset_20260401", default_config: {enabled: true}, configs: [{name: "web_search", enabled: false}]}]`; spawn a session asking it to search the web; session completes without invoking web_search (inspect JSONL stream — no `item.completed` with `type: "web_search"`)
+- [ ] Same test with `write` + `edit` both disabled produces a session whose sandbox is read-only (model attempts to write, gets error)
+
+**Gate**: Confirm Phases 2+3+4 all landed cleanly. Phase 5's test module will exercise them end-to-end.
+
+---
+
+## Phase 5: E2E test module
+
+### Overview
+
+Create `tests/e2e/test_agent_tools.py`. Small focused matrix: 3 canonical tests × 3 enforceable runtimes (claude, codex, gemini) + 1 claude-oauth smoke + 1 multi-turn persistence = **~11 real sessions per full run, ~$0.12 at cheapest models**.
+
+Pick one representative tool per runtime — unit tests already cover the full name-mapping surface, so e2e only needs to prove integration works.
+
+### Representative tool per runtime
+- `claude` + `claude-oauth` → `web_fetch` (easy prompt, clean `WebFetch` signal, disable via `--disallowedTools "WebFetch"`)
+- `codex` → `web_search` (the only per-tool enforceable codex canonical)
+- `gemini` → `bash` / `run_shell_command` (Policy Engine deny path is best-documented)
+
+### Changes Required
+
+#### 1. `tests/e2e/test_agent_tools.py` — new file
+
+```python
+"""E2E tests verifying Agent.tools field is enforced by each runtime CLI.
+
+Tight matrix — unit tests cover per-tool translation; these only prove the
+translation layer integrates end-to-end. ~11 sessions per full run.
+"""
+
+from __future__ import annotations
+
+import json
+import pytest
+
+from tests.e2e.conftest import (
+    RUNTIME_MODELS,
+    FairyClient,
+    _unique,
+    stream_all_output,
+)
+
+pytestmark = [pytest.mark.slow, pytest.mark.tool_matrix]
+
+# Representative tool per runtime — the one the matrix tests use.
+REPRESENTATIVE_TOOL = {
+    "claude": "web_fetch",
+    "claude-oauth": "web_fetch",
+    "codex": "web_search",
+    "gemini": "bash",
+}
+
+# Canonical tool name → runtime's CLI/stream name
+RUNTIME_TOOL_NAMES = {
+    "claude": {"web_fetch": "WebFetch"},
+    "claude-oauth": {"web_fetch": "WebFetch"},
+    "codex": {"web_search": "web_search"},
+    "gemini": {"bash": "run_shell_command"},
+}
+
+PROMPTS = {
+    "web_fetch": "Use your web fetch tool to fetch https://httpbin.org/get and print the response body. Do not use shell.",
+    "web_search": "Use your web search tool to search for 'current UTC date' and print the top result's title.",
+    "bash": "Run the shell command `echo TOOL_SIGNAL_BASH` using your shell tool and print the output.",
+}
+
+
+# ---------------------------------------------------------------------------
+# Stream parsers
+# ---------------------------------------------------------------------------
+
+
+def _parse_claude_tool_names(events: list[dict]) -> list[str]:
+    names: list[str] = []
+    for e in events:
+        if e.get("type") != "output":
+            continue
+        try:
+            obj = json.loads(e.get("data", ""))
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if obj.get("type") == "assistant":
+            for block in obj.get("message", {}).get("content", []):
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    name = block.get("name")
+                    if name:
+                        names.append(name)
+    return names
+
+
+def _parse_codex_tool_names(events: list[dict]) -> list[str]:
+    names: list[str] = []
+    for e in events:
+        if e.get("type") != "output":
+            continue
+        try:
+            obj = json.loads(e.get("data", ""))
+        except (json.JSONDecodeError, TypeError):
+            continue
+        # codex uses item-level types inside item.started / item.completed events
+        if obj.get("type") in ("item.started", "item.completed"):
+            item_type = obj.get("item", {}).get("type")
+            if item_type == "web_search":
+                names.append("web_search")
+            elif item_type == "command_execution":
+                names.append("shell")
+            elif item_type == "mcp_tool_call":
+                names.append(f"mcp__{obj['item'].get('server')}__{obj['item'].get('tool')}")
+    return names
+
+
+def _parse_gemini_tool_names(events: list[dict]) -> list[str]:
+    names: list[str] = []
+    for e in events:
+        if e.get("type") != "output":
+            continue
+        try:
+            obj = json.loads(e.get("data", ""))
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if obj.get("type") == "tool_use":
+            name = obj.get("tool_name")
+            if name:
+                names.append(name)
+    return names
+
+
+def _tool_was_invoked(events: list[dict], runtime: str, tool: str) -> bool:
+    target = RUNTIME_TOOL_NAMES[runtime][tool]
+    if runtime in ("claude", "claude-oauth"):
+        return target in _parse_claude_tool_names(events)
+    if runtime == "codex":
+        return target in _parse_codex_tool_names(events)
+    if runtime == "gemini":
+        return target in _parse_gemini_tool_names(events)
+    return False
+
+
+def _any_tool_was_invoked(events: list[dict], runtime: str) -> bool:
+    """Used by deny-all to check NOTHING ran."""
+    if runtime in ("claude", "claude-oauth"):
+        return bool(_parse_claude_tool_names(events))
+    if runtime == "codex":
+        # Shell-only tools that codex emits even on no-op; filter to the
+        # canonical set we control
+        return bool(_parse_codex_tool_names(events))
+    if runtime == "gemini":
+        return bool(_parse_gemini_tool_names(events))
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Toolset builders
+# ---------------------------------------------------------------------------
+
+
+def _allow_only(tool: str) -> list[dict]:
+    return [{
+        "type": "agent_toolset_20260401",
+        "default_config": {"enabled": False},
+        "configs": [{"name": tool, "enabled": True}],
+    }]
+
+
+def _deny(tool: str) -> list[dict]:
+    return [{
+        "type": "agent_toolset_20260401",
+        "default_config": {"enabled": True},
+        "configs": [{"name": tool, "enabled": False}],
+    }]
+
+
+def _deny_all() -> list[dict]:
+    return [{"type": "agent_toolset_20260401", "default_config": {"enabled": False}}]
+
+
+# ---------------------------------------------------------------------------
+# Runtime fixture — claude-oauth tested separately (smoke only)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="class", params=["claude", "codex", "gemini"])
+def runtime(request, e2e_runtimes):
+    if request.param not in e2e_runtimes:
+        pytest.skip(f"{request.param} not in E2E_RUNTIMES")
+    return request.param
+
+
+# ---------------------------------------------------------------------------
+# Matrix tests — 3 runtimes × 3 tests = 9 sessions
+# ---------------------------------------------------------------------------
+
+
+class TestToolEnforcement:
+    """Core matrix — prove each runtime's translation layer works end-to-end."""
+
+    def test_allow_tool_is_invocable(
+        self, api: FairyClient, create_agent, create_session, runtime,
+    ):
+        tool = REPRESENTATIVE_TOOL[runtime]
+        agent = create_agent(
+            name=_unique(f"e2e-allow-{runtime}"),
+            model=RUNTIME_MODELS[runtime],
+            runtime=runtime,
+            tools=_allow_only(tool),
+        )
+        session = create_session(
+            agent_id=agent["id"],
+            prompt=PROMPTS[tool],
+            timeout=120,
+        )
+        final, events = api.run_session(session["id"])
+        assert final["status"] == "completed", (
+            f"Allow test failed: status={final['status']}, "
+            f"exit_code={final.get('exit_code')}\n"
+            f"Output: {stream_all_output(events)[:500]}"
+        )
+        assert _tool_was_invoked(events, runtime, tool), (
+            f"Expected '{tool}' ({RUNTIME_TOOL_NAMES[runtime][tool]}) to be invoked.\n"
+            f"Output: {stream_all_output(events)[:500]}"
+        )
+
+    def test_deny_tool_not_invoked(
+        self, api: FairyClient, create_agent, create_session, runtime,
+    ):
+        tool = REPRESENTATIVE_TOOL[runtime]
+        agent = create_agent(
+            name=_unique(f"e2e-deny-{runtime}"),
+            model=RUNTIME_MODELS[runtime],
+            runtime=runtime,
+            tools=_deny(tool),
+        )
+        session = create_session(
+            agent_id=agent["id"],
+            prompt=PROMPTS[tool],
+            timeout=120,
+        )
+        _final, events = api.run_session(session["id"])
+        assert not _tool_was_invoked(events, runtime, tool), (
+            f"Tool '{tool}' was invoked despite being disabled.\n"
+            f"Output: {stream_all_output(events)[:500]}"
+        )
+
+    def test_deny_all_blocks_everything(
+        self, api: FairyClient, create_agent, create_session, runtime,
+    ):
+        agent = create_agent(
+            name=_unique(f"e2e-denyall-{runtime}"),
+            model=RUNTIME_MODELS[runtime],
+            runtime=runtime,
+            tools=_deny_all(),
+        )
+        session = create_session(
+            agent_id=agent["id"],
+            prompt="Run `echo hello`, read /etc/hostname, and list /tmp files.",
+            timeout=120,
+        )
+        _final, events = api.run_session(session["id"])
+        assert not _any_tool_was_invoked(events, runtime), (
+            f"Tool was invoked despite deny-all.\n"
+            f"Output: {stream_all_output(events)[:500]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Claude-oauth smoke — 1 session
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeOAuthSmoke:
+    """Prove the claude-oauth path receives the same tool flags as claude."""
+
+    def test_oauth_agent_respects_deny(
+        self, api: FairyClient, create_agent, create_session, e2e_runtimes,
+    ):
+        if "claude-oauth" not in e2e_runtimes:
+            pytest.skip("claude-oauth not in E2E_RUNTIMES")
+        agent = create_agent(
+            name=_unique("e2e-oauth-smoke"),
+            model=RUNTIME_MODELS["claude-oauth"],
+            runtime="claude-oauth",
+            tools=_deny("web_fetch"),
+        )
+        session = create_session(
+            agent_id=agent["id"],
+            prompt=PROMPTS["web_fetch"],
+            timeout=120,
+        )
+        _final, events = api.run_session(session["id"])
+        assert not _tool_was_invoked(events, "claude-oauth", "web_fetch")
+
+
+# ---------------------------------------------------------------------------
+# Multi-turn persistence — 1 session (claude only)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiTurnPersistence:
+    """Restrictions must re-apply on POST /sessions/{id}/prompt.
+
+    Claude --continue does NOT persist CLI flags; the wrapper script is rebuilt
+    per call. This test proves Fairy re-emits the flag.
+    """
+
+    def test_deny_persists_across_turns(
+        self, api: FairyClient, create_agent, create_session, e2e_runtimes,
+    ):
+        if "claude" not in e2e_runtimes:
+            pytest.skip("claude not in E2E_RUNTIMES")
+        agent = create_agent(
+            name=_unique("e2e-multi-turn"),
+            model=RUNTIME_MODELS["claude"],
+            runtime="claude",
+            tools=_deny("web_fetch"),
+        )
+        session = create_session(
+            agent_id=agent["id"],
+            prompt="Say hello.",
+            timeout=60,
+        )
+        api.run_session(session["id"])
+
+        # Second turn: ask it to fetch a URL
+        resp = api.send_prompt(
+            session["id"],
+            prompt=PROMPTS["web_fetch"],
+            timeout=120,
+        )
+        assert resp.status_code == 202
+        _final, events = api.run_session(session["id"])
+        assert not _tool_was_invoked(events, "claude", "web_fetch"), (
+            "web_fetch was invoked on turn 2 — restrictions did not persist."
+        )
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `make test-e2e-tools E2E_RUNTIMES=claude` passes — 4 tests green (3 matrix + 1 multi-turn)
+- [ ] `make test-e2e-tools E2E_RUNTIMES=claude,codex,gemini` passes — 9 tests green
+- [ ] `make test-e2e-tools E2E_RUNTIMES=claude-oauth` passes the smoke
+- [ ] `make test-e2e-fast` does NOT run `tool_matrix` tests (they're all `@slow`)
+
+#### Manual Verification
+- [ ] Total real session count for `make test-e2e-tools` with all runtimes is ≤12
+- [ ] Total cost for a full `make test-e2e-tools` run is observed under $0.20
+
+**Gate**: Phase 5 complete when the matrix runs clean against a real Fairy deployment with all 4 runtimes configured.
+
+---
+
+## Phase 6: Markers, Makefile, docs
+
+### Overview
+
+Register the `tool_matrix` pytest marker. Add a `make test-e2e-tools` target. Update `README.md` with the per-runtime enforcement capability table so users know what's enforceable on each runtime.
+
+### Changes Required
+
+#### 1. `pyproject.toml`
+
+```toml
+[tool.pytest.ini_options]
+markers = [
+    "slow: spawns real agent sessions (expensive)",
+    "tool_matrix: verifies agent tool enforcement across runtimes",
+]
+```
+
+#### 2. `Makefile`
+
+```makefile
+test-e2e-tools:
+	FAIRY_API_URL=$${FAIRY_API_URL:-http://localhost:8777} \
+	  uv run pytest tests/e2e/test_agent_tools.py -v -m "tool_matrix"
+```
+
+#### 3. `README.md` — add a "Tool enforcement per runtime" section
+
+```markdown
+## Tool enforcement per runtime
+
+Fairy's `Agent.tools` field accepts the Anthropic Managed Agents `agent_toolset_20260401`
+spec. Enforcement depends on what the underlying runtime CLI supports:
+
+| Canonical tool | claude / claude-oauth | codex | gemini |
+|---------------|-----------------------|-------|--------|
+| `bash`        | enforceable           | not enforceable (always available) | enforceable |
+| `read`        | enforceable           | not enforceable                    | enforceable |
+| `write`       | enforceable           | enforceable via read-only sandbox (only when `edit` is also disabled) | enforceable (applies to both `write_file` and `replace`) |
+| `edit`        | enforceable           | not enforceable                    | enforceable |
+| `glob`        | enforceable           | not enforceable                    | enforceable |
+| `grep`        | enforceable           | not enforceable                    | enforceable |
+| `web_fetch`   | enforceable           | no codex equivalent (no-op)        | enforceable |
+| `web_search`  | enforceable           | enforceable                        | enforceable |
+
+Configurations are accepted silently even when unenforceable on the selected runtime.
+For full behavioral guarantees, use the `claude` or `gemini` runtimes; `codex` is a
+best-effort match.
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `pytest --markers` lists both `slow` and `tool_matrix`
+- [ ] `make test-e2e-tools` exists and is runnable
+- [ ] `make lint` passes
+- [ ] `make test` passes
+
+#### Manual Verification
+- [ ] README capability table renders correctly on GitHub
+- [ ] Table matches the gap list in `thoughts/research/2026-04-16-agent-tool-enforcement-e2e.md`
+
+---
+
+## Testing Strategy
+
+### Automated
+- **Unit**: every Phase 2–4 translation has exhaustive parametrized unit tests in `tests/test_sprites_exec.py`. Zero dollar cost.
+- **Integration (wrapper generation)**: unit tests assert flags/files appear in generated wrapper scripts without spawning Sprites.
+- **E2E**: 11 real sessions per full run, opt-in via `make test-e2e-tools`. Default `make test-e2e-fast` skips them.
+
+### Manual Testing Steps
+1. Fresh Fairy dev server. Create claude agent with `tools: [{type: "agent_toolset_20260401", default_config: {enabled: false}}]`.
+2. Spawn a session asking it to read any file. Confirm session completes but the stream contains no `Read` tool_use.
+3. Repeat with gemini runtime and `bash` deny — confirm Policy Engine denial appears as `tool_result.error.message` containing "denied by policy".
+4. Repeat with codex runtime and `web_search: false` — confirm no `web_search` item in JSONL stream.
+5. Multi-turn: create a claude session, let it complete, `POST /sessions/{id}/prompt` with a prompt that needs the denied tool. Confirm the restriction still holds.
+6. Verify creating an agent with `tools: [{type: "custom", name: "x"}]` returns 422.
+
+## Performance Considerations
+
+- Wrapper-script size grows by at most one TOML file (<1KB) — negligible.
+- No extra Sprite commands or HTTP roundtrips at session start.
+- Test matrix is bounded: 11 sessions per full run, ~$0.12 at cheapest models.
+
+## References
+
+- Research: `thoughts/research/2026-04-16-agent-tool-enforcement-e2e.md`
+- Existing e2e patterns: `tests/e2e/test_sessions.py:21-47`
+- MCP wiring template: `src/fairy/sprites_exec.py:120-206` (`_build_mcp_claude`/`_codex`/`_gemini`)
+- Managed Agents spec: per user-provided docs (canonical tool list: `bash, read, write, edit, glob, grep, web_fetch, web_search`)

--- a/thoughts/research/2026-04-16-agent-tool-enforcement-e2e.md
+++ b/thoughts/research/2026-04-16-agent-tool-enforcement-e2e.md
@@ -1,0 +1,567 @@
+---
+date: 2026-04-16T17:48:00-07:00
+researcher: Claude Code (team-research skill)
+git_commit: 9ea0965e5112cea2cee4fbb1ac8d18ad2b9eb833
+branch: add-e2e-tests
+repository: ravi-hq/fairy
+topic: "E2E test suite verifying coding agents respect Agent.tools"
+tags: [research, team-research, e2e, tools, claude-cli, codex, gemini, tool-enforcement]
+status: complete
+method: agent-team
+team_size: 4
+tracks: [claude-cli, codex-cli, gemini-cli, synthesis]
+last_updated: 2026-04-16
+last_updated_by: Claude Code
+---
+
+# Research: E2E test suite verifying agent tools are respected by coding agents
+
+**Date**: 2026-04-16
+**Researcher**: Claude Code (team-research)
+**Git Commit**: [`9ea0965`](https://github.com/ravi-hq/fairy/commit/9ea0965e5112cea2cee4fbb1ac8d18ad2b9eb833)
+**Branch**: `add-e2e-tests`
+**Repository**: ravi-hq/fairy
+**Method**: Agent team (4 specialist researchers)
+
+## Research Question
+
+Build an e2e test suite that verifies agent tools are respected by the coding agents (claude, claude-oauth, codex, gemini). `Agent.tools` on Fairy is modeled on Anthropic's Managed Agents `agent_toolset_20260401` spec; each runtime needs its own translation, and tests must prove the translation actually constrains the running agent.
+
+## Summary
+
+Fairy stores and validates `Agent.tools` (in `src/fairy/models.py:222` and `src/fairy/views.py:468`), but **does not wire it through to any runtime CLI**. `sprites_exec.py` currently only translates `mcp_servers`, not `tools`. To build a meaningful e2e test suite, two things must happen together: (1) a new wiring layer in `sprites_exec.py` that translates each Managed-Agents canonical name to runtime-specific flags/config, and (2) a matrix test module that spawns real sessions and inspects their stream output for tool invocations.
+
+Each runtime has a different enforcement surface:
+- **Claude CLI**: clean CLI flags — `--tools "Bash,Read"` (allowlist) or `--disallowedTools "WebFetch"` (denylist). PascalCase names. Restrictions don't persist on `--continue` — must re-pass.
+- **Codex CLI**: coarse-grained only — `sandbox_mode` (read-only / workspace-write / danger-full-access) plus per-MCP `enabled_tools`. No individual on/off for bash/read/write/edit/glob/grep. No `web_fetch` at all. Six of the eight canonical tools are **hard gaps** for codex.
+- **Gemini CLI**: no usable CLI flag — must write `~/.gemini/policies/*.toml` Policy Engine files OR `~/.gemini/settings.json` `tools.core` allowlist before invocation. Managed-Agents `write` maps to two Gemini tools (`write_file` + `replace`) — both must be denied. `tools.exclude` is deprecated; use Policy Engine.
+
+The e2e matrix is **4 runtimes × 8 tools × 2 polarities = 64 sessions**, with ~12 codex combinations marked `xfail`. Net ~60 real sessions per full run at ~$0.35–0.85 on cheapest-model configuration (haiku-4-5 / o4-mini / gemini-2.5-flash).
+
+## Research Tracks
+
+### Track 1: Claude CLI tool enforcement
+**Researcher**: claude-cli-researcher
+**Scope**: `claude` / `claude-oauth` runtime CLI flags, stream-json event shapes, MCP integration
+
+#### Findings:
+
+1. **`--tools` restricts availability** — `--tools "Bash,Read,Edit"` limits Claude to only those built-in tools. `--tools ""` disables ALL. This is the availability-restriction flag. ([cli-reference](https://code.claude.com/docs/en/cli-reference))
+2. **`--allowedTools` ≠ restriction** — `--allowedTools "Bash,Read"` auto-approves those tools without restricting; docs explicitly say "To restrict which tools are available, use `--tools` instead." ([cli-reference](https://code.claude.com/docs/en/cli-reference))
+3. **`--disallowedTools` removes from context** — `--disallowedTools "WebFetch,WebSearch"` strips specific tools from the model's toolset. ([cli-reference](https://code.claude.com/docs/en/cli-reference))
+4. **`--permission-mode dontAsk`** — Auto-denies anything not in `permissions.allow`; useful for lockdown CI runs. ([cli-reference](https://code.claude.com/docs/en/cli-reference))
+5. **`settings.json` `permissions.allow` / `permissions.deny`** — Persistent rules, deny takes absolute priority; managed settings win over CLI flags. ([permissions](https://code.claude.com/docs/en/permissions))
+6. **Tool names are PascalCase** — `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, `WebSearch`. Managed Agents spec is snake_case — translation layer required. ([tools-reference](https://code.claude.com/docs/en/tools-reference))
+7. **MCP naming: `mcp__<server>__<tool>`** — `--strict-mcp-config` only restricts which MCP servers load from `--mcp-config`; does NOT affect `--allowedTools`/`--disallowedTools`. ([permissions#mcp](https://code.claude.com/docs/en/permissions))
+8. **No structured tool-denial event** — When `--disallowedTools` or `--tools ""` is used, tool is removed from model context before session starts. No `tool_denied` event exists. Runtime `permissions.deny` in `--print` mode → non-zero exit + stderr, not a JSON event. ([headless](https://code.claude.com/docs/en/headless))
+9. **`--continue` does not persist restrictions** — Each invocation must re-pass `--tools` / `--disallowedTools`. In `--print` mode, a disallowed-tool attempt aborts with non-zero exit. ([headless](https://code.claude.com/docs/en/headless))
+10. **`claude-oauth` = claude for enforcement** — Only difference is env var (`CLAUDE_CODE_OAUTH_TOKEN` vs `ANTHROPIC_API_KEY`). CLI, flags, stream format identical. ([cli-reference](https://code.claude.com/docs/en/cli-reference))
+11. **`--bare` mode** — Skips hooks/skills/plugins/MCP/CLAUDE.md auto-discovery. Defaults to Bash + read + edit only. Useful for reproducible CI. ([headless](https://code.claude.com/docs/en/headless))
+12. **Fairy wiring gap confirmed** — `runtimes.py:59` emits `claude --print --verbose --output-format stream-json -p "$PROMPT"` with no `--tools` or `--disallowedTools`. `Agent.tools` is entirely unwired.
+
+#### Managed-Agents → Claude CLI mapping
+
+| Managed Agents name | Claude CLI name | Disable recipe |
+|---------------------|-----------------|----------------|
+| `bash` | `Bash` | `--disallowedTools "Bash"` |
+| `read` | `Read` | `--disallowedTools "Read"` |
+| `write` | `Write` | `--disallowedTools "Write"` |
+| `edit` | `Edit` | `--disallowedTools "Edit"` |
+| `glob` | `Glob` | `--disallowedTools "Glob"` |
+| `grep` | `Grep` | `--disallowedTools "Grep"` |
+| `web_fetch` | `WebFetch` | `--disallowedTools "WebFetch"` |
+| `web_search` | `WebSearch` | `--disallowedTools "WebSearch"` |
+| `mcp_toolset` `server_x.tool_y` | `mcp__server_x__tool_y` | `--disallowedTools "mcp__server_x__tool_y"` |
+| `mcp_toolset` `server_x` (all) | `mcp__server_x` | `--disallowedTools "mcp__server_x"` |
+| `custom` | No direct analog | Only via MCP server |
+| disable ALL | n/a | `--tools ""` |
+
+Recipes:
+- **Allow-list (`default_config.enabled=false`)**: compute enabled set → `--tools "Bash,Read"`
+- **Deny-list (`default_config.enabled=true`)**: compute disabled set → `--disallowedTools "WebFetch,WebSearch"`
+
+#### Stream-json event shapes
+
+```json
+// System init (first event)
+{"type":"system","subtype":"init","session_id":"...","tools":["Read","Edit","Bash"],"mcp_servers":[],"plugins":[],"model":"claude-sonnet-4-6"}
+
+// Tool use (inside an assistant event)
+{"type":"assistant","message":{"id":"msg_...","role":"assistant","model":"...","content":[{"type":"tool_use","id":"toolu_...","name":"Write","input":{"file_path":"...","content":"..."}}],"stop_reason":"tool_use","usage":{...}},"session_id":"..."}
+
+// Tool result (inside a user event)
+{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_...","type":"tool_result","content":"File created successfully at: /path/to/file.txt"}]},"session_id":"..."}
+
+// Tool result error
+{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_...","type":"tool_result","content":"Error: Permission denied","is_error":true}]},"session_id":"..."}
+
+// Final result
+{"type":"result","subtype":"success","result":"...","session_id":"...","total_cost_usd":0.001}
+```
+
+Assertion: parse stream, find `type=="assistant"` events, check `message.content[]` for `type=="tool_use"` with matching `name`.
+
+### Track 2: Codex CLI tool enforcement
+**Researcher**: codex-researcher-v2
+**Scope**: `codex` runtime CLI flags, config.toml keys, JSONL event shapes, sandbox + approval mechanics
+
+#### Findings:
+
+1. **`--full-auto`** — Preset: `workspace-write` sandbox + `on-request` approvals. Fairy's current mode. Does NOT disable tools. ([cli/reference](https://developers.openai.com/codex/cli/reference))
+2. **`--ask-for-approval`** — `untrusted | on-request | never`. `never` = fully automated, no pauses. ([cli/reference](https://developers.openai.com/codex/cli/reference))
+3. **`--sandbox`** — `read-only | workspace-write | danger-full-access`. Filesystem + network scope control. ([cli/reference](https://developers.openai.com/codex/cli/reference))
+4. **`--dangerously-bypass-approvals-and-sandbox` / `--yolo`** — Bypasses everything. Not for Fairy.
+5. **`--config key=value`** — Inline config override. Per-invocation only; NOT persisted on resume. ([cli/reference](https://developers.openai.com/codex/cli/reference))
+6. **`approval_policy` config key** — `untrusted` / `on-request` / `never` / `granular`. ([config-reference](https://developers.openai.com/codex/config-reference))
+7. **`sandbox_mode` config key** — `read-only` / `workspace-write` / `danger-full-access`. ([config-reference](https://developers.openai.com/codex/config-reference))
+8. **`web_search` top-level config key** — `"cached"` | `"live"` | `"disabled"`. The ONLY built-in tool with a dedicated on/off switch. ([config-basic](https://developers.openai.com/codex/config-basic))
+9. **Codex built-in tools** — Just two: `shell` (all bash/command execution, internally sometimes called `Bash`) and `web_search`. No separate `read`/`write`/`edit`/`glob`/`grep` — everything file-related flows through `shell`. No `web_fetch`. ([cli/features](https://developers.openai.com/codex/cli/features))
+10. **Starlark execution policy** — `~/.codex/rules/*.rules` in Starlark. `prefix_rule()` matches shell command prefixes with `allow`/`prompt`/`forbidden`. Most restrictive wins. ([exec-policy](https://developers.openai.com/codex/exec-policy))
+11. **MCP per-server keys** — `enabled` (bool), `enabled_tools` (allow-list array), `disabled_tools` (deny-list array, applied after allow-list), `required`, `default_tools_approval_mode`. Per-tool: `[mcp_servers.<id>.tools.<name>] enabled=false`. ([config-sample](https://developers.openai.com/codex/config-sample))
+12. **Resume doesn't persist CLI flags** — `codex exec resume --last` does NOT carry `--sandbox`/`--ask-for-approval`/`--config` from the prior invocation. Config.toml values DO apply fresh. ([cli/reference](https://developers.openai.com/codex/cli/reference))
+13. **JSONL event types** — Top-level: `thread.started`, `turn.started`, `turn.completed`, `turn.failed`, `item.started`, `item.updated`, `item.completed`, `error`. Item subtypes: `agent_message`, `reasoning`, `command_execution`, `file_change`, `mcp_tool_call`, `web_search`, `todo_list`, `error`, `unknown`.
+14. **PostToolUse hook** — Fires after Bash; only supports Bash tool. Hook can block via `{"decision":"block"}`.
+15. **`requirements.toml`** — Admin/org layer; can forbid values like `approval_policy="never"`.
+
+#### Managed-Agents → Codex mapping
+
+| MA name | Codex mechanism | Recipe | GAP? |
+|---|---|---|---|
+| `bash` | `shell` built-in | Sandbox + Starlark prefix rules; no per-tool on/off | PARTIAL |
+| `read` | Via `shell` only | `sandbox_mode=read-only` prevents writes but not reads; cannot disable reads without disabling shell | **GAP** |
+| `write` | Via `shell` only | `sandbox_mode=read-only` for blunt-instrument write block | PARTIAL |
+| `edit` | Via `shell` only | Same as write | **GAP** |
+| `glob` | Via `shell` only | No independent disable | **GAP** |
+| `grep` | Via `shell` only | No independent disable | **GAP** |
+| `web_fetch` | No equivalent | MCP or shell `curl` workaround only | **GAP** |
+| `web_search` | `web_search` built-in | `web_search="disabled"` in config.toml, or `--config web_search=disabled` | MATCH |
+| `mcp_toolset` | `[mcp_servers.<id>]` | `enabled_tools`/`disabled_tools`, per-tool `enabled=false` | MATCH |
+| `custom` | No equivalent | MCP server workaround | **GAP** |
+
+#### JSONL event shapes
+
+```json
+{"type":"thread.started","thread_id":"..."}
+{"type":"turn.started"}
+
+// Command execution (bash/shell)
+{"type":"item.started","item":{"id":"item_1","type":"command_execution","command":"bash -lc ls","status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"bash -lc ls","status":"completed","output":"docs\nsdk\n","exit_code":0}}
+
+// MCP tool call
+{"type":"item.started","item":{"id":"item_2","type":"mcp_tool_call","server":"<name>","tool":"<tool>","input":{...},"status":"in_progress"}}
+
+// Web search
+{"type":"item.completed","item":{"id":"item_4","type":"web_search","query":"...","results":[...],"status":"completed"}}
+
+// Agent message
+{"type":"item.completed","item":{"id":"item_3","type":"agent_message","text":"..."}}
+
+{"type":"turn.completed","usage":{"input_tokens":...,"cached_input_tokens":...,"output_tokens":...}}
+
+// Tool denial: NO dedicated event type. Surfaces as turn.failed or item with status:"denied".
+```
+
+#### Codex-specific gaps (xfail candidates)
+
+- **GAP-1**: No separate `read` tool — collapses into `shell`
+- **GAP-2**: No per-tool `write` disable — only coarse `sandbox_mode`
+- **GAP-3**: No separate `edit` tool
+- **GAP-4**: No separate `glob` tool
+- **GAP-5**: No separate `grep` tool
+- **GAP-6**: No `web_fetch` built-in at all
+- **GAP-7**: `bash` not discrete — cannot disable shell without breaking the agent
+- **GAP-8**: No `custom` tool abstraction
+- **GAP-9**: No structured denial event shape
+- **GAP-10**: Resume doesn't persist `--config` overrides
+- **GAP-11**: `enabled_tools` / `disabled_tools` config-file-only (no CLI flag)
+- **GAP-12**: `approval_policy="never"` vs `--full-auto` interaction unclear
+
+### Track 3: Gemini CLI tool enforcement
+**Researcher**: gemini-cli-researcher
+**Scope**: `gemini` runtime settings.json, Policy Engine TOML, stream-json event shapes
+
+#### Findings:
+
+1. **`settings.json` `tools` key** — `tools.core` (allowlist: if set, ONLY listed tools available; applies to ALL built-ins, not just shell) and `tools.exclude` (blocklist, DEPRECATED). Per-command shell filter: `"tools.core": ["run_shell_command(git)"]` allows only git. ([shell.md#command-restrictions](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/shell.md#command-restrictions))
+2. **CLI flags are effectively useless** — `--allowed-tools` is DEPRECATED ("Use the Policy Engine instead"). No `--denied-tools`, `--tools`, or `--disable-tools`. `--allowed-mcp-server-names` restricts which MCP servers start. `--approval-mode` controls confirmation globally. `--sandbox/-s` does filesystem/network isolation, not tool-name restriction. ([cli-reference](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/cli-reference.md))
+3. **Policy Engine (primary mechanism)** — TOML files at `~/.gemini/policies/*.toml` are the preferred mechanism. `deny` rule without `argsPattern` excludes the tool from model context entirely. Schema supports `toolName` (string/array; wildcards `*`, `mcp_*`, `mcp_server_*`), `mcpName`, `commandPrefix`/`commandRegex`, `argsPattern`, `decision` (allow/deny/ask_user), `priority` (0-999, tiered: User=4, Admin=5), `interactive` (true=interactive only, false=headless only — critical for Fairy), `modes`, `denyMessage`. ([policy-engine](https://github.com/google-gemini/gemini-cli/blob/main/docs/reference/policy-engine.md))
+4. **Built-in tool taxonomy**:
+
+| Canonical | Display | Kind |
+|---|---|---|
+| `run_shell_command` | Shell | Execute |
+| `read_file` | ReadFile | Read |
+| `read_many_files` | ReadManyFiles | Read |
+| `write_file` | WriteFile | Edit |
+| `replace` | EditFile | Edit |
+| `glob` | FindFiles | Search |
+| `grep_search` | SearchText | Search |
+| `list_directory` | ReadFolder | Read |
+| `web_fetch` | WebFetch | Fetch |
+| `google_web_search` | GoogleSearch | Search |
+| `ask_user`, `write_todos`, `save_memory`, etc. | | Interact/Memory |
+| `list_mcp_resources`, `read_mcp_resource` | | MCP |
+
+5. **`--resume` persists restrictions** — Policy files and `settings.json` re-loaded on every invocation. No way to resume a session with fewer restrictions than current config.
+6. **MCP + `trust:true`** — MCP tools have per-server `includeTools`/`excludeTools` arrays. Policy Engine's `mcpName` / `mcp_*` DO apply to MCP tools. `trust:true` bypasses `ask_user` → `allow` only; does NOT bypass `deny`. In headless mode, `ask_user` already → `deny` — so `trust:true` has no extra effect.
+7. **Deny-all-then-allowlist** — `"tools.core": []` disables all built-ins. Or use Policy Engine low-priority `toolName="*" decision="deny"` + higher-priority allow rules. No single boolean equivalent to Claude's `default_config.enabled:false`.
+
+#### Managed-Agents → Gemini mapping
+
+| MA name | Gemini canonical | Disable recipe (TOML) | GAP? |
+|---|---|---|---|
+| `bash` | `run_shell_command` | `toolName="run_shell_command" decision="deny"` | No |
+| `read` | `read_file` | `toolName="read_file" decision="deny"` | Partial (`read_many_files`, `list_directory` separate) |
+| `write` | `write_file` + `replace` | `toolName=["write_file","replace"] decision="deny"` | **GAP** — maps to TWO tools |
+| `edit` | `replace` | `toolName="replace" decision="deny"` | No |
+| `glob` | `glob` | `toolName="glob" decision="deny"` | No |
+| `grep` | `grep_search` | `toolName="grep_search" decision="deny"` | No |
+| `web_fetch` | `web_fetch` | `toolName="web_fetch" decision="deny"` | No |
+| `web_search` | `google_web_search` | `toolName="google_web_search" decision="deny"` | Partial (API grounding; deny in headless unconfirmed) |
+| `custom` | N/A | `mcpName="*" decision="deny"` | **GAP** |
+| `mcp_toolset` | per-server MCP | `mcpName="<server>" decision="deny"` | No |
+
+#### TOML deny-all + allowlist example
+
+```toml
+[[rule]]
+toolName = "*"
+decision = "deny"
+priority = 1
+
+[[rule]]
+toolName = ["read_file", "glob", "grep_search"]
+decision = "allow"
+priority = 100
+```
+
+#### Stream-json event shapes
+
+```jsonc
+{"type":"init","timestamp":"...","session_id":"...","model":"gemini-2.5-pro"}
+{"type":"message","timestamp":"...","role":"assistant","content":"...","delta":true}
+
+// Tool use
+{"type":"tool_use","timestamp":"...","tool_name":"run_shell_command","tool_id":"call_xyz","parameters":{"command":"echo hello"}}
+
+// Tool result — success
+{"type":"tool_result","timestamp":"...","tool_id":"call_xyz","status":"success","output":"hello\n"}
+
+// Tool result — denied (no dedicated denial event)
+{"type":"tool_result","timestamp":"...","tool_id":"call_xyz","status":"error","error":{"type":"PolicyDenial","message":"Tool execution denied by policy"}}
+
+{"type":"error","timestamp":"...","severity":"warning","message":"..."}
+
+{"type":"result","timestamp":"...","status":"success","stats":{...}}
+```
+
+Assertion: `event.type == "tool_use" && event.tool_name == <expected>`; denial = `tool_result.status == "error"` + `error.message` contains "denied by policy".
+
+#### Gemini-specific gaps
+
+- **GAP-1**: No usable CLI flag for per-invocation restriction — all restriction is file-based
+- **GAP-2**: `tools.exclude` is deprecated
+- **GAP-3**: MA `write` needs TWO Gemini tools denied (`write_file` + `replace`)
+- **GAP-4**: No dedicated denial event — must string-match error message
+- **GAP-5**: Workspace-level policies (`.gemini/policies/*.toml` in project dir) broken (issue #18186); must use `~/.gemini/policies/`
+- **GAP-6**: Config files must be pre-written before `gemini` invocation (no inline flag option)
+- **GAP-7**: `google_web_search` uses Gemini API grounding — policy deny in headless unconfirmed
+
+### Track 4: Synthesis — wiring plan + e2e test design
+**Researcher**: synthesis-v2
+**Scope**: map findings back to Fairy source code; produce wiring plan, test matrix, prompt playbook, and test module skeleton
+
+#### Part A — Fairy Wiring Plan
+
+**Files requiring changes:**
+- `src/fairy/sprites_exec.py` — add `_build_tool_flags_and_files()` called from `build_wrapper_script()`
+- `src/fairy/views.py` — pass `agent_obj.tools` into `build_wrapper_script()` at `create_session` (line 225) AND `send_prompt` continue path
+
+**Proposed function signature:**
+```python
+def _build_tool_flags(
+    runtime: str,
+    tools: list[dict],
+) -> dict:
+    """
+    Returns:
+        cli_flags: str — extra flags to append to the exec line
+        files: dict[str, str] — {absolute_path: file_content} written before exec
+    """
+```
+
+Dispatches to `_tool_flags_claude(tools)`, `_tool_files_codex(tools)`, `_tool_files_gemini(tools)`. The `files` dict entries are emitted as heredoc blocks in the wrapper script (same pattern as `_build_mcp_claude`).
+
+**Per-runtime translation:**
+
+For **claude / claude-oauth**: parse `agent_toolset_20260401` entries.
+- `default_config.enabled=False`, no per-tool overrides → `--tools ""`
+- `default_config.enabled=True`, some disabled → `--disallowedTools "WebFetch,Edit"` (PascalCase)
+- `default_config.enabled=False`, some enabled → `--tools "Bash,Read"`
+- Mixed (default=True, some disabled) → prefer `--disallowedTools`
+- `mcp_toolset`: already handled via `--mcp-config`
+- `custom`: GAP — ignored at CLI layer
+
+For **codex**: extend `_build_mcp_codex()` to also write top-level `sandbox_mode` and `web_search` config keys.
+- If `web_search` disabled → `web_search = "disabled"`
+- If `write` and `edit` both disabled → `sandbox_mode = "read-only"`
+- Otherwise `workspace-write`
+- Per-MCP `enabled_tools`/`disabled_tools` written under `[mcp_servers.<name>]`
+
+For **gemini**: extend `_build_mcp_gemini()` to also write `~/.gemini/policies/fairy.toml`.
+- Convert each canonical name to Gemini's canonical (with `write` → both `write_file` and `replace`)
+- Emit `[[rule]] toolName=... decision="deny" interactive=false` entries
+
+#### Part B — Existing e2e patterns (must reuse)
+
+From `tests/e2e/conftest.py`:
+- `FairyClient` HTTP wrapper — methods: `create_agent`, `create_session`, `collect_stream`, `run_session`, `stream_session_raw`, `wait_for_session`
+- `RUNTIME_MODELS` — `{"claude":"claude-haiku-4-5","codex":"o4-mini","gemini":"gemini-2.5-flash","claude-oauth":"claude-haiku-4-5"}`
+- `create_agent` / `create_environment` / `create_session` factory fixtures with auto-cleanup
+- `api` session-scoped `FairyClient` fixture
+- `e2e_runtimes` fixture — parsed `E2E_RUNTIMES`
+- `stream_stdout(events)`, `stream_all_output(events)` — helpers
+- `_unique(prefix)` — name helper
+
+From `tests/e2e/test_sessions.py`:
+- `pytestmark = pytest.mark.slow` — module-level convention
+- Class-scoped `runtime` fixture parametrized on `RUNTIME_MODELS.keys()` with `e2e_runtimes` skip
+- `_create_throwaway_agent()` / `_start_throwaway_session()` — for class-scoped fixtures
+- `api.run_session(sid)` — returns `(final_status_dict, events_list)`
+
+#### Part C — Test matrix (runtime × tool × polarity)
+
+| Runtime | bash | read | write | edit | glob | grep | web_fetch | web_search |
+|---------|------|------|-------|------|------|------|-----------|------------|
+| **claude** | A+D | A+D | A+D | A+D | A+D | A+D | A+D | A+D |
+| **claude-oauth** | A+D | A+D | A+D | A+D | A+D | A+D | A+D | A+D |
+| **codex** | xfail | xfail | A+D (sandbox) | xfail | xfail | xfail | xfail | A+D (config) |
+| **gemini** | A+D | A+D | A+D | A+D | A+D | A+D | A+D | A+D |
+
+Codex xfail reasons (from `RUNTIME_GAP_MATRIX` in skeleton):
+- `bash`, `read`, `edit`, `glob`, `grep` — no per-tool flag
+- `web_fetch` — no codex equivalent at all
+
+#### Part D — Prompt playbook
+
+| Canonical | Prompt | claude | codex | gemini | Signal |
+|---|---|---|---|---|---|
+| `bash` | "Run the shell command `echo TOOL_SIGNAL_BASH` using your shell/bash tool" | `Bash` | `shell` | `run_shell_command` | tool_use.name |
+| `read` | "Use your file-read tool to read /etc/hostname" | `Read` | n/a | `read_file` | tool_use.name |
+| `write` | "Use your file-write tool to create /tmp/fairy_tool_test_write.txt with 'TOOL_SIGNAL_WRITE'" | `Write` | n/a | `write_file` | tool_use.name |
+| `edit` | "Use your file-edit/replace tool to change 'OLD_CONTENT' to 'NEW_CONTENT' in /tmp/fairy_tool_test_edit.txt" | `Edit` | n/a | `replace` | tool_use.name |
+| `glob` | "Use your glob tool to list files matching /tmp/*.txt (not shell find/ls)" | `Glob` | n/a | `glob` | tool_use.name |
+| `grep` | "Use your grep tool to search 'root' in /etc/passwd (not shell)" | `Grep` | n/a | `grep_search` | tool_use.name |
+| `web_fetch` | "Use your web fetch tool to fetch https://httpbin.org/get" | `WebFetch` | n/a | `web_fetch` | tool_use.name |
+| `web_search` | "Use your web search tool to search 'current UTC date'" | `WebSearch` | `web_search` | `google_web_search` | tool_use.name |
+
+**Allow assertion**: `_tool_was_invoked(events, runtime, tool) == True`
+**Deny assertion**: `_tool_was_invoked(events, runtime, tool) == False`
+
+#### Part E — Cost & bucketing
+
+- Every test: `@pytest.mark.slow` (existing)
+- Add `@pytest.mark.tool_matrix` marker for this module
+- Register in `pyproject.toml`:
+  ```toml
+  [tool.pytest.ini_options]
+  markers = [
+      "slow: spawns real agent sessions",
+      "tool_matrix: tests tool enforcement across runtimes",
+  ]
+  ```
+- New `make test-e2e-tools` target
+- `make test-e2e-fast` already excludes `@slow`, so `tool_matrix` tests auto-excluded
+
+**Cost estimate**:
+- Matrix: 4 runtimes × 8 tools × 2 polarities = 64 sessions + 4 TestDefaultEnabled + 4 TestDenyAll = 72 total
+- Minus ~12 codex xfails = ~60 actual sessions run
+- claude-haiku-4-5: ~$0.003–0.01/session × 20 ≈ $0.10–0.20
+- o4-mini: ~$0.01–0.03/session × 16 ≈ $0.20–0.50
+- gemini-2.5-flash: ~$0.002–0.008/session × 20 ≈ $0.05–0.15
+- **Total per full run: ~$0.35–0.85**
+
+#### Part F — `test_agent_tools.py` skeleton
+
+Key structure:
+
+```python
+"""E2E tests verifying that Agent.tools field is enforced by each runtime CLI."""
+
+from __future__ import annotations
+import json
+import pytest
+from tests.e2e.conftest import RUNTIME_MODELS, FairyClient, _unique, stream_all_output
+
+pytestmark = [pytest.mark.slow, pytest.mark.tool_matrix]
+
+CANONICAL_TOOLS = ["bash", "read", "write", "edit", "glob", "grep", "web_fetch", "web_search"]
+
+RUNTIME_TOOL_NAMES: dict[str, dict[str, str | None]] = {
+    "claude": {"bash":"Bash","read":"Read","write":"Write","edit":"Edit","glob":"Glob","grep":"Grep","web_fetch":"WebFetch","web_search":"WebSearch"},
+    "claude-oauth": {"bash":"Bash","read":"Read","write":"Write","edit":"Edit","glob":"Glob","grep":"Grep","web_fetch":"WebFetch","web_search":"WebSearch"},
+    "codex": {"bash":"shell","read":None,"write":"write_file","edit":None,"glob":None,"grep":None,"web_fetch":None,"web_search":"web_search"},
+    "gemini": {"bash":"run_shell_command","read":"read_file","write":"write_file","edit":"replace","glob":"glob","grep":"grep_search","web_fetch":"web_fetch","web_search":"google_web_search"},
+}
+
+RUNTIME_GAP_MATRIX: dict[tuple[str, str], str | None] = {
+    ("codex", "bash"): "codex has no per-tool bash disable; enforced at sandbox_mode level only",
+    ("codex", "read"): "codex has no per-tool read disable",
+    ("codex", "edit"): "codex edit maps to sandbox_mode only, not individually toggleable",
+    ("codex", "glob"): "codex has no per-tool glob disable",
+    ("codex", "grep"): "codex has no per-tool grep disable",
+    ("codex", "web_fetch"): "codex has no web_fetch equivalent tool",
+}
+
+@pytest.fixture(scope="session", params=list(RUNTIME_MODELS.keys()))
+def runtime(request, e2e_runtimes):
+    if request.param not in e2e_runtimes:
+        pytest.skip(f"{request.param} not in E2E_RUNTIMES")
+    return request.param
+
+def _xfail_if_gap(runtime: str, tool: str) -> None:
+    reason = RUNTIME_GAP_MATRIX.get((runtime, tool))
+    if reason:
+        pytest.xfail(reason)
+
+def _prompt_for(tool: str) -> str: ...  # see full skeleton
+
+def _parse_claude_events(raw_events: list[dict]) -> list[str]:
+    """Find tool_use blocks inside assistant events."""
+    ...
+
+def _parse_gemini_events(raw_events: list[dict]) -> list[str]:
+    """Find events where type=='tool_use' and extract tool_name."""
+    ...
+
+def _parse_codex_events(raw_events: list[dict]) -> list[str]:
+    """Find item.started events with type=='command_execution' or 'mcp_tool_call' or 'web_search'."""
+    ...
+
+def _tool_was_invoked(events, runtime, tool) -> bool:
+    runtime_tool_name = RUNTIME_TOOL_NAMES.get(runtime, {}).get(tool)
+    if runtime_tool_name is None:
+        return False
+    if runtime in ("claude", "claude-oauth"):
+        return runtime_tool_name in _parse_claude_events(events)
+    elif runtime == "gemini":
+        return runtime_tool_name in _parse_gemini_events(events)
+    elif runtime == "codex":
+        return runtime_tool_name in _parse_codex_events(events)
+    return False
+
+def _make_allow_toolset(tool: str) -> list[dict]:
+    return [{
+        "type": "agent_toolset_20260401",
+        "default_config": {"enabled": False},
+        "configs": [{"name": tool, "enabled": True}],
+    }]
+
+def _make_deny_toolset(tool: str) -> list[dict]:
+    return [{
+        "type": "agent_toolset_20260401",
+        "default_config": {"enabled": True},
+        "configs": [{"name": tool, "enabled": False}],
+    }]
+
+def _make_deny_all_toolset() -> list[dict]:
+    return [{"type": "agent_toolset_20260401", "default_config": {"enabled": False}}]
+
+
+class TestToolAllow:
+    @pytest.mark.parametrize("tool", CANONICAL_TOOLS)
+    def test_allow_tool_is_invoked(self, api, create_agent, create_session, runtime, tool):
+        _xfail_if_gap(runtime, tool)
+        agent = create_agent(name=_unique(f"e2e-allow-{runtime}-{tool}"),
+                             model=RUNTIME_MODELS[runtime], runtime=runtime,
+                             tools=_make_allow_toolset(tool))
+        session = create_session(agent_id=agent["id"], prompt=_prompt_for(tool), timeout=120)
+        final, events = api.run_session(session["id"])
+        assert final["status"] == "completed"
+        assert _tool_was_invoked(events, runtime, tool)
+
+
+class TestToolDeny:
+    @pytest.mark.parametrize("tool", CANONICAL_TOOLS)
+    def test_deny_tool_not_invoked(self, api, create_agent, create_session, runtime, tool):
+        _xfail_if_gap(runtime, tool)
+        agent = create_agent(..., tools=_make_deny_toolset(tool))
+        session = create_session(agent_id=agent["id"], prompt=_prompt_for(tool), timeout=120)
+        final, events = api.run_session(session["id"])
+        assert not _tool_was_invoked(events, runtime, tool)
+
+
+class TestDefaultEnabled:
+    def test_no_tools_field_session_completes(self, ...): ...
+    def test_explicit_all_enabled_session_completes(self, ...): ...
+
+
+class TestDenyAll:
+    def test_deny_all_no_tools_invoked(self, ...):
+        # Prompt that would normally trigger bash + file tools
+        # Assert no canonical tool (excluding gaps) was invoked
+        ...
+
+
+class TestMcpToolset:
+    @pytest.mark.skip(reason="Requires live MCP endpoint via E2E_MCP_URL")
+    def test_mcp_tool_invoked(self, ...): ...
+
+
+class TestCustomTool:
+    @pytest.mark.skip(reason="TODO: custom tool enforcement not yet wired in Fairy CLI layer")
+    def test_custom_tool_schema_available(self, ...): ...
+```
+
+Full skeleton available in the team's synthesis deliverable (preserved in team transcript).
+
+## Cross-Track Discoveries
+
+1. **The wiring gap is symmetric but the enforcement surface isn't** — All three runtimes confirm `Agent.tools` is stored but not translated, yet each runtime requires a completely different enforcement strategy: claude uses CLI flags, gemini needs on-disk TOML policies, codex has coarse sandbox modes plus MCP per-server keys. The `_build_tool_flags()` function must return both `cli_flags: str` AND `files: dict[path, content]` to handle this diversity.
+
+2. **Tool-denial events are universally absent as structured events** — Claude, codex, and gemini all lack a dedicated `tool_denied` stream event type. Denial signals differ: claude removes the tool from the `system/init` `tools[]` array (silent — model never sees it); gemini emits a `tool_result` with `status:"error"` and message "Tool execution denied by policy"; codex surfaces denial as non-zero exit or `turn.failed`. The test helper `_tool_was_invoked()` must therefore not assert on a denial event type — it must check tool *absence* in the stream.
+
+3. **The Managed-Agents spec ergonomics break down for codex** — Six of the eight canonical tool names have no enforceable codex analog. The Managed-Agents API contract becomes an aspirational surface for codex; we can only enforce `web_search`, sandbox-level write restriction, and MCP per-server allowlisting. This is a product-level clarification the Fairy team should document in the README.
+
+4. **MCP tool naming converges on prefix-based schemes across runtimes** — Claude uses `mcp__<server>__<tool>`, gemini uses `mcpName="<server>"` in policies, codex uses `[mcp_servers.<id>.tools.<name>]`. Fairy's validator accepts `mcp_toolset` with `mcp_server_name`; the runtime-specific translation is straightforward per-runtime but the central abstraction is sound.
+
+5. **Resume / multi-turn semantics vary** — Claude `--continue` doesn't persist flag-based restrictions (must re-pass); gemini `--resume` re-reads policy files fresh (restrictions persist by happenstance); codex `exec resume` doesn't persist `--config` overrides either. The Fairy `send_prompt` continue path must pass `agent.tools` through `build_wrapper_script` on every call — not just initial creation.
+
+## Code References
+
+| File | Tracks | Findings | Link |
+|------|--------|----------|------|
+| `src/fairy/runtimes.py:56-81` | 1, 2, 3, 4 | Where runtime `cmd` / `continue_cmd` templates live — injection point for flags | [permalink](https://github.com/ravi-hq/fairy/blob/9ea0965/src/fairy/runtimes.py#L56-L81) |
+| `src/fairy/sprites_exec.py:259-293` | 4 | `build_wrapper_script` — needs new `tools=` parameter + `_build_tool_flags` companion | [permalink](https://github.com/ravi-hq/fairy/blob/9ea0965/src/fairy/sprites_exec.py#L259-L293) |
+| `src/fairy/sprites_exec.py:120-206` | 4 | `_build_mcp_claude` / `_build_mcp_codex` / `_build_mcp_gemini` — pattern to follow for `_build_tool_files_*` | [permalink](https://github.com/ravi-hq/fairy/blob/9ea0965/src/fairy/sprites_exec.py#L120-L206) |
+| `src/fairy/views.py:224-228` | 4 | `create_session` — call site that currently passes `mcp_servers` but not `tools` | [permalink](https://github.com/ravi-hq/fairy/blob/9ea0965/src/fairy/views.py#L224-L228) |
+| `src/fairy/views.py:461-510` | 4 | `_validate_tools` / `_validate_mcp_servers` + `AGENT_VERSIONED_FIELDS` | [permalink](https://github.com/ravi-hq/fairy/blob/9ea0965/src/fairy/views.py#L461-L510) |
+| `tests/e2e/conftest.py:20-27,203-229` | 4 | `RUNTIME_MODELS` + `api`/`create_agent`/`create_session` fixtures | [permalink](https://github.com/ravi-hq/fairy/blob/9ea0965/tests/e2e/conftest.py#L20-L229) |
+| `tests/e2e/test_sessions.py:21-47` | 4 | Class-scoped `runtime` parametrization pattern to reuse | [permalink](https://github.com/ravi-hq/fairy/blob/9ea0965/tests/e2e/test_sessions.py#L21-L47) |
+| `tests/e2e/test_agents.py` | 4 | Existing tool-validation tests (API-level, not runtime-level) | [permalink](https://github.com/ravi-hq/fairy/blob/9ea0965/tests/e2e/test_agents.py) |
+
+## Architecture Insights
+
+**The Managed-Agents spec is Fairy's public contract; per-runtime translation is Fairy's responsibility.** Users write `{type: "agent_toolset_20260401", configs: [{name: "web_fetch", enabled: false}]}` once, and Fairy translates that to `--disallowedTools WebFetch` for claude, a TOML policy for gemini, and `web_search="disabled"` for codex's analog. Gaps must be surfaced clearly — either at validation time (reject configurations that can't be enforced on the chosen runtime) or at documentation time (explicit README table of enforceable-per-runtime).
+
+**Recommendation**: introduce a per-runtime "capability matrix" exposed via an admin endpoint or in `runtimes.py`, so the API can warn at agent creation time when a tools configuration is partially-enforceable. This is similar to how `MODEL_RUNTIME_MAP` already constrains which models pair with which runtime.
+
+**Stream-json heterogeneity is the primary test-design risk.** Each runtime's event format is different enough that `_tool_was_invoked` needs three parsers. Keep these parsers small, tested (unit tests with recorded fixtures would help), and in `tests/e2e/` or a sibling helpers module — not in production code.
+
+## Historical Context
+
+- `thoughts/research/2026-04-16-agent-tools-and-mcp.md` — prior research into the `Agent.tools` / `mcp_servers` API schema
+- `thoughts/research/2026-04-16-e2e-test-suite.md` — design of the existing e2e suite (patterns this test module will reuse)
+
+## Related Research
+
+- Prior session-execution research: `thoughts/research/2026-04-16-session-based-execution.md`
+- Sprites platform: `thoughts/research/2026-04-15-sprites-platform-research.md`, `thoughts/research/2026-04-16-sprites-deep-dive.md`
+
+## Open Questions
+
+1. **Custom tools in non-API runtimes** — The Managed-Agents `custom` tool type declares a tool to a model and expects the *caller* to execute it (client-executed tool use). Claude/codex/gemini CLIs don't expose a mechanism for this; "custom" only flows through MCP. Should Fairy reject `custom` entries at validation time, or silently treat them as a no-op at the CLI layer?
+2. **Codex web_fetch workaround** — If a user configures `web_fetch: enabled` on a codex agent, should Fairy transparently substitute an MCP server that provides web_fetch (increases complexity, leaks implementation) or reject the configuration at agent-create time (breaks spec portability)?
+3. **Gemini `google_web_search` headless enforcement** — Researcher flagged that denial of `google_web_search` (which uses Gemini API grounding, not a local tool) may not actually take effect in headless mode. Worth an integration test to confirm before shipping.
+4. **Multi-turn consistency** — When `POST /sessions/{id}/prompt` is called on an existing session, should the tools be taken from the current agent version, or frozen to the version at session creation? Affects whether tool restrictions can drift mid-conversation.


### PR DESCRIPTION
## Summary

First of a 3-PR stack that closes the Agent.tools enforcement gap (was the
original #5 as one PR). Baseline plumbing + claude runtime enforcement only.

Stack:
- **this PR** — baseline + claude
- #? — codex
- #? — gemini
- then original #6 rebase → mcp stack (4 more PRs)

## What's in this PR

- `_build_tool_flags()` dispatcher in `sprites_exec.py`. Claude /
  claude-oauth route to `_tool_flags_claude`; codex / gemini return
  `("", {})` (placeholder until later PRs).
- `_format_tool_files_heredoc()` — emits `mkdir` + heredoc blocks for
  runtimes that enforce via config files (dormant until 5c).
- `build_wrapper_script(..., tools=...)` — plumbed through both
  `create_session` and `send_prompt`, so restrictions re-emit on
  `--continue`.
- Removes `custom` from `VALID_TOOL_TYPES`. It never had a per-runtime
  analog and never reached the CLI layer.
- Drive-by: drop unused `datetime.timezone` import in `auth.py`.
- README gains a tool-enforcement capability table (accurate once full
  stack lands).
- `tool_matrix` pytest marker + `make test-e2e-tools` target.
- `tests/e2e/test_agent_tools.py` parametrized on claude only; 5b/5c widen.
- Unit tests: `TestWrapperScriptToolPlumbing` (baseline), `TestClaudeToolFlags`.

## Notes for review

- `_build_tool_flags` returns `("", {})` for codex/gemini — intentional
  dead branches that 5b/5c activate.
- The README capability table shows the table reached once all three
  runtime PRs land. If 5b/5c don't land, this needs trimming to claude only.
- Research + plan docs in `thoughts/` (1730 lines) describe all three
  runtimes — same docs will be referenced by 5b and 5c.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 163 unit tests pass
- [ ] `FAIRY_API_TOKEN=<t> make test-e2e-tools` — claude matrix only

🤖 Generated with [Claude Code](https://claude.com/claude-code)