### PR TITLE
Enforce mcp_toolset: gemini MCP

### DIFF
--- a/src/fairy/sprites_exec.py
+++ b/src/fairy/sprites_exec.py
@@ -152,8 +152,16 @@ def _build_clone_section(repos: list[RepoSpec]) -> str:
     return "\n".join(lines)
 
 
-def _build_mcp_claude(servers: list[McpServerSpec]) -> str:
-    """Generate Claude MCP config JSON and write command."""
+def _build_mcp_claude(
+    servers: list[McpServerSpec],
+    rules: dict[str, McpToolsetRules] | None = None,  # noqa: ARG001 — read by _tool_files_claude_mcp
+) -> str:
+    """Generate Claude MCP config JSON and write command.
+
+    The rules parameter is threaded through for signature parity with codex/gemini,
+    but Claude applies MCP allow/deny via a separate `~/.claude/settings.json`
+    writer (`_tool_files_claude_mcp`), not inside this file.
+    """
     config: dict[str, dict] = {}
     for s in servers:
         if s.type == "url":
@@ -260,20 +268,46 @@ def _build_mcp_codex(
     return "\n".join(lines)
 
 
-def _build_mcp_gemini(servers: list[McpServerSpec]) -> str:
-    """Generate Gemini MCP config JSON and write command."""
+def _build_mcp_gemini(
+    servers: list[McpServerSpec],
+    rules: dict[str, McpToolsetRules] | None = None,
+) -> str:
+    """Generate Gemini MCP config JSON and write command.
+
+    MCP tool allow/deny is emitted as includeTools/excludeTools on each mcpServers
+    entry — not via the Policy Engine TOML that `_tool_files_gemini` writes for
+    built-in tools. Policy Engine uses single-underscore `mcp_{server}_{tool}`
+    naming which misparses server aliases containing underscores, so we keep MCP
+    rules localized to the settings.json file that this function already writes.
+    """
+    rules = rules or {}
     config: dict[str, dict] = {}
     for s in servers:
         if s.type == "url":
             entry: dict = {"httpUrl": s.url, "trust": True}
             if s.headers:
                 entry["headers"] = s.headers
-            config[s.name] = entry
         elif s.type == "stdio":
             entry = {"command": s.command, "args": s.args, "trust": True}
             if s.env:
                 entry["env"] = s.env
-            config[s.name] = entry
+        else:
+            continue
+
+        server_rules = rules.get(s.name)
+        if server_rules is not None:
+            if not server_rules.default_enabled and not server_rules.per_tool:
+                entry["includeTools"] = []
+            else:
+                allowed = [t for t, e in server_rules.per_tool.items() if e]
+                denied = [t for t, e in server_rules.per_tool.items() if not e]
+                if not server_rules.default_enabled and allowed:
+                    entry["includeTools"] = allowed
+                if denied:
+                    entry["excludeTools"] = denied
+
+        config[s.name] = entry
+
     content = json.dumps({"mcpServers": config}, indent=2)
     return (
         "# MCP server configuration\n"
@@ -295,17 +329,17 @@ def _build_mcp_section(
     so `tools` is threaded through here. Other runtimes emit tool enforcement via
     the separate `_tool_files_*` path.
 
-    `rules` carries per-server mcp_toolset allow/deny. Codex consumes it inside
-    its MCP config; claude consumes it via `_tool_files_claude_mcp`.
+    `rules` carries per-server mcp_toolset allow/deny. Codex and gemini consume it
+    inside their MCP config; claude consumes it via `_tool_files_claude_mcp`.
     """
     if runtime_name == "codex":
         return _build_mcp_codex(servers, tools=tools, rules=rules)
     if not servers:
         return ""
     if runtime_name in ("claude", "claude-oauth"):
-        return _build_mcp_claude(servers)
+        return _build_mcp_claude(servers, rules=rules)
     if runtime_name == "gemini":
-        return _build_mcp_gemini(servers)
+        return _build_mcp_gemini(servers, rules=rules)
     return ""
 
 

--- a/tests/e2e/test_mcp_enforcement.py
+++ b/tests/e2e/test_mcp_enforcement.py
@@ -43,6 +43,7 @@ RUNTIME_MCP_TOOL_NAMES = {
     "claude":       f"mcp__{MCP_TEST_SERVER_NAME}__{MCP_TEST_TOOL_NAME}",
     "claude-oauth": f"mcp__{MCP_TEST_SERVER_NAME}__{MCP_TEST_TOOL_NAME}",
     "codex":        f"mcp__{MCP_TEST_SERVER_NAME}__{MCP_TEST_TOOL_NAME}",
+    "gemini":       f"mcp__{MCP_TEST_SERVER_NAME}__{MCP_TEST_TOOL_NAME}",
 }
 
 PROMPT_INVOKE = (
@@ -96,12 +97,30 @@ def _parse_codex_mcp_tool_names(events: list[dict]) -> list[str]:
     return names
 
 
+def _parse_gemini_mcp_tool_names(events: list[dict]) -> list[str]:
+    names: list[str] = []
+    for e in events:
+        if e.get("type") != "output":
+            continue
+        try:
+            obj = json.loads(e.get("data", ""))
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if obj.get("type") == "tool_use":
+            name = obj.get("tool_name") or obj.get("name") or ""
+            if name.startswith("mcp__"):
+                names.append(name)
+    return names
+
+
 def _mcp_tool_was_invoked(events: list[dict], runtime: str) -> bool:
     target = RUNTIME_MCP_TOOL_NAMES[runtime]
     if runtime in ("claude", "claude-oauth"):
         return target in _parse_claude_mcp_tool_names(events)
     if runtime == "codex":
         return target in _parse_codex_mcp_tool_names(events)
+    if runtime == "gemini":
+        return target in _parse_gemini_mcp_tool_names(events)
     return False
 
 
@@ -110,6 +129,8 @@ def _any_mcp_tool_was_invoked(events: list[dict], runtime: str) -> bool:
         return bool(_parse_claude_mcp_tool_names(events))
     if runtime == "codex":
         return bool(_parse_codex_mcp_tool_names(events))
+    if runtime == "gemini":
+        return bool(_parse_gemini_mcp_tool_names(events))
     return False
 
 
@@ -157,7 +178,7 @@ def mcp_test_url(fairy_url):
     return f"{fairy_url.rstrip('/')}/test-mcp"
 
 
-@pytest.fixture(scope="class", params=["claude", "codex"])
+@pytest.fixture(scope="class", params=["claude", "codex", "gemini"])
 def runtime(request, e2e_runtimes):
     if request.param not in e2e_runtimes:
         pytest.skip(f"{request.param} not in E2E_RUNTIMES")

--- a/tests/test_tools_mcp.py
+++ b/tests/test_tools_mcp.py
@@ -1224,3 +1224,73 @@ class TestCodexMcpToolsetRules:
 
 # --- Gemini MCP toolset rules emission ---
 
+# --- Gemini MCP toolset rules emission ---
+
+
+class TestGeminiMcpToolsetRules:
+    def _config(self, tools, servers):
+        script = build_wrapper_script(
+            RUNTIMES["gemini"], "k", "p", mcp_servers=servers, tools=tools,
+        )
+        # Extract the heredoc body between `<< 'MCP_EOF'\n` and `\nMCP_EOF`
+        start = script.index("cat > ~/.gemini/settings.json << 'MCP_EOF'\n") + len(
+            "cat > ~/.gemini/settings.json << 'MCP_EOF'\n"
+        )
+        end = script.index("\nMCP_EOF\n", start)
+        return json.loads(script[start:end])
+
+    def test_no_rules_no_include_exclude(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        cfg = self._config([], servers)
+        assert cfg["mcpServers"]["gh"]["httpUrl"] == "https://mcp.gh/mcp"
+        assert "includeTools" not in cfg["mcpServers"]["gh"]
+        assert "excludeTools" not in cfg["mcpServers"]["gh"]
+
+    def test_default_disabled_no_configs_emits_empty_include_tools(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "gh",
+            "default_config": {"enabled": False},
+        }]
+        cfg = self._config(tools, servers)
+        assert cfg["mcpServers"]["gh"]["includeTools"] == []
+
+    def test_per_tool_deny_emits_exclude_tools(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "gh",
+            "configs": [{"name": "create_issue", "enabled": False}],
+        }]
+        cfg = self._config(tools, servers)
+        assert cfg["mcpServers"]["gh"]["excludeTools"] == ["create_issue"]
+        assert "includeTools" not in cfg["mcpServers"]["gh"]
+
+    def test_default_disabled_with_allow_emits_include_tools(self):
+        servers = [McpServerSpec(name="gh", type="url", url="https://mcp.gh/mcp")]
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "gh",
+            "default_config": {"enabled": False},
+            "configs": [{"name": "list_issues", "enabled": True}],
+        }]
+        cfg = self._config(tools, servers)
+        assert cfg["mcpServers"]["gh"]["includeTools"] == ["list_issues"]
+
+    def test_rules_coexist_with_trust_and_headers(self):
+        servers = [McpServerSpec(
+            name="gh", type="url", url="https://mcp.gh/mcp",
+            headers={"Authorization": "Bearer x"},
+        )]
+        tools = [{
+            "type": "mcp_toolset",
+            "mcp_server_name": "gh",
+            "configs": [{"name": "create_issue", "enabled": False}],
+        }]
+        cfg = self._config(tools, servers)
+        entry = cfg["mcpServers"]["gh"]
+        assert entry["trust"] is True
+        assert entry["headers"] == {"Authorization": "Bearer x"}
+        assert entry["excludeTools"] == ["create_issue"]
+


### PR DESCRIPTION
## Summary

Stacked on #11. Final PR of the MCP enforcement chain. Lands gemini MCP
allow/deny via `includeTools`/`excludeTools` in
`~/.gemini/settings.json`.

## Changes

- `_build_mcp_gemini(..., rules=...)` per-server keys:
  - `includeTools = []` (deny entire server)
  - `includeTools = [...]` (default-disabled + allow specific)
  - `excludeTools = [...]` (default-allow + deny specific)
- `_build_mcp_claude` also gains `rules=` (unused in the function; the
  actual claude enforcement is via the separate settings.json file written
  by `_tool_files_claude_mcp`). Just for signature parity.
- Policy Engine intentionally **not** used for MCP — its single-underscore
  naming `mcp_{server}_{tool}` misparses server aliases containing
  underscores. Keeping MCP allow/deny localized to settings.json avoids it.
- 5 gemini unit tests including a "rules coexist with `trust` and
  `headers` in the same entry" guard.
- e2e fixture now parametrizes claude+codex+gemini.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 232 unit tests pass (matches original #6 total)
- [ ] `FAIRY_API_TOKEN=<t> E2E_RUNTIMES=claude,codex,gemini make test-e2e-mcp`
- [ ] `make test-e2e-tools` still green (stack compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)