### PR TITLE
Enforce Agent.tools: codex

### DIFF
--- a/src/fairy/sprites_exec.py
+++ b/src/fairy/sprites_exec.py
@@ -140,10 +140,50 @@ def _build_mcp_claude(servers: list[McpServerSpec]) -> str:
     )
 
 
-def _build_mcp_codex(servers: list[McpServerSpec]) -> str:
-    """Generate Codex MCP config TOML and write command."""
-    lines = ["# MCP server configuration", "mkdir -p ~/.codex"]
+def _codex_top_level_keys(tools: list[dict]) -> list[str]:
+    """Derive top-level codex config.toml keys from Managed-Agents tools.
+
+    Only two canonical tools have per-tool codex enforcement:
+    - `web_search`: top-level `web_search = "disabled"`
+    - `write` + `edit` together: `sandbox_mode = "read-only"`
+
+    bash/read/glob/grep/web_fetch have no per-tool codex equivalent and are
+    accepted silently.
+    """
+    toolset = _find_agent_toolset(tools)
+    if toolset is None:
+        return []
+    default_enabled = toolset.get("default_config", {}).get("enabled", True)
+    configs = {c["name"]: c.get("enabled", True) for c in toolset.get("configs", [])}
+
+    def tool_enabled(name: str) -> bool:
+        return configs.get(name, default_enabled)
+
+    lines: list[str] = []
+    if not tool_enabled("web_search"):
+        lines.append('web_search = "disabled"')
+    if not tool_enabled("write") and not tool_enabled("edit"):
+        lines.append('sandbox_mode = "read-only"')
+    return lines
+
+
+def _build_mcp_codex(
+    servers: list[McpServerSpec],
+    tools: list[dict] | None = None,
+) -> str:
+    """Generate Codex config TOML (MCP servers + tool enforcement keys)."""
+    tools = tools or []
+    top_level = _codex_top_level_keys(tools)
+
+    if not servers and not top_level:
+        return ""
+
+    lines = ["# Codex configuration (MCP + tool enforcement)", "mkdir -p ~/.codex"]
     lines.append("cat > ~/.codex/config.toml << 'MCP_EOF'")
+    if top_level:
+        lines.extend(top_level)
+        if servers:
+            lines.append("")
     for s in servers:
         lines.append(f"[mcp_servers.{s.name}]")
         if s.type == "url":
@@ -193,15 +233,24 @@ def _build_mcp_gemini(servers: list[McpServerSpec]) -> str:
     )
 
 
-def _build_mcp_section(runtime_name: str, servers: list[McpServerSpec]) -> str:
-    """Build MCP config section for the wrapper script."""
+def _build_mcp_section(
+    runtime_name: str,
+    servers: list[McpServerSpec],
+    tools: list[dict] | None = None,
+) -> str:
+    """Build MCP config section for the wrapper script.
+
+    Codex folds tool-enforcement keys into the same config.toml it uses for MCP,
+    so `tools` is threaded through here. Other runtimes emit tool enforcement via
+    the separate `_tool_files_*` path.
+    """
+    if runtime_name == "codex":
+        return _build_mcp_codex(servers, tools=tools)
     if not servers:
         return ""
     if runtime_name in ("claude", "claude-oauth"):
         return _build_mcp_claude(servers)
-    elif runtime_name == "codex":
-        return _build_mcp_codex(servers)
-    elif runtime_name == "gemini":
+    if runtime_name == "gemini":
         return _build_mcp_gemini(servers)
     return ""
 
@@ -283,8 +332,8 @@ def _build_tool_flags(
       cli_flags — extra flags appended to the exec line (leading space if non-empty)
       files     — {absolute_path: content} to write as heredoc blocks before exec
 
-    Runtimes without a per-tool enforcement path (codex, gemini) return ("", {}).
-    Subsequent PRs land those translations.
+    Codex folds its tool enforcement into the MCP config.toml instead of using
+    this path — it returns ("", {}) here. See `_build_mcp_codex`.
     """
     if not tools:
         return "", {}
@@ -335,7 +384,7 @@ def build_wrapper_script(
         packages_section = _build_packages_section(environment.packages)
         setup_section = _build_setup_script_section(environment.setup_script)
 
-    mcp_section = _build_mcp_section(config.name, mcp_servers or [])
+    mcp_section = _build_mcp_section(config.name, mcp_servers or [], tools=tools)
     mcp_flags = _mcp_cmd_flags(config.name, mcp_servers or [])
 
     mcp_names = [s.name for s in (mcp_servers or [])]

--- a/tests/e2e/test_agent_tools.py
+++ b/tests/e2e/test_agent_tools.py
@@ -25,17 +25,23 @@ pytestmark = [pytest.mark.slow, pytest.mark.tool_matrix]
 REPRESENTATIVE_TOOL = {
     "claude": "web_fetch",
     "claude-oauth": "web_fetch",
+    "codex": "web_search",
 }
 
 RUNTIME_TOOL_NAMES = {
     "claude": {"web_fetch": "WebFetch"},
     "claude-oauth": {"web_fetch": "WebFetch"},
+    "codex": {"web_search": "web_search"},
 }
 
 PROMPTS = {
     "web_fetch": (
         "Use your web fetch tool to fetch https://httpbin.org/get and print the "
         "response body. Do not use shell."
+    ),
+    "web_search": (
+        "Use your web search tool to search for 'current UTC date' and print the "
+        "top result's title."
     ),
 }
 
@@ -58,16 +64,43 @@ def _parse_claude_tool_names(events: list[dict]) -> list[str]:
     return names
 
 
+def _parse_codex_tool_names(events: list[dict]) -> list[str]:
+    names: list[str] = []
+    for e in events:
+        if e.get("type") != "output":
+            continue
+        try:
+            obj = json.loads(e.get("data", ""))
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if obj.get("type") in ("item.started", "item.completed"):
+            item = obj.get("item", {})
+            item_type = item.get("type")
+            if item_type == "web_search":
+                names.append("web_search")
+            elif item_type == "command_execution":
+                names.append("shell")
+            elif item_type == "mcp_tool_call":
+                server = item.get("server", "")
+                tool = item.get("tool", "")
+                names.append(f"mcp__{server}__{tool}")
+    return names
+
+
 def _tool_was_invoked(events: list[dict], runtime: str, tool: str) -> bool:
     target = RUNTIME_TOOL_NAMES[runtime][tool]
     if runtime in ("claude", "claude-oauth"):
         return target in _parse_claude_tool_names(events)
+    if runtime == "codex":
+        return target in _parse_codex_tool_names(events)
     return False
 
 
 def _any_tool_was_invoked(events: list[dict], runtime: str) -> bool:
     if runtime in ("claude", "claude-oauth"):
         return bool(_parse_claude_tool_names(events))
+    if runtime == "codex":
+        return bool(_parse_codex_tool_names(events))
     return False
 
 
@@ -91,7 +124,7 @@ def _deny_all() -> list[dict]:
     return [{"type": "agent_toolset_20260401", "default_config": {"enabled": False}}]
 
 
-@pytest.fixture(scope="class", params=["claude"])
+@pytest.fixture(scope="class", params=["claude", "codex"])
 def runtime(request, e2e_runtimes):
     if request.param not in e2e_runtimes:
         pytest.skip(f"{request.param} not in E2E_RUNTIMES")

--- a/tests/test_tools_mcp.py
+++ b/tests/test_tools_mcp.py
@@ -684,3 +684,92 @@ class TestClaudeToolFlags:
         assert '--disallowedTools "Bash"' in script
         assert "--continue" in script
 
+# --- Phase 4: Codex config.toml tool enforcement ---
+
+
+class TestCodexToolConfig:
+    def _script(self, tools, servers=None):
+        config = RUNTIMES["codex"]
+        return build_wrapper_script(
+            config, "key", "prompt", mcp_servers=servers, tools=tools,
+        )
+
+    def test_no_tools_no_mcp_no_config_block(self):
+        script = self._script([])
+        assert "~/.codex/config.toml" not in script
+
+    def test_web_search_disabled_writes_top_level_key(self):
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [{"name": "web_search", "enabled": False}],
+        }]
+        script = self._script(tools)
+        assert 'web_search = "disabled"' in script
+
+    def test_write_and_edit_disabled_sets_read_only_sandbox(self):
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [
+                {"name": "write", "enabled": False},
+                {"name": "edit", "enabled": False},
+            ],
+        }]
+        script = self._script(tools)
+        assert 'sandbox_mode = "read-only"' in script
+
+    def test_only_write_disabled_does_not_set_sandbox(self):
+        """Sandbox is blunt — only flip it if both write AND edit are disabled."""
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [{"name": "write", "enabled": False}],
+        }]
+        script = self._script(tools)
+        assert "sandbox_mode" not in script
+
+    def test_default_off_disables_web_search_and_sets_sandbox(self):
+        tools = [{"type": "agent_toolset_20260401", "default_config": {"enabled": False}}]
+        script = self._script(tools)
+        assert 'web_search = "disabled"' in script
+        assert 'sandbox_mode = "read-only"' in script
+
+    def test_unenforceable_tools_are_silent(self):
+        """bash/read/glob/grep/web_fetch disable produces no codex config."""
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [
+                {"name": "bash", "enabled": False},
+                {"name": "read", "enabled": False},
+                {"name": "glob", "enabled": False},
+                {"name": "grep", "enabled": False},
+                {"name": "web_fetch", "enabled": False},
+            ],
+        }]
+        script = self._script(tools)
+        # None of these produce a top-level key, and no MCP servers either
+        assert "~/.codex/config.toml" not in script
+
+    def test_mcp_still_works_alongside_tool_config(self):
+        servers = [McpServerSpec(name="github", type="url", url="https://mcp.github.com/mcp")]
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [{"name": "web_search", "enabled": False}],
+        }]
+        script = self._script(tools, servers=servers)
+        assert 'web_search = "disabled"' in script
+        assert "[mcp_servers.github]" in script
+
+    def test_codex_no_tool_flags_on_exec_line(self):
+        """Codex enforcement is file-based; no CLI flags appended to exec."""
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": False},
+        }]
+        script = self._script(tools)
+        exec_line = next(line for line in script.splitlines() if line.startswith("exec "))
+        assert "--tools" not in exec_line
+        assert "--disallowedTools" not in exec_line


### PR DESCRIPTION
## Summary

Stacked on #7. Adds codex tool enforcement — folded into the same
`~/.codex/config.toml` that already carries MCP server config.

## Changes

- `_codex_top_level_keys` → `web_search = "disabled"` + `sandbox_mode = "read-only"`
  (sandbox flips only when both `write` AND `edit` are off, matching codex
  sandbox semantics).
- `_build_mcp_codex` accepts `tools=` and writes a `config.toml` even
  without MCP servers if enforcement keys are needed.
- bash/read/glob/grep/web_fetch are silent-accept (no codex equivalent).
- `TestCodexToolConfig` unit tests + widened e2e `runtime` fixture.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 171 unit tests pass
- [ ] `FAIRY_API_TOKEN=<t> E2E_RUNTIMES=claude,codex make test-e2e-tools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)