### PR TITLE
Enforce Agent.tools: gemini

### DIFF
--- a/src/fairy/sprites_exec.py
+++ b/src/fairy/sprites_exec.py
@@ -321,6 +321,77 @@ def _tool_flags_claude(tools: list[dict], mcp_server_names: list[str]) -> str:
     return f' --disallowedTools "{",".join(disabled_tools)}"'
 
 
+_GEMINI_TOOL_NAMES: dict[str, list[str]] = {
+    "bash": ["run_shell_command"],
+    "read": ["read_file"],
+    "write": ["write_file", "replace"],
+    "edit": ["replace"],
+    "glob": ["glob"],
+    "grep": ["grep_search"],
+    "web_fetch": ["web_fetch"],
+    "web_search": ["google_web_search"],
+}
+
+GEMINI_POLICY_PATH = "/home/sprite/.gemini/policies/fairy.toml"
+
+
+def _gemini_names_toml(names: list[str]) -> str:
+    return "[" + ", ".join(f'"{n}"' for n in names) + "]"
+
+
+def _tool_files_gemini(tools: list[dict]) -> dict[str, str]:
+    """Translate Managed-Agents tools spec → Gemini Policy Engine TOML.
+
+    Written to ~/.gemini/policies/fairy.toml; loaded on every gemini invocation
+    (including --resume), so restrictions persist across multi-turn sessions.
+
+    default_config.enabled=False → deny-all catch-all + allow-rules for enabled tools
+    default_config.enabled=True  → per-tool deny rules for each disabled tool
+    """
+    toolset = _find_agent_toolset(tools)
+    if toolset is None:
+        return {}
+    default_enabled = toolset.get("default_config", {}).get("enabled", True)
+    configs = {c["name"]: c.get("enabled", True) for c in toolset.get("configs", [])}
+
+    rules: list[str] = []
+
+    if not default_enabled:
+        rules.append(
+            "[[rule]]\n"
+            'toolName = "*"\n'
+            'decision = "deny"\n'
+            "priority = 1\n"
+            "interactive = false"
+        )
+        allowed: list[str] = []
+        for canonical, enabled in configs.items():
+            if enabled and canonical in _GEMINI_TOOL_NAMES:
+                allowed.extend(_GEMINI_TOOL_NAMES[canonical])
+        if allowed:
+            rules.append(
+                "[[rule]]\n"
+                f"toolName = {_gemini_names_toml(allowed)}\n"
+                'decision = "allow"\n'
+                "priority = 100\n"
+                "interactive = false"
+            )
+    else:
+        for canonical, enabled in configs.items():
+            if enabled or canonical not in _GEMINI_TOOL_NAMES:
+                continue
+            rules.append(
+                "[[rule]]\n"
+                f"toolName = {_gemini_names_toml(_GEMINI_TOOL_NAMES[canonical])}\n"
+                'decision = "deny"\n'
+                "interactive = false"
+            )
+
+    if not rules:
+        return {}
+    return {GEMINI_POLICY_PATH: "\n\n".join(rules) + "\n"}
+
+
 def _build_tool_flags(
     runtime_name: str,
     tools: list[dict],
@@ -339,6 +410,8 @@ def _build_tool_flags(
         return "", {}
     if runtime_name in ("claude", "claude-oauth"):
         return _tool_flags_claude(tools, mcp_server_names), {}
+    if runtime_name == "gemini":
+        return "", _tool_files_gemini(tools)
     return "", {}
 
 

--- a/tests/e2e/test_agent_tools.py
+++ b/tests/e2e/test_agent_tools.py
@@ -158,7 +158,7 @@ def runtime(request, e2e_runtimes):
 
 
 class TestToolEnforcement:
-    """Per-runtime matrix. Subsequent PRs widen the `runtime` fixture params."""
+    """Per-runtime matrix — 3 runtimes × 3 tests = 9 sessions per full run."""
 
     def test_allow_tool_is_invocable(
         self, api: FairyClient, create_agent, create_session, runtime,

--- a/tests/e2e/test_agent_tools.py
+++ b/tests/e2e/test_agent_tools.py
@@ -26,12 +26,14 @@ REPRESENTATIVE_TOOL = {
     "claude": "web_fetch",
     "claude-oauth": "web_fetch",
     "codex": "web_search",
+    "gemini": "bash",
 }
 
 RUNTIME_TOOL_NAMES = {
     "claude": {"web_fetch": "WebFetch"},
     "claude-oauth": {"web_fetch": "WebFetch"},
     "codex": {"web_search": "web_search"},
+    "gemini": {"bash": "run_shell_command"},
 }
 
 PROMPTS = {
@@ -42,6 +44,10 @@ PROMPTS = {
     "web_search": (
         "Use your web search tool to search for 'current UTC date' and print the "
         "top result's title."
+    ),
+    "bash": (
+        "Run the shell command `echo TOOL_SIGNAL_BASH` using your shell tool and "
+        "print the output."
     ),
 }
 
@@ -87,12 +93,30 @@ def _parse_codex_tool_names(events: list[dict]) -> list[str]:
     return names
 
 
+def _parse_gemini_tool_names(events: list[dict]) -> list[str]:
+    names: list[str] = []
+    for e in events:
+        if e.get("type") != "output":
+            continue
+        try:
+            obj = json.loads(e.get("data", ""))
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if obj.get("type") == "tool_use":
+            name = obj.get("tool_name")
+            if name:
+                names.append(name)
+    return names
+
+
 def _tool_was_invoked(events: list[dict], runtime: str, tool: str) -> bool:
     target = RUNTIME_TOOL_NAMES[runtime][tool]
     if runtime in ("claude", "claude-oauth"):
         return target in _parse_claude_tool_names(events)
     if runtime == "codex":
         return target in _parse_codex_tool_names(events)
+    if runtime == "gemini":
+        return target in _parse_gemini_tool_names(events)
     return False
 
 
@@ -101,6 +125,8 @@ def _any_tool_was_invoked(events: list[dict], runtime: str) -> bool:
         return bool(_parse_claude_tool_names(events))
     if runtime == "codex":
         return bool(_parse_codex_tool_names(events))
+    if runtime == "gemini":
+        return bool(_parse_gemini_tool_names(events))
     return False
 
 
@@ -124,7 +150,7 @@ def _deny_all() -> list[dict]:
     return [{"type": "agent_toolset_20260401", "default_config": {"enabled": False}}]
 
 
-@pytest.fixture(scope="class", params=["claude", "codex"])
+@pytest.fixture(scope="class", params=["claude", "codex", "gemini"])
 def runtime(request, e2e_runtimes):
     if request.param not in e2e_runtimes:
         pytest.skip(f"{request.param} not in E2E_RUNTIMES")

--- a/tests/test_tools_mcp.py
+++ b/tests/test_tools_mcp.py
@@ -684,6 +684,109 @@ class TestClaudeToolFlags:
         assert '--disallowedTools "Bash"' in script
         assert "--continue" in script
 
+# --- Phase 3: Gemini Policy Engine TOML ---
+
+
+class TestGeminiToolFiles:
+    def _files(self, tools):
+        from fairy.sprites_exec import _tool_files_gemini
+        return _tool_files_gemini(tools)
+
+    def test_no_toolset_returns_empty(self):
+        assert self._files([]) == {}
+
+    def test_default_enabled_no_overrides_returns_empty(self):
+        tools = [{"type": "agent_toolset_20260401", "default_config": {"enabled": True}}]
+        assert self._files(tools) == {}
+
+    def test_default_off_returns_deny_all(self):
+        from fairy.sprites_exec import GEMINI_POLICY_PATH
+        tools = [{"type": "agent_toolset_20260401", "default_config": {"enabled": False}}]
+        content = self._files(tools)[GEMINI_POLICY_PATH]
+        assert 'toolName = "*"' in content
+        assert 'decision = "deny"' in content
+
+    def test_default_off_with_allowlist(self):
+        from fairy.sprites_exec import GEMINI_POLICY_PATH
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": False},
+            "configs": [{"name": "bash", "enabled": True}],
+        }]
+        content = self._files(tools)[GEMINI_POLICY_PATH]
+        assert 'toolName = "*"' in content
+        assert '"run_shell_command"' in content
+        assert 'decision = "allow"' in content
+
+    def test_write_disabled_denies_both_gemini_tools(self):
+        """Managed-Agents `write` must deny both `write_file` AND `replace`."""
+        from fairy.sprites_exec import GEMINI_POLICY_PATH
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [{"name": "write", "enabled": False}],
+        }]
+        content = self._files(tools)[GEMINI_POLICY_PATH]
+        assert '"write_file"' in content
+        assert '"replace"' in content
+        assert 'decision = "deny"' in content
+
+    @pytest.mark.parametrize("canonical,expected", [
+        ("bash", ["run_shell_command"]),
+        ("read", ["read_file"]),
+        ("edit", ["replace"]),
+        ("glob", ["glob"]),
+        ("grep", ["grep_search"]),
+        ("web_fetch", ["web_fetch"]),
+        ("web_search", ["google_web_search"]),
+    ])
+    def test_every_canonical_name_maps_correctly(self, canonical, expected):
+        from fairy.sprites_exec import GEMINI_POLICY_PATH
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [{"name": canonical, "enabled": False}],
+        }]
+        content = self._files(tools)[GEMINI_POLICY_PATH]
+        for name in expected:
+            assert f'"{name}"' in content
+
+    def test_interactive_false_on_every_rule(self):
+        from fairy.sprites_exec import GEMINI_POLICY_PATH
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [{"name": "bash", "enabled": False}],
+        }]
+        content = self._files(tools)[GEMINI_POLICY_PATH]
+        assert "interactive = false" in content
+
+    def test_wrapper_script_gemini_writes_policy_file(self):
+        config = RUNTIMES["gemini"]
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [{"name": "bash", "enabled": False}],
+        }]
+        script = build_wrapper_script(config, "key", "prompt", tools=tools)
+        assert "/home/sprite/.gemini/policies/fairy.toml" in script
+        assert "TOOLFILE_EOF" in script
+        assert '"run_shell_command"' in script
+
+    def test_gemini_no_tool_flags_on_exec_line(self):
+        """Gemini enforcement is file-based; no CLI flags appended to exec."""
+        config = RUNTIMES["gemini"]
+        tools = [{
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True},
+            "configs": [{"name": "bash", "enabled": False}],
+        }]
+        script = build_wrapper_script(config, "key", "prompt", tools=tools)
+        # Extract the exec line
+        exec_line = next(line for line in script.splitlines() if line.startswith("exec "))
+        assert "--tools" not in exec_line
+        assert "--disallowedTools" not in exec_line
+
 # --- Phase 4: Codex config.toml tool enforcement ---
 
 

--- a/tests/test_tools_mcp.py
+++ b/tests/test_tools_mcp.py
@@ -684,6 +684,7 @@ class TestClaudeToolFlags:
         assert '--disallowedTools "Bash"' in script
         assert "--continue" in script
 
+
 # --- Phase 3: Gemini Policy Engine TOML ---
 
 
@@ -786,6 +787,7 @@ class TestGeminiToolFiles:
         exec_line = next(line for line in script.splitlines() if line.startswith("exec "))
         assert "--tools" not in exec_line
         assert "--disallowedTools" not in exec_line
+
 
 # --- Phase 4: Codex config.toml tool enforcement ---
 


### PR DESCRIPTION
## Summary

Stacked on #8. Final runtime PR of the Agent.tools enforcement stack.
Lands gemini enforcement via the Policy Engine.

## Changes

- `_tool_files_gemini` writes `~/.gemini/policies/fairy.toml`. The Policy
  Engine reloads this on every invocation (including `--resume`), so
  restrictions persist across turns without Fairy rewriting per-turn state.
- `default_config.enabled=False` → catch-all deny + higher-priority allow-rules.
- `default_config.enabled=True` → per-tool deny rules.
- `write → [write_file, replace]` (replace can write too, not just edit).
- e2e fixture now parametrizes claude/codex/gemini.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 186 unit tests pass (matches original #5 total)
- [ ] `FAIRY_API_TOKEN=<t> E2E_RUNTIMES=claude,codex,gemini make test-e2e-tools`
- [ ] `FAIRY_API_TOKEN=<t> E2E_RUNTIMES=claude-oauth make test-e2e-tools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)