### PR TITLE
Enforce mcp_toolset: codex MCP

### DIFF
--- a/src/fairy/sprites_exec.py
+++ b/src/fairy/sprites_exec.py
@@ -205,9 +205,11 @@ def _codex_top_level_keys(tools: list[dict]) -> list[str]:
 def _build_mcp_codex(
     servers: list[McpServerSpec],
     tools: list[dict] | None = None,
+    rules: dict[str, McpToolsetRules] | None = None,
 ) -> str:
     """Generate Codex config TOML (MCP servers + tool enforcement keys)."""
     tools = tools or []
+    rules = rules or {}
     top_level = _codex_top_level_keys(tools)
 
     if not servers and not top_level:
@@ -221,6 +223,19 @@ def _build_mcp_codex(
             lines.append("")
     for s in servers:
         lines.append(f"[mcp_servers.{s.name}]")
+        server_rules = rules.get(s.name)
+        if server_rules is not None:
+            if not server_rules.default_enabled and not server_rules.per_tool:
+                lines.append("enabled = false")
+            else:
+                allowed = [t for t, e in server_rules.per_tool.items() if e]
+                denied = [t for t, e in server_rules.per_tool.items() if not e]
+                if not server_rules.default_enabled and allowed:
+                    allow_list = ", ".join(f'"{t}"' for t in allowed)
+                    lines.append(f"enabled_tools = [{allow_list}]")
+                if denied:
+                    deny_list = ", ".join(f'"{t}"' for t in denied)
+                    lines.append(f"disabled_tools = [{deny_list}]")
         if s.type == "url":
             lines.append(f'url = "{s.url}"')
             for key, val in s.headers.items():
@@ -272,15 +287,19 @@ def _build_mcp_section(
     runtime_name: str,
     servers: list[McpServerSpec],
     tools: list[dict] | None = None,
+    rules: dict[str, McpToolsetRules] | None = None,
 ) -> str:
     """Build MCP config section for the wrapper script.
 
     Codex folds tool-enforcement keys into the same config.toml it uses for MCP,
     so `tools` is threaded through here. Other runtimes emit tool enforcement via
     the separate `_tool_files_*` path.
+
+    `rules` carries per-server mcp_toolset allow/deny. Codex consumes it inside
+    its MCP config; claude consumes it via `_tool_files_claude_mcp`.
     """
     if runtime_name == "codex":
-        return _build_mcp_codex(servers, tools=tools)
+        return _build_mcp_codex(servers, tools=tools, rules=rules)
     if not servers:
         return ""
     if runtime_name in ("claude", "claude-oauth"):
@@ -537,7 +556,9 @@ def build_wrapper_script(
         setup_section = _build_setup_script_section(environment.setup_script)
 
     mcp_rules = _build_mcp_toolset_rules(tools or [])
-    mcp_section = _build_mcp_section(config.name, mcp_servers or [], tools=tools)
+    mcp_section = _build_mcp_section(
+        config.name, mcp_servers or [], tools=tools, rules=mcp_rules,
+    )
     mcp_flags = _mcp_cmd_flags(config.name, mcp_servers or [])
 
     mcp_names = [s.name for s in (mcp_servers or [])]

--- a/tests/e2e/test_mcp_enforcement.py
+++ b/tests/e2e/test_mcp_enforcement.py
@@ -42,6 +42,7 @@ MCP_DANGEROUS_SENTINEL = "SHOULD_NOT_BE_CALLED"
 RUNTIME_MCP_TOOL_NAMES = {
     "claude":       f"mcp__{MCP_TEST_SERVER_NAME}__{MCP_TEST_TOOL_NAME}",
     "claude-oauth": f"mcp__{MCP_TEST_SERVER_NAME}__{MCP_TEST_TOOL_NAME}",
+    "codex":        f"mcp__{MCP_TEST_SERVER_NAME}__{MCP_TEST_TOOL_NAME}",
 }
 
 PROMPT_INVOKE = (
@@ -77,16 +78,38 @@ def _parse_claude_mcp_tool_names(events: list[dict]) -> list[str]:
     return names
 
 
+def _parse_codex_mcp_tool_names(events: list[dict]) -> list[str]:
+    names: list[str] = []
+    for e in events:
+        if e.get("type") != "output":
+            continue
+        try:
+            obj = json.loads(e.get("data", ""))
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if obj.get("type") in ("item.started", "item.completed"):
+            item = obj.get("item", {})
+            if item.get("type") == "mcp_tool_call":
+                server = item.get("server", "")
+                tool = item.get("tool", "")
+                names.append(f"mcp__{server}__{tool}")
+    return names
+
+
 def _mcp_tool_was_invoked(events: list[dict], runtime: str) -> bool:
     target = RUNTIME_MCP_TOOL_NAMES[runtime]
     if runtime in ("claude", "claude-oauth"):
         return target in _parse_claude_mcp_tool_names(events)
+    if runtime == "codex":
+        return target in _parse_codex_mcp_tool_names(events)
     return False
 
 
 def _any_mcp_tool_was_invoked(events: list[dict], runtime: str) -> bool:
     if runtime in ("claude", "claude-oauth"):
         return bool(_parse_claude_mcp_tool_names(events))
+    if runtime == "codex":
+        return bool(_parse_codex_mcp_tool_names(events))
     return False
 
 
@@ -134,7 +157,7 @@ def mcp_test_url(fairy_url):
     return f"{fairy_url.rstrip('/')}/test-mcp"
 
 
-@pytest.fixture(scope="class", params=["claude"])
+@pytest.fixture(scope="class", params=["claude", "codex"])
 def runtime(request, e2e_runtimes):
     if request.param not in e2e_runtimes:
         pytest.skip(f"{request.param} not in E2E_RUNTIMES")

--- a/tests/test_tools_mcp.py
+++ b/tests/test_tools_mcp.py
@@ -1160,3 +1160,67 @@ class TestMcpToolsetValidation:
         )
         assert resp.status_code == 422
         assert "gh" in str(resp.json()["detail"])
+# --- Codex MCP toolset rules emission ---
+
+
+class TestCodexMcpToolsetRules:
+    def _script(self, tools, servers):
+        return build_wrapper_script(
+            RUNTIMES["codex"], "k", "p", mcp_servers=servers, tools=tools,
+        )
+
+    def test_no_rules_no_tool_keys_in_server_block(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        tools = []
+        script = self._script(tools, servers)
+        assert "[mcp_servers.gh]" in script
+        assert "enabled_tools" not in script
+        assert "disabled_tools" not in script
+        assert "enabled = false" not in script
+
+    def test_default_disabled_no_configs_emits_enabled_false(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "gh",
+            "default_config": {"enabled": False},
+        }]
+        script = self._script(tools, servers)
+        assert "enabled = false" in script
+
+    def test_per_tool_deny_emits_disabled_tools(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "gh",
+            "configs": [{"name": "create_issue", "enabled": False}],
+        }]
+        script = self._script(tools, servers)
+        assert 'disabled_tools = ["create_issue"]' in script
+        assert "enabled = false" not in script
+
+    def test_default_disabled_with_allow_emits_enabled_tools(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "gh",
+            "default_config": {"enabled": False},
+            "configs": [{"name": "list_issues", "enabled": True}],
+        }]
+        script = self._script(tools, servers)
+        assert 'enabled_tools = ["list_issues"]' in script
+
+    def test_rules_for_other_server_do_not_leak(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "linear",  # validated away by view layer, ignored here
+            "default_config": {"enabled": False},
+        }]
+        script = self._script(tools, servers)
+        server_block = script.split("[mcp_servers.gh]")[1].split("MCP_EOF")[0]
+        assert "enabled = false" not in server_block
+
+
+# --- Gemini MCP toolset rules emission ---
+


### PR DESCRIPTION
## Summary

Stacked on #10. Adds codex MCP enforcement — folded into the same
`~/.codex/config.toml` block that already carries the per-server MCP
config (built in 5b for tool flags; reused here for mcp_toolset rules).

## Changes

- `_build_mcp_codex(..., rules=...)` emits per-server keys:
  - `enabled = false` (deny entire server, no per-tool overrides)
  - `enabled_tools = [...]` (default-disabled + allow-specific)
  - `disabled_tools = [...]` (default-allow + deny-specific)
- `_build_mcp_section` threads `rules` through for codex. Claude unchanged,
  gemini still ignores rules until 6c.
- 5 unit tests in `TestCodexMcpToolsetRules` including a "rules for
  another server don't leak into this server's block" guard.
- e2e fixture widened to claude+codex; codex `mcp_tool_call` parser added.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 227 unit tests pass (+5 from 6a)
- [ ] `FAIRY_API_TOKEN=<t> E2E_RUNTIMES=claude,codex make test-e2e-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)