### PR TITLE
Write Claude MCP config to ~/.claude.json (auto-discovered, no flags)

### DIFF
--- a/src/agent_on_demand/session_service/dispatcher.py
+++ b/src/agent_on_demand/session_service/dispatcher.py
@@ -1,4 +1,4 @@
-"""Render the tiny /run-agent.sh dispatcher and compute per-runtime MCP CLI flags."""
+"""Render the tiny /run-agent.sh dispatcher."""
 
 from __future__ import annotations
 
@@ -12,16 +12,7 @@ RUN_SCRIPT_PATH = "/run-agent.sh"
 _TEMPLATE_PATH = Path(__file__).parent / "run_agent.sh.tmpl"
 
 
-def mcp_cmd_flags(runtime_name: str, has_mcp: bool) -> str:
-    """Return extra CLI flags needed for MCP (only Claude needs explicit flags)."""
-    if not has_mcp:
-        return ""
-    if runtime_name in ("claude", "claude-oauth"):
-        return " --mcp-config /tmp/mcp.json --strict-mcp-config"
-    return ""
-
-
-def render_dispatcher_script(runtime: RuntimeConfig, *, has_mcp: bool) -> str:
+def render_dispatcher_script(runtime: RuntimeConfig) -> str:
     """Render the tiny per-turn dispatcher script.
 
     The dispatcher does no setup work — all provisioning happens inline during
@@ -29,10 +20,9 @@ def render_dispatcher_script(runtime: RuntimeConfig, *, has_mcp: bool) -> str:
     and execs the runtime CLI with the right continuation flags.
     """
     template = _TEMPLATE_PATH.read_text()
-    flags = mcp_cmd_flags(runtime.name, has_mcp)
     replacements = {
-        "@@RUN_CMD@@": f"{runtime.cmd}{flags}",
-        "@@CONTINUE_CMD@@": f"{runtime.continue_cmd}{flags}",
+        "@@RUN_CMD@@": runtime.cmd,
+        "@@CONTINUE_CMD@@": runtime.continue_cmd,
     }
     for token, value in replacements.items():
         template = template.replace(token, value)

--- a/src/agent_on_demand/session_service/provisioning.py
+++ b/src/agent_on_demand/session_service/provisioning.py
@@ -234,7 +234,7 @@ def _write_mcp_claude(sprite: Sprite, servers: list[McpServerSpec]) -> None:
                 entry["env"] = s.env
             config[s.name] = entry
     fs = sprite.filesystem()
-    (fs / "tmp/mcp.json").write_text(json.dumps({"mcpServers": config}, indent=2))
+    (fs / "home/sprite/.claude.json").write_text(json.dumps({"mcpServers": config}, indent=2))
 
 
 def _write_mcp_codex(sprite: Sprite, servers: list[McpServerSpec]) -> None:
@@ -301,7 +301,7 @@ def _write_skills(sprite: Sprite, runtime_name: str, skills: list[SkillSpec]) ->
 
 
 def _write_run_script(sprite: Sprite, spec: SessionSpec) -> None:
-    script = render_dispatcher_script(spec.runtime, has_mcp=bool(spec.mcp_servers))
+    script = render_dispatcher_script(spec.runtime)
     try:
         fs = sprite.filesystem()
         (fs / RUN_SCRIPT_PATH.lstrip("/")).write_text(script)

--- a/tests/e2e/test_mcp.py
+++ b/tests/e2e/test_mcp.py
@@ -177,11 +177,11 @@ class TestMcpPersistsAcrossTurns:
     """Regression: MCP config must be re-emitted on every /prompt turn.
 
     Prior to the fix, ``send_prompt`` rebuilt ``run-agent.sh`` without passing
-    ``mcp_servers``. The resulting script neither regenerated ``/tmp/mcp.json``
-    nor appended ``--mcp-config --strict-mcp-config`` to the agent CLI, so MCP
-    tools disappeared on every turn after the first. This test calls the MCP
-    echo tool twice in the same session — once on create, once via
-    ``send_prompt`` — with different signals, and asserts both fire.
+    ``mcp_servers``. The resulting script never wrote the per-runtime MCP
+    config file (e.g. ``~/.claude.json``), so MCP tools disappeared on every
+    turn after the first. This test calls the MCP echo tool twice in the same
+    session — once on create, once via ``send_prompt`` — with different
+    signals, and asserts both fire.
     """
 
     def test_mcp_tool_invocable_on_second_turn(

--- a/tests/test_runtimes.py
+++ b/tests/test_runtimes.py
@@ -1,5 +1,5 @@
 from agent_on_demand.runtimes import RUNTIMES
-from agent_on_demand.session_service.dispatcher import mcp_cmd_flags, render_dispatcher_script
+from agent_on_demand.session_service.dispatcher import render_dispatcher_script
 
 
 def test_all_runtimes_defined():
@@ -11,7 +11,7 @@ def test_dispatcher_reads_prompt_from_stdin():
     never touches the Sprite filesystem and never leaks into WS URL query
     params (which is what env= / argv would do)."""
     config = RUNTIMES["claude"]
-    script = render_dispatcher_script(config, has_mcp=False)
+    script = render_dispatcher_script(config)
     assert "PROMPT=$(cat)" in script
     assert "/tmp/aod-prompt.txt" not in script
     assert '"$PROMPT"' in script
@@ -22,7 +22,7 @@ def test_dispatcher_sources_env_file():
     key and AOD_SESSION_ID are exported at exec time without being baked into
     the script body."""
     config = RUNTIMES["claude"]
-    script = render_dispatcher_script(config, has_mcp=False)
+    script = render_dispatcher_script(config)
     assert "source /tmp/aod-env" in script
     assert "set -a" in script
     # API key env-var name never appears in the dispatcher — it only lives
@@ -34,7 +34,7 @@ def test_dispatcher_has_no_setup_sections():
     """All setup (packages, clone, MCP, skills) ran during provision_session.
     The dispatcher does not re-do any of it, and it carries no sentinel."""
     config = RUNTIMES["claude"]
-    script = render_dispatcher_script(config, has_mcp=True)
+    script = render_dispatcher_script(config)
     assert "apt-get" not in script
     assert "pip install" not in script
     assert "git clone" not in script
@@ -47,7 +47,7 @@ def test_dispatcher_has_no_setup_sections():
 def test_dispatcher_dispatches_by_mode():
     """Dispatcher takes $1 = run|continue so the same script serves every turn."""
     config = RUNTIMES["claude"]
-    script = render_dispatcher_script(config, has_mcp=False)
+    script = render_dispatcher_script(config)
     assert 'MODE="${1:-run}"' in script
     assert 'case "$MODE" in' in script
     assert config.cmd in script
@@ -73,28 +73,17 @@ def test_dispatcher_emits_structured_failure_marker():
     command in the dispatcher fails under `set -e`. This is what operators
     grep for when the runtime CLI blows up mid-turn."""
     config = RUNTIMES["claude"]
-    script = render_dispatcher_script(config, has_mcp=False)
+    script = render_dispatcher_script(config)
     assert "trap '__aod_on_err" in script
     assert "AOD_STAGE_FAILED" in script
     assert "set -Eeuo pipefail" in script
 
 
-def test_mcp_cmd_flags_only_for_claude():
-    assert mcp_cmd_flags("claude", has_mcp=True).startswith(" --mcp-config")
-    assert mcp_cmd_flags("claude-oauth", has_mcp=True).startswith(" --mcp-config")
-    assert mcp_cmd_flags("codex", has_mcp=True) == ""
-    assert mcp_cmd_flags("gemini", has_mcp=True) == ""
-    assert mcp_cmd_flags("claude", has_mcp=False) == ""
-
-
-def test_mcp_flags_appear_in_dispatcher_when_has_mcp():
-    config = RUNTIMES["claude"]
-    script = render_dispatcher_script(config, has_mcp=True)
-    assert "--mcp-config /tmp/mcp.json" in script
-    assert "--strict-mcp-config" in script
-
-
-def test_no_mcp_flags_when_has_mcp_false():
-    config = RUNTIMES["claude"]
-    script = render_dispatcher_script(config, has_mcp=False)
-    assert "--mcp-config" not in script
+def test_dispatcher_carries_no_mcp_flags():
+    """MCP config is auto-discovered from each runtime's default path
+    (Claude → ~/.claude.json, Codex → ~/.codex/config.toml, Gemini →
+    ~/.gemini/settings.json), so the dispatcher needs no --mcp-config flags."""
+    for config in RUNTIMES.values():
+        script = render_dispatcher_script(config)
+        assert "--mcp-config" not in script
+        assert "--strict-mcp-config" not in script

--- a/tests/test_tools_mcp.py
+++ b/tests/test_tools_mcp.py
@@ -47,12 +47,12 @@ def runtime_key(user, sprites_key):
 
 
 def _mcp_json(sprite) -> dict:
-    return json.loads(sprite.write_map()["/tmp/mcp.json"])
+    return json.loads(sprite.write_map()["/home/sprite/.claude.json"])
 
 
 @pytest.mark.django_db
 class TestSessionMcpIntegration:
-    def test_claude_mcp_url_server_writes_json_and_flags(
+    def test_claude_mcp_url_server_writes_json(
         self, client: Client, auth_headers, runtime_key, user, fake_sprites
     ):
         agent = Agent.objects.create(
@@ -77,10 +77,9 @@ class TestSessionMcpIntegration:
         assert cfg == {
             "mcpServers": {"github": {"type": "http", "url": "https://mcp.github.com/mcp"}}
         }
-        # The dispatcher script picks up --mcp-config flags
         run_script = sprite.write_map()["/run-agent.sh"]
-        assert "--mcp-config /tmp/mcp.json" in run_script
-        assert "--strict-mcp-config" in run_script
+        assert "--mcp-config" not in run_script
+        assert "--strict-mcp-config" not in run_script
 
     def test_claude_mcp_with_headers(
         self, client: Client, auth_headers, runtime_key, user, fake_sprites
@@ -166,7 +165,7 @@ class TestSessionMcpIntegration:
         toml = sprite.write_map()["/home/sprite/.codex/config.toml"]
         assert "[mcp_servers.github]" in toml
         assert 'url = "https://mcp.github.com/mcp"' in toml
-        # Codex does NOT get --mcp-config CLI flags
+        # MCP is auto-discovered from ~/.codex/config.toml — no CLI flags.
         run_script = sprite.write_map()["/run-agent.sh"]
         assert "--mcp-config" not in run_script
 
@@ -248,7 +247,7 @@ class TestSessionMcpIntegration:
         )
         assert resp.status_code == 202
         writes = fake_sprites.last_sprite().write_map()
-        assert "/tmp/mcp.json" not in writes
+        assert "/home/sprite/.claude.json" not in writes
         run_script = writes["/run-agent.sh"]
         assert "--mcp-config" not in run_script
 


### PR DESCRIPTION
## Summary

- Write Claude's MCP config to `/home/sprite/.claude.json` instead of `/tmp/mcp.json`. Claude auto-discovers it from there, same as Codex (`~/.codex/config.toml`) and Gemini (`~/.gemini/settings.json`).
- Drop `--mcp-config /tmp/mcp.json --strict-mcp-config` from the dispatcher. With the file at the default path, the flags are redundant.
- Remove `mcp_cmd_flags` and the `has_mcp` parameter on `render_dispatcher_script` — no callers left.

We own the whole Sprite environment, so the original reasons for `--strict-mcp-config` (defense against stale `~/.claude.json` from the host) don't apply.

## Test plan

- [x] `make test` — 201 pass
- [x] `make lint` — clean
- [ ] `make test-e2e-fast` against a deployed branch (touches MCP config write path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)