### PR TITLE
Fix three latent bugs in the session-execution threading path

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -15,7 +15,14 @@ projects:
             plan: starter
             buildCommand: pip install uv && uv sync && uv run python manage.py collectstatic --noinput
             preDeployCommand: uv run python manage.py migrate --noinput
-            startCommand: uv run gunicorn config.wsgi:application --bind 0.0.0.0:$PORT
+            startCommand: >-
+              uv run gunicorn config.wsgi:application
+              --bind 0.0.0.0:$PORT
+              --workers 3
+              --graceful-timeout 650
+              --timeout 700
+              --max-requests 1000
+              --max-requests-jitter 50
             healthCheckPath: /health
             envVars:
               - key: DATABASE_URL

--- a/src/agent_on_demand/stream.py
+++ b/src/agent_on_demand/stream.py
@@ -6,6 +6,7 @@ import threading
 import time
 from collections.abc import Generator
 
+from django.db import close_old_connections
 from django.utils import timezone
 from sprites import ExecError, Sprite
 
@@ -78,7 +79,28 @@ def run_session_background(
     streams over the Sprites WS stdin frame; the runtime-CLI invocation is
     assembled inline per turn (no on-Sprite dispatcher script). Logs are
     tagged with the turn so consumers can replay per-turn.
+
+    Django's per-request DB-connection lifecycle doesn't apply here since this
+    runs in a daemon thread spawned outside the request cycle; we call
+    `close_old_connections()` on entry and exit so a turn's DB writes don't
+    hold a connection for the worker's full lifetime.
     """
+    close_old_connections()
+    try:
+        _run_session_background_inner(session, turn, sprite, runtime, prompt, mode, timeout)
+    finally:
+        close_old_connections()
+
+
+def _run_session_background_inner(
+    session: AgentSession,
+    turn: SessionTurn,
+    sprite: Sprite,
+    runtime: RuntimeConfig,
+    prompt: str,
+    mode: str,
+    timeout: float,
+):
     output_q: queue.Queue = queue.Queue(maxsize=4096)
     db_buffer: list[AgentSessionLog] = []
     result_holder: list = []
@@ -89,6 +111,8 @@ def run_session_background(
             db_buffer.clear()
 
     def _run_command():
+        # NOTE: if you add DB writes inside this inner thread, wrap the body
+        # in close_old_connections()/finally the same way the outer thread does.
         try:
             cmd = sprite.command(
                 "bash",

--- a/src/agent_on_demand/views/sessions.py
+++ b/src/agent_on_demand/views/sessions.py
@@ -371,6 +371,15 @@ def send_prompt(request, session_id):
     if session.status == "terminated":
         return JsonResponse({"detail": "Session has been terminated"}, status=409)
 
+    # A `failed` session may have left its Sprite mid-execution (see Muddy
+    # Zone 8 in thoughts/research/2026-04-18-sprites-script-setup.md). Making
+    # `failed` terminal prevents a resume from colliding with a runaway turn.
+    if session.status == "failed":
+        return JsonResponse(
+            {"detail": "Session has failed and cannot be resumed. Start a new session."},
+            status=409,
+        )
+
     try:
         body = json.loads(request.body)
     except (json.JSONDecodeError, ValueError):
@@ -398,6 +407,11 @@ def send_prompt(request, session_id):
                 return JsonResponse({"detail": "Session is already running"}, status=409)
             if locked.status == "terminated":
                 return JsonResponse({"detail": "Session has been terminated"}, status=409)
+            if locked.status == "failed":
+                return JsonResponse(
+                    {"detail": ("Session has failed and cannot be resumed. Start a new session.")},
+                    status=409,
+                )
 
             next_turn_number = (
                 SessionTurn.objects.filter(session=locked).aggregate(n=Max("turn_number"))["n"] or 0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -624,6 +624,29 @@ def test_send_prompt_to_terminated_session(client: Client, auth_headers, user):
 
 
 @pytest.mark.django_db
+def test_send_prompt_to_failed_session_rejected(client: Client, auth_headers, user):
+    """Failed sessions are terminal: the underlying Sprite may still be running
+    (see Muddy Zone 8). Resuming would risk two concurrent executions on the
+    same Sprite, so we force callers to start a new session instead."""
+    session = AgentSession.objects.create(
+        user=user,
+        runtime="claude",
+        prompt="test",
+        sprite_name="sprite-xyz",
+        status="failed",
+        exit_code=1,
+    )
+    resp = client.post(
+        f"/sessions/{session.id}/prompt",
+        data=json.dumps({"prompt": "retry"}),
+        content_type="application/json",
+        **auth_headers,
+    )
+    assert resp.status_code == 409
+    assert "failed" in resp.json()["detail"].lower()
+
+
+@pytest.mark.django_db
 def test_run_session_background_persists_int_exit_code_on_exec_error(user, mocker):
     """Regression: ExecError.exit_code is a method, not a property. The
     background runner must call it before storing on `session.exit_code`,
@@ -671,6 +694,39 @@ def test_run_session_background_persists_int_exit_code_on_exec_error(user, mocke
     assert turn.status == "failed"
     assert turn.exit_code == 1
     assert turn.ended_at is not None
+
+
+@pytest.mark.django_db
+def test_run_session_background_closes_db_connections(user, mocker):
+    """Django's per-request DB-connection lifecycle doesn't apply to threads
+    spawned outside the request cycle. We call close_old_connections() on
+    entry and exit so a turn's DB writes don't hold a connection for the
+    worker's full lifetime."""
+    from sprites import ExecError
+
+    from agent_on_demand.models import SessionTurn
+    from agent_on_demand.runtimes import RUNTIMES
+
+    session = AgentSession.objects.create(user=user, runtime="claude", prompt="t", status="pending")
+    turn = SessionTurn.objects.create(session=session, turn_number=1, prompt="t", status="pending")
+
+    mock_sprite = mocker.MagicMock()
+    mock_cmd = mocker.MagicMock()
+    mock_cmd.run.side_effect = ExecError("exit status 0", exit_code=0)
+    mock_sprite.command.return_value = mock_cmd
+
+    close_spy = mocker.patch("agent_on_demand.stream.close_old_connections")
+
+    # Re-import after patching so the module uses the spy.
+    from agent_on_demand.stream import run_session_background
+
+    run_session_background(
+        session, turn, mock_sprite, RUNTIMES["claude"], "hi", "run", timeout=10.0
+    )
+
+    # At minimum: called at entry and at exit (finally). >= 2 is defensive —
+    # if the code inadvertently calls it an extra time elsewhere, still fine.
+    assert close_spy.call_count >= 2
 
 
 @pytest.mark.django_db

--- a/thoughts/plans/2026-04-19-threading-architecture-decision.md
+++ b/thoughts/plans/2026-04-19-threading-architecture-decision.md
@@ -1,0 +1,170 @@
+# Threading Architecture — Decision Plan
+
+## What this document is
+
+This is a **decision plan**, not an implementation plan. Its job is to surface the real contenders for how session execution should work, call out what makes them differ, and identify the small number of open questions whose answers determine the pick. Once we land on a direction, a separate implementation plan follows.
+
+The research behind this is [`thoughts/research/2026-04-19-threading-in-web-server.md`](/thoughts/research/2026-04-19-threading-in-web-server.md). The baseline bug-fix work (which must land first) is [`thoughts/plans/2026-04-19-threading-bug-fixes.md`](/thoughts/plans/2026-04-19-threading-bug-fixes.md).
+
+## The problem we're solving
+
+Today, every turn spawns **two nested daemon threads** inside the Gunicorn worker process. This has three structural consequences that the bug-fix plan does not address:
+
+1. **No durability across deploys.** Daemon threads die with the worker. Even with a 650 s graceful timeout, every deploy during an in-flight turn is a gamble.
+2. **Capacity cap = 3 concurrent streaming sessions.** Render starter → 3 sync Gunicorn workers, and the SSE endpoint pins a worker for the turn's full duration via `time.sleep(0.5)` polling. Execution threads are a separate concurrency axis; the SSE pin is independent.
+3. **Thread lifecycle is load-bearing but invisible.** The state machine in `run_session_background` is never tested — every unit test mocks `threading.Thread`. What actually happens on a thread panic, a queue overflow, or a shutdown mid-drain is documented only by inspection of the code.
+
+The user's original framing — *"maybe consider not needing to spawn them"* — is the right reframe. This document evaluates **three contenders**, only one of which keeps the "spawn a background thread per turn" pattern.
+
+## Contenders
+
+### Contender A — Keep threads, tame them
+*"Bounded `ThreadPoolExecutor` + `gthread` Gunicorn workers + cancel-via-future."*
+
+**What changes:**
+- `session_service/turn.py`: replace the bare `threading.Thread(daemon=True)` spawn with a module-level `ThreadPoolExecutor(max_workers=N)`. Wire `shutdown(wait=True, cancel_futures=False)` to `atexit` + Django's `request_finished`.
+- `render.yaml`: add `--worker-class=gthread --threads=8` to the Gunicorn invocation. SSE endpoints no longer pin an entire worker process.
+- `stream.py`: the inner `cmd_thread` stays, but pass a `threading.Event` into it. On outer-thread join timeout, set the event and call `future.cancel()` on the SDK's internal asyncio future (which is accessible via `cmd._future` or similar — needs a small spike on the Sprites SDK to confirm).
+- The `run_session_background` shape stays — same queue drain, same DB writes, same SSE replay pattern.
+
+**What it buys:**
+- Bounded capacity (no more unlimited daemon spawning).
+- Deterministic shutdown semantics.
+- SSE concurrency = workers × threads instead of workers.
+- Actual cancellation of runaway turns.
+
+**What it doesn't fix:**
+- Deploys still kill in-flight turns. `graceful-timeout` helps but is ultimately bounded by Render's platform SIGKILL window.
+- Still two nested threads per turn, just accounted for.
+- Turn state reconciliation (what happens to a turn whose worker died mid-flight?) is still "nothing — the row stays `running` forever."
+
+**Cost:**
+- Small code change (~50 lines touched), no new dependencies, no new Render services.
+- One real operational thing to understand: `gthread` workers use the GIL differently and have slightly different memory behavior. Not a hazard, just a knob change.
+
+**Time estimate:** 1–2 days of focused work.
+
+---
+
+### Contender B — Don't spawn threads at all
+*"Streaming POST response; turn runs inline on the HTTP thread via gthread workers."*
+
+**What changes:**
+- `POST /sessions` stops returning 202. Instead, it returns `200 OK` with `Content-Type: text/event-stream` and streams the turn's output directly on the response body. The request handler *is* the runner — no background thread.
+- The SDK call (`sprite.command(...).run()`) runs on the Gunicorn worker thread. With `--worker-class=gthread --threads=8`, a single worker can hold 8 concurrent turns.
+- The inner `_run_command` thread goes away entirely — the SDK's own event loop thread (which already exists in `sprites.loop`) does the WebSocket work; the Gunicorn thread blocks waiting for it via `asyncio.run_coroutine_threadsafe().result()`, which is what `cmd.run()` already does.
+- `run_session_background` is deleted. `TaggingQueueWriter` hooks into the HTTP response stream instead of an internal queue.
+- `GET /sessions/{id}/stream` still exists but becomes *replay-only* — tails `AgentSessionLog` for observers who missed the live stream.
+- `POST /sessions/{id}/prompt` (continue turns) works the same way — streams directly in the response.
+- DB writes still happen during the turn (per-log-chunk inserts + state transitions), but from the request handler thread, not a daemon thread. No `close_old_connections()` needed because Django's per-request connection lifecycle already handles it.
+
+**What it buys:**
+- **Zero daemon threads in the web process.** The user's stated preference, taken seriously.
+- Simplest possible concurrency model: "one turn per HTTP thread, capacity = workers × threads."
+- No Muddy Zone 8 zombie window — there's no `join(timeout)` to time out. The SDK call either completes or the client disconnects (which kills the worker thread, which kills the SDK call).
+- No state-machine ambiguity. On worker crash, the HTTP connection drops; the client knows; the DB row transition fails naturally.
+- Simpler testing — the state machine is exercised by ordinary request tests.
+
+**What it doesn't fix:**
+- Deploys still kill in-flight turns. Client sees a dropped connection mid-stream; can retry by issuing a new POST.
+- Turn state reconciliation still needs thought — a mid-turn SIGKILL leaves the DB row `running`. Need a reaper or a "mark orphaned on startup" hook.
+
+**Cost:**
+- Meaningful API contract change. POST now blocks for the turn's duration (up to 10 minutes). Any client that expected a 202 with a stream URL needs updating. Internal caller only? External? Need to check.
+- Refactor of `stream.py` and `turn.py` — maybe ~150 lines touched, but most of it is deletion.
+- The streaming-POST pattern is less common than 202+SSE-reconnect; some HTTP proxies have issues with long-lived streaming POST bodies. Render specifically needs to be verified.
+- Reversing direction (going back to background threads) after shipping this is non-trivial.
+
+**Time estimate:** 3–5 days. Refactor + client-side updates + verification of the streaming-POST path through Render's proxy layer.
+
+---
+
+### Contender C — Out-of-process worker
+*"Procrastinate (Postgres broker) + Render Background Worker service."*
+
+**What changes:**
+- New `worker` entry in `render.yaml` pointing at a `procrastinate worker` invocation.
+- `pyproject.toml` gains `procrastinate[django]` (or similar).
+- New Django app / migrations for Procrastinate's task tables in the existing Postgres.
+- `session_service/turn.py`: `run_turn` becomes `task_run_turn.defer(session_id=..., prompt=...)`. Returns immediately. HTTP returns 202 as before.
+- `stream.py` `run_session_background` moves to a Procrastinate task function. Same body, but runs in the worker process.
+- The SSE endpoint stays unchanged — still tails `AgentSessionLog`.
+- On-deploy: the worker service restarts independently of the web service. In-flight tasks survive if Procrastinate's retry/recovery semantics are wired up (they are, built-in).
+
+**What it buys:**
+- **Real durability across deploys.** A web deploy doesn't touch worker state. A worker deploy can drain in-flight tasks gracefully (configurable timeout). Orphaned tasks can be retried.
+- Clean separation: web workers for HTTP, background workers for SDK calls.
+- Natural home for retry logic, DLQ, scheduled cleanup jobs.
+- Capacity is tunable independently of HTTP capacity.
+
+**What it doesn't fix:**
+- SSE saturation on the web side (still need `gthread` or equivalent). That's orthogonal to where execution runs.
+- The fundamental "long-running tasks are hard" operational weight — now there are two services to monitor instead of one.
+
+**Cost:**
+- **New Render Background Worker service** (~$7/mo on starter). Small $ cost but a real ops decision — more surface to monitor, deploy, and debug.
+- New dependency (Procrastinate) with its own version cadence and learning curve.
+- Migration: Procrastinate's schema migration runs against our Postgres. Low risk (it's additive tables), but real.
+- Rollback harder if something goes wrong — the worker becomes load-bearing immediately.
+
+**Time estimate:** 5–8 days. Infrastructure setup + task function port + retry semantics + CHANGELOG.
+
+## Comparison
+
+| Criterion | A: Thread pool + gthread | B: Streaming POST | C: Procrastinate worker |
+|---|---|---|---|
+| Daemon threads in web process | Yes, bounded | **No** | **No** |
+| Survives deploy of web service | No | No | **Yes** |
+| Fixes SSE saturation | Yes (gthread) | Yes (gthread) | Partial (needs gthread still) |
+| Fixes zombie window | Yes (via future.cancel) | **N/A — no join timeout** | **N/A — worker owns lifecycle** |
+| API contract change | No | **Yes — POST blocks** | No |
+| New infra | No | No | **Yes — Render Background Worker** |
+| New dependency | No | No | Procrastinate |
+| Reversible | Cheap | Expensive | Cheap (can re-spawn threads) |
+| Time estimate | 1–2 days | 3–5 days | 5–8 days |
+| Cost | $0 | $0 | ~$7/mo |
+
+## Recommendation (subject to the open questions below)
+
+**First choice: Contender B (streaming POST).** It takes the user's "maybe not spawn them at all" framing seriously. The API change is the main cost, and that cost is inversely proportional to how young this project is — now is the cheapest moment to make it. The operational surface shrinks rather than grows.
+
+**Second choice: Contender A (thread pool + gthread).** If the streaming-POST contract is a hard no — because external clients already depend on the 202+SSE-reconnect pattern, or because Render's proxy layer mishandles long streaming POSTs — this is the sane incremental path. Low risk, keeps threads but makes them accountable.
+
+**Not first choice: Contender C (Procrastinate worker).** Right answer if durability-across-deploys is the most important property. Not first choice because the ops burden is real and the user's framing was "not spawn them," which C achieves but at the cost of more moving parts than B.
+
+## Open questions (answer these before picking)
+
+These are the questions whose answers change the ranking.
+
+1. **Does Render's HTTP proxy handle long-lived streaming POST responses well?** Specifically: does it honor `Transfer-Encoding: chunked` for up to 10 minutes without buffering or cutting the connection? If no, Contender B is off the table. How to check: deploy a test endpoint that streams chunks over 10 minutes; observe. Or ask Render support.
+
+2. **Who are the clients of `POST /sessions`?** If only Fairy's own UI + internal testing, the API change in B is trivial to coordinate. If there are external integrations (agents calling agents?), the change needs a deprecation path. Check CLAUDE.md, README, and the e2e test suite for evidence of external consumers.
+
+3. **What is Render's platform-level SIGTERM-to-SIGKILL window on the starter plan?** Both A and C want `--graceful-timeout 650`. If Render force-kills in 30 s regardless, that flag is aspirational. Determines whether deploy-loss is fixable in A without also doing C.
+
+4. **Is there appetite for a second Render service?** Gates C. Operational + $7/mo + monitoring overhead. Worth it only if (a) we've measured deploy-loss rate as meaningful or (b) we're sure we want retry semantics regardless.
+
+5. **Can the Sprites SDK's internal asyncio future actually be cancelled cleanly?** A's cancel-via-future depends on this. Small spike needed — instantiate a `Command`, inspect its internal state, try calling `.cancel()` on the `concurrent.futures.Future` returned by `run_coroutine_threadsafe`. If cancellation doesn't actually kill the WebSocket frame loop, A can't close Muddy Zone 8 cleanly and A's value drops.
+
+## Process
+
+1. **Land [`thoughts/plans/2026-04-19-threading-bug-fixes.md`](/thoughts/plans/2026-04-19-threading-bug-fixes.md) first.** Those fixes are unambiguously good regardless of which contender wins.
+2. **Answer the five open questions above.** Spikes, not meetings — a day of probing gives us the data.
+3. **Pick a contender.** Write its implementation plan (a separate document).
+4. **Ship.**
+
+## What each implementation plan would contain
+
+Just to make the "we're deferring, not just punting" concrete — here's the rough shape each follow-up would take:
+
+**If A wins:** `thoughts/plans/2026-04-19-threadpool-plus-gthread.md` covering the executor, `gthread` config, cancel-via-future spike, tests that actually exercise the state machine (since `Thread` is no longer mocked in the same way).
+
+**If B wins:** `thoughts/plans/2026-04-19-streaming-post-refactor.md` covering the HTTP contract change, deletion of `run_session_background`, client migration plan, Render streaming-POST verification, CHANGELOG.
+
+**If C wins:** `thoughts/plans/2026-04-19-procrastinate-worker.md` covering the Render service config, Procrastinate integration, migration, task function port, retry/DLQ semantics, deploy strategy.
+
+## Related
+
+- Research: [`thoughts/research/2026-04-19-threading-in-web-server.md`](/thoughts/research/2026-04-19-threading-in-web-server.md)
+- Bug-fix baseline: [`thoughts/plans/2026-04-19-threading-bug-fixes.md`](/thoughts/plans/2026-04-19-threading-bug-fixes.md)
+- Prior art on session execution model: [`thoughts/plans/2026-04-16-session-based-execution.md`](/thoughts/plans/2026-04-16-session-based-execution.md), [`thoughts/research/2026-04-18-sprites-script-setup.md`](/thoughts/research/2026-04-18-sprites-script-setup.md)

--- a/thoughts/plans/2026-04-19-threading-bug-fixes.md
+++ b/thoughts/plans/2026-04-19-threading-bug-fixes.md
@@ -1,0 +1,256 @@
+# Threading Bug Fixes — Implementation Plan
+
+## Overview
+
+Three small, independent fixes to the session-execution threading code. Each stands on its own; none commits to a larger architectural direction. These are the "Group A" items from [`thoughts/research/2026-04-19-threading-in-web-server.md`](/thoughts/research/2026-04-19-threading-in-web-server.md) — active bugs that deserve fixing before we decide where threading goes next.
+
+No DB migration. No new dependencies. No API surface changes.
+
+## Research Summary
+
+Backed by [`thoughts/research/2026-04-19-threading-in-web-server.md`](/thoughts/research/2026-04-19-threading-in-web-server.md).
+
+- **Bug 1 — Active DB connection leak.** `run_session_background` writes to the ORM from a daemon thread and never closes the connection on exit. Gunicorn runs without `--max-requests`, so workers never recycle voluntarily; the leaked connection is held for the worker's lifetime.
+- **Bug 2 — Muddy Zone 8 zombie window.** `stream.py:152` has a 5 s `cmd_thread.join(timeout=5.0)` that marks the session `failed` while the inner daemon thread is still running and the Sprite is still executing. Combined with `failed` being a resumable state (Muddy Zone 2), a follow-up `POST /prompt` spawns a *second* execution on the same Sprite.
+- **Bug 3 — Gunicorn 30 s graceful timeout vs. 600 s turn timeout.** Every deploy during an in-flight turn force-kills the daemon thread at the 30 s mark; the Sprite keeps executing; the DB row stays `status="running"` forever.
+
+## Current State Analysis
+
+- Two nested `threading.Thread(daemon=True)` spawns per turn: `session_service/turn.py:33-38` (outer) and `stream.py:126` (inner).
+- Zero ORM connection cleanup anywhere in the thread body.
+- `render.yaml:18`: `gunicorn config.wsgi:application --bind 0.0.0.0:$PORT` — no flags, pure defaults.
+- `config/settings.py:96`: `DEFAULT_TIMEOUT = int(os.environ.get("DEFAULT_TIMEOUT", "600"))`.
+- `send_prompt` at `views/sessions.py` blocks only on `running` and `terminated`, so `failed` is resumable.
+
+## Desired End State
+
+1. Daemon threads doing ORM work call `close_old_connections()` at entry and exit.
+2. The zombie window is closed. Either: (a) `failed` sessions can't be resumed, (b) cancellation propagates to the Sprite, or (c) both.
+3. Gunicorn's `--graceful-timeout` accommodates the real turn limit; workers recycle voluntarily so leaked state can't accumulate indefinitely.
+
+### Verification
+
+- `make lint && make fmt` clean.
+- `make test` passes. New unit tests cover: (a) `close_old_connections` called in thread entry/exit, (b) a follow-up `POST /prompt` on a `failed` session returns 409.
+- Manual smoke: run an agent turn locally (`make dev`), verify a real DB connection closes on turn completion via `django.db.connections[DEFAULT].queries` inspection.
+- `AOD_API_TOKEN=… make test-e2e-fast` passes.
+
+## What We're NOT Doing
+
+- Not replacing the daemon-thread model with a `ThreadPoolExecutor`, Procrastinate worker, ASGI, or any other execution-model change. Those decisions are the subject of [`thoughts/plans/2026-04-19-threading-architecture-decision.md`](/thoughts/plans/2026-04-19-threading-architecture-decision.md), which should land before any of those get implemented.
+- Not fixing SSE worker-saturation (`time.sleep(0.5)` poll loop pinning workers). That's architectural — covered in the decision plan.
+- Not adding structured failure telemetry beyond what already exists.
+- Not changing `DEFAULT_TIMEOUT` or any turn-level semantics.
+
+## Implementation Approach
+
+Three independent changes. Can land as one PR (recommended — the review surface is small) or three stacked PRs if the team prefers smaller merges.
+
+1. Close DB connections in the thread body (`stream.py`).
+2. Block `send_prompt` on `failed` status + add a test.
+3. Update `render.yaml` with graceful-timeout + max-requests.
+
+Optional follow-up: propagate cancel to the Sprite's asyncio future on join timeout. Not required for this PR — the `failed`-is-terminal change makes the zombie window non-exploitable on its own. See "Open Follow-up" at the bottom.
+
+## File Ownership Map
+
+| File | Change | Notes |
+|------|--------|-------|
+| `src/agent_on_demand/stream.py` | modify | Add `close_old_connections()` at `run_session_background` entry and in a `finally` block at exit. |
+| `src/agent_on_demand/views/sessions.py` | modify | `send_prompt`: reject `failed` with 409 alongside `running` and `terminated`. |
+| `render.yaml` | modify | Add `--graceful-timeout 650 --timeout 700 --workers 3 --max-requests 1000 --max-requests-jitter 50` to the gunicorn invocation. |
+| `tests/test_api.py` | modify | Add `test_send_prompt_rejects_failed_session`. |
+| `tests/test_stream.py` (create, or add to existing) | create/modify | Assert `close_old_connections` is invoked on thread entry and exit. |
+
+## Phase 1: DB connection cleanup
+
+### Changes Required
+
+#### 1. `src/agent_on_demand/stream.py` — wrap the thread body
+
+Import `close_old_connections` at the top:
+
+```python
+from django.db import close_old_connections
+```
+
+Call it at the start of `run_session_background` and in a `finally` block:
+
+```python
+def run_session_background(
+    session: AgentSession,
+    turn: SessionTurn,
+    sprite: Sprite,
+    runtime: RuntimeConfig,
+    prompt: str,
+    mode: str,
+    timeout: float,
+):
+    # Django's recommended pattern for long-lived threads: close any
+    # stale connections on entry (in case this thread inherits one from
+    # the request handler) and close again on exit so we don't hold a
+    # connection for the worker's full lifetime.
+    close_old_connections()
+    try:
+        # ... existing body (output_q setup, _run_command inner thread,
+        # queue drain loop, state transitions) ...
+    finally:
+        close_old_connections()
+```
+
+Single wrap. Placement matters: entry-side catches any stale connection inherited from the request thread; exit-side releases the connection this thread opened for the DB writes.
+
+#### 2. `tests/test_stream.py` — new unit test
+
+Either create `tests/test_stream.py` or add a class to an existing file:
+
+```python
+@pytest.mark.django_db
+def test_run_session_background_closes_db_connections(user, mocker):
+    from sprites import ExecError
+
+    from agent_on_demand.models import SessionTurn
+    from agent_on_demand.runtimes import RUNTIMES
+    from agent_on_demand.stream import run_session_background
+
+    session = AgentSession.objects.create(
+        user=user, runtime="claude", prompt="t", status="pending"
+    )
+    turn = SessionTurn.objects.create(
+        session=session, turn_number=1, prompt="t", status="pending"
+    )
+
+    mock_sprite = mocker.MagicMock()
+    mock_cmd = mocker.MagicMock()
+    mock_cmd.run.side_effect = ExecError("exit status 0", exit_code=0)
+    mock_sprite.command.return_value = mock_cmd
+
+    close_spy = mocker.spy(
+        __import__("django.db", fromlist=["close_old_connections"]),
+        "close_old_connections",
+    )
+
+    run_session_background(
+        session, turn, mock_sprite, RUNTIMES["claude"], "hi", "run", timeout=10.0
+    )
+
+    # Called at entry and at exit (finally).
+    assert close_spy.call_count >= 2
+```
+
+The `>= 2` rather than `== 2` is defensive — if the code path inadvertently calls it an extra time elsewhere, the test still passes. The semantic guarantee is "at least entry + exit."
+
+## Phase 2: Close the zombie window via `failed`-is-terminal
+
+### Changes Required
+
+#### 1. `src/agent_on_demand/views/sessions.py` — reject resume of `failed`
+
+Find the existing block in `send_prompt`:
+
+```python
+if session.status == "running":
+    return JsonResponse({"detail": "Session is already running"}, status=409)
+
+if session.status == "terminated":
+    return JsonResponse({"detail": "Session has been terminated"}, status=409)
+```
+
+Add a `failed` branch:
+
+```python
+if session.status == "failed":
+    return JsonResponse(
+        {"detail": "Session has failed and cannot be resumed. Start a new session."},
+        status=409,
+    )
+```
+
+Do the same in the locked re-check inside the `transaction.atomic()` block of `send_prompt`.
+
+#### 2. `tests/test_api.py` — regression test
+
+```python
+@pytest.mark.django_db
+def test_send_prompt_rejects_failed_session(client: Client, auth_headers, user):
+    session = AgentSession.objects.create(
+        user=user, runtime="claude", prompt="test",
+        sprite_name="sprite-x", status="failed", exit_code=1,
+    )
+    resp = client.post(
+        f"/sessions/{session.id}/prompt",
+        data=json.dumps({"prompt": "retry"}),
+        content_type="application/json",
+        **auth_headers,
+    )
+    assert resp.status_code == 409
+    assert "failed" in resp.json()["detail"].lower()
+```
+
+### Why this, not the cancel-via-future fix?
+
+The cleaner long-term fix is "on join timeout, cancel the SDK's internal asyncio future via `future.cancel()`" (see the research doc, cross-track discovery #5). But that touches the Sprites SDK internals and needs real-Sprite validation. The `failed`-is-terminal change blunts the actual hazard (two executions on one Sprite) with one line of code and zero new surface. The cancel-via-future fix can land later as a separate PR.
+
+This is explicitly accepting that a *single* failed turn can still leave the Sprite executing for up to its timeout — it just can't cause a second turn to collide with it. Acceptable tradeoff.
+
+## Phase 3: Raise Gunicorn graceful timeout + add max-requests
+
+### Changes Required
+
+#### 1. `render.yaml` — extend the gunicorn invocation
+
+Find:
+
+```yaml
+startCommand: uv run gunicorn config.wsgi:application --bind 0.0.0.0:$PORT
+```
+
+Replace with:
+
+```yaml
+startCommand: >
+  uv run gunicorn config.wsgi:application
+  --bind 0.0.0.0:$PORT
+  --workers 3
+  --graceful-timeout 650
+  --timeout 700
+  --max-requests 1000
+  --max-requests-jitter 50
+```
+
+Explanation of each flag:
+
+- `--workers 3`: explicit, matches Render starter's `2*CPU+1` default. Makes the contract visible.
+- `--graceful-timeout 650`: 50 s of headroom above the 600 s `DEFAULT_TIMEOUT`. On SIGTERM, Gunicorn waits this long before force-killing workers — long enough for an in-flight turn to finish.
+- `--timeout 700`: worker silence timeout. Above graceful-timeout so Gunicorn doesn't self-kill a worker that's legitimately running a long turn.
+- `--max-requests 1000 --max-requests-jitter 50`: voluntarily recycle workers after ~1000 requests (jittered). Caps leaked-state accumulation — if Phase 1 misses a connection path, this still bounds the damage.
+
+**Render-specific caveat to verify:** Render's platform-level deploy timeout may be *lower* than 650 s on the starter plan. If so, this config is aspirational and we need to either (a) upgrade the plan, (b) accept deploy kills but rely on Phase 2 to prevent the worst outcome. The `--graceful-timeout` should match whatever Render gives us; if Render is 30 s platform-level, setting Gunicorn to 650 s gains nothing.
+
+**How to verify:** before shipping, check Render's docs / dashboard for the actual SIGTERM→SIGKILL window on the starter plan. If it's < 650 s, pick the largest plan-compatible value and document the mismatch in the PR.
+
+### Verification
+
+- `render.yaml` parses clean (`yamllint` or just `python -c "import yaml; yaml.safe_load(open('render.yaml'))"`).
+- Deploy to staging, trigger a deploy during an in-flight agent turn, confirm the turn completes rather than orphaning.
+
+## Risks
+
+- **Render graceful-timeout ceiling unknown.** The Phase 3 config assumes Render lets Gunicorn take 650 s. If Render caps lower, Phase 3 is a no-op and the real fix is Plan 2's "out-of-process worker" track.
+- **`failed`-is-terminal is a behavior change visible to clients.** Today a client can retry a failed session and get a 202. After Phase 2 they get a 409. Callers who retry on failure need to start a new session. Worth a note in CHANGELOG / release notes.
+- **`close_old_connections()` inside the outer thread doesn't reach the inner `_run_command` thread.** The inner thread doesn't touch the ORM currently, so this is fine today — but if anyone ever adds DB writes inside `_run_command`, they'd need their own `close_old_connections()`. Document this in a comment at the `_run_command` definition so the next person notices.
+
+## Open Follow-up
+
+**Cancel via future in a separate PR.** The structural fix to the zombie window — propagating cancellation to the SDK's internal asyncio future — is worth doing, but it (a) touches SDK internals that need real-Sprite validation, and (b) is a meaningfully larger surface than the three fixes above. Proposed approach for the follow-up:
+
+1. Pass a `threading.Event` into `_run_command`.
+2. On join timeout, `set()` the event from the outer thread.
+3. `_run_command` watches the event between queue writes and calls `future.cancel()` on the `asyncio.run_coroutine_threadsafe` future (retrievable from the SDK's internal `Command` object — need to confirm the SDK exposes it).
+
+That's a full spike on the Sprites SDK and is out of scope here.
+
+## Related
+
+- Research: [`thoughts/research/2026-04-19-threading-in-web-server.md`](/thoughts/research/2026-04-19-threading-in-web-server.md) — the full investigation that surfaced these bugs.
+- Architectural decision (next): [`thoughts/plans/2026-04-19-threading-architecture-decision.md`](/thoughts/plans/2026-04-19-threading-architecture-decision.md) — what we do about the daemon threads themselves, after the bugs are fixed.

--- a/thoughts/research/2026-04-19-threading-in-web-server.md
+++ b/thoughts/research/2026-04-19-threading-in-web-server.md
@@ -1,0 +1,196 @@
+---
+date: 2026-04-19T22:55:00-07:00
+researcher: Claude Code (team-research skill)
+git_commit: a2531b34248f49c6d9610cfbf62b34ec1058c123
+branch: main
+repository: ravi-hq/agent-on-demand
+topic: "What are we doing with threading? Discomfort with spawning threads inside a web server"
+tags: [research, team-research, threading, deployment, concurrency, background-work]
+status: complete
+method: agent-team
+team_size: 4
+tracks: [thread-inventory, deployment-surface, prior-art, alternatives]
+last_updated: 2026-04-19
+last_updated_by: Claude Code
+---
+
+# Research: Threading in the Web Server
+
+**Date**: 2026-04-19T22:55-07:00
+**Researcher**: Claude Code (team-research)
+**Git Commit**: [`a2531b3`](https://github.com/ravi-hq/agent-on-demand/commit/a2531b34248f49c6d9610cfbf62b34ec1058c123)
+**Branch**: `main`
+**Repository**: ravi-hq/agent-on-demand
+**Method**: Agent team (4 specialist researchers)
+
+## Research Question
+
+*"What are we doing with threading? I don't like spawning threads inside of web servers."*
+
+## Summary
+
+The discomfort is well-founded. The app currently spawns **two nested daemon threads per turn** (outer via `run_turn`, inner via `run_session_background`) to wrap a blocking Sprites WebSocket exec that can last up to 10 minutes. This is v1 scaffolding from `thoughts/plans/2026-04-16-session-based-execution.md` that was never revisited.
+
+Three compounding operational problems are already present on `main`:
+
+1. **Deploy-time data corruption.** Gunicorn's default 30 s graceful-shutdown timeout is **20× shorter** than the 600 s per-turn limit. Every deploy kills in-flight daemon threads mid-run; the Sprite keeps executing on the remote, and the DB row stays `status="running"` forever with no reconciliation.
+2. **Capacity is 3 concurrent sessions, not by design.** Render's starter plan runs 3 sync Gunicorn workers (`2*CPU+1`). The SSE stream endpoint holds a worker for the full turn duration via a 500 ms sleep-poll loop (`stream.py`). Three active streams → server is full.
+3. **Zombie executions.** The documented 5 s `cmd_thread.join(timeout=5.0)` window in `stream.py:152` can mark a session `failed` while the daemon thread is still running and the Sprite is still executing. Combined with `failed` being a resumable state, a client can trigger a second concurrent execution on the same Sprite.
+
+**Short-term fix (low risk, no new infra):** replace the bare `threading.Thread(daemon=True)` spawn with a **bounded `ThreadPoolExecutor`** managed as a module-level singleton, with a proper `atexit` / Django signal shutdown hook that waits up to N seconds. Gives bounded capacity, deterministic shutdown semantics, and preserves the existing SSE-via-DB-polling design. Alongside this, two small-surface bug fixes that are orthogonal but cheap: (1) `close_old_connections()` at thread entry and `connection.close()` at exit (fixes an active DB connection leak on long turns, not just a latent one), and (2) fix Muddy Zone 8 by propagating a cancel via `threading.Event` + `future.cancel()` on the SDK's internal asyncio future — the SDK uses `asyncio.run_coroutine_threadsafe` internally, so the future is cancellable without any library change. Finally: Gunicorn's `--graceful-timeout` needs to be raised to match the 600 s turn limit, and SSE worker saturation needs a separate fix — either switch to Gunicorn `gthread` workers (`--worker-class=gthread --threads=N`), or replace the SSE endpoint with a client-polling `/sessions/{id}/logs?after={id}` endpoint. Neither of those is fixed by the executor alone.
+
+**Medium-term fix (durable):** move session execution to an **out-of-process Postgres-backed worker** (Procrastinate is the cleanest fit for this Render + Postgres stack — no Redis tax, Postgres is already provisioned). Requires a new Render Background Worker service (~$7/mo). That unlocks deploys without losing in-flight work, proper retry semantics, and decouples long-running turns from the web workers' capacity.
+
+**Not recommended:** Celery / RQ / Dramatiq (Redis adds ops cost for no win here), asyncio/ASGI rewrite (the Sprites SDK internally runs its own event loop anyway — migrating buys little and costs a lot).
+
+## Research Tracks
+
+### Track 1: Thread inventory + lifecycle
+**Researcher**: thread-inventory-researcher
+**Scope**: `src/agent_on_demand/` full sweep; `.venv/.../sprites/`
+
+#### Findings
+
+1. **Outer daemon thread** — [`session_service/turn.py:33-38`](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/src/agent_on_demand/session_service/turn.py#L33-L38). Spawned by views on every turn (both `"run"` and `"continue"`). Target is `run_session_background`. `daemon=True`. HTTP caller returns 202 immediately.
+2. **Inner daemon thread** — [`stream.py:126`](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/src/agent_on_demand/stream.py#L126). Spawned *inside* the outer thread. Target is `_run_command` which calls `sprite.command(...).run()` — the blocking Sprites WebSocket exec. `daemon=True`.
+3. **What `_run_command` does** — [`stream.py:91-117`](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/src/agent_on_demand/stream.py#L91-L117). Runs the inline `bash -c` turn command, pipes stdout/stderr through `TaggingQueueWriter` onto a shared `queue.Queue`. Records `("exit", code)` or `("error", str)` into `result_holder`. Sentinels the queue in `finally`.
+4. **Coordination model** — [`stream.py:129-164`](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/src/agent_on_demand/stream.py#L129-L164). Outer thread drains the queue in batches of 20, writes `AgentSessionLog` rows, then joins the inner thread with a **5 s timeout**.
+5. **Zombie window confirmed** — [`stream.py:152`](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/src/agent_on_demand/stream.py#L152). Muddy Zone 8 from prior research. Timeout fires → `result_holder` empty → session marked `failed, exit_code=None`. Inner thread still alive, Sprite still executing, no kill mechanism. Combined with `failed` being resumable (Muddy Zone 2), a follow-up `POST /prompt` spawns a *second* execution on the same Sprite.
+6. **ORM access from background threads without cleanup** — [`stream.py`](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/src/agent_on_demand/stream.py). `session.save()`, `AgentSessionLog.objects.bulk_create()`, `turn.save()` run on the daemon thread. No `connection.close()` or `close_old_connections()` on thread exit. Latent connection-leak risk.
+7. **Daemon thread on worker restart = orphans** — Both threads are `daemon=True`, so SIGTERM/SIGKILL kills them mid-flight. Sprite keeps running on the remote; session row stays `status="running"` with no reconciliation job.
+8. **Only two thread spawns exist** — entire `src/` search. No `asyncio.create_task`, `ThreadPoolExecutor`, `Timer`. The threading surface is small but load-bearing.
+
+### Track 2: Deployment surface
+**Researcher**: deployment-researcher
+**Scope**: `render.yaml`, `pyproject.toml`, `Makefile`, `config/settings.py`, `config/wsgi.py`
+
+#### Findings
+
+1. **Production**: [`render.yaml:18`](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/render.yaml#L18) runs `uv run gunicorn config.wsgi:application --bind 0.0.0.0:$PORT`. No `--workers`, `--threads`, `--timeout`, or `--max-requests` flags — pure defaults.
+2. **Gunicorn defaults activated** — sync workers, `2*CPU+1` processes (Render starter = 1 CPU → 3 workers), **30 s graceful-shutdown timeout**, no voluntary worker recycling.
+3. **Development**: [`Makefile:5`](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/Makefile#L5) → `python manage.py runserver 0.0.0.0:8777`. Single-threaded Django dev server.
+4. **Critical gap: 30 s shutdown vs. 600 s turn limit** — [`config/settings.py:96`](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/src/config/settings.py#L96): `DEFAULT_TIMEOUT = int(os.environ.get("DEFAULT_TIMEOUT", "600"))`. Every deploy/restart force-kills daemon threads after 30 s. No graceful drain of in-flight work.
+5. **SSE endpoint pins a sync worker** — [`stream.py:180`](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/src/agent_on_demand/stream.py#L180). `stream_session_from_db` runs `time.sleep(0.5)` in a loop for the full turn duration. Three concurrent streams = worker pool exhausted.
+6. **Render only** — `render.yaml` + PostgreSQL `basic-256mb` web service `starter`. No Dockerfile, no Procfile, no Fly config, no compose file. No Background Worker service.
+7. **Pure WSGI** — [`config/wsgi.py`](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/src/config/wsgi.py). No ASGI conversion, no `sync_to_async` wrapping, no Channels.
+
+### Track 3: Prior art + decision history
+**Researcher**: prior-art-researcher
+**Scope**: `thoughts/plans/`, `thoughts/research/`, `git log --all`
+
+#### Findings
+
+1. **Decision origin** — [`thoughts/plans/2026-04-16-session-based-execution.md`](/thoughts/plans/2026-04-16-session-based-execution.md). Rationale for `threading.Thread(daemon=True)` was **explicitly "v1 simplicity, already using threads for streaming"**. Not a considered architectural choice — a deliberate deferral.
+2. **Celery and ASGI explicitly rejected** — [`thoughts/research/2026-04-16-session-based-execution.md`](/thoughts/research/2026-04-16-session-based-execution.md). Direct quote: *"No Celery or task queue — background threads are sufficient for v1. No ASGI migration — WSGI handles this fine."*
+3. **Muddy Zone 8 already flagged as "serious"** — [`thoughts/research/2026-04-18-sprites-script-setup.md`](/thoughts/research/2026-04-18-sprites-script-setup.md). The join-timeout zombie window is called out as the single most concerning interaction surfaced by that research, and was explicitly deferred again in `thoughts/plans/2026-04-19-session-service-api-refactor.md` under "What We're NOT Doing."
+4. **State machine never tested** — [`thoughts/research/2026-04-18-session-backend-abstraction.md`](/thoughts/research/2026-04-18-session-backend-abstraction.md). The `pending → running → completed` state machine in `run_session_background` is mocked out in every unit test via `patch("session_service.turn.threading.Thread")`. No test exercises the real thread lifecycle.
+5. **No commits touch threading meaningfully** — `git log --oneline --all | head -60` has zero commits matching `threading`, `celery`, `async`, `worker`, or `daemon` in their messages. The pattern has been unchanged since the session-based-execution feature landed.
+
+### Track 4: Alternatives + migration paths
+**Researcher**: alternatives-researcher
+**Scope**: Library survey + `render.yaml` + `.venv` inspection
+
+#### Findings
+
+1. **The Sprites SDK is not really sync at the bottom** — `.venv/.../sprites/exec.py` → `_run_sync()` → `sprites.loop.run_sync()` → `asyncio.run_coroutine_threadsafe(coro, persistent_loop)`. The SDK has its **own singleton asyncio event loop on a background thread**; `cmd.run()` just blocks the calling thread via `future.result(timeout=...)`. Implication: the "sync-only SDK" framing isn't strictly true. An ASGI view calling `sync_to_async(cmd.run)()` would work — but the SDK's own loop still adds a layer.
+2. **Django 6.x has a task framework skeleton, no worker backend bundled** — `.venv/.../django/tasks/` ships `ImmediateBackend` (in-process synchronous) and `DummyBackend`. No DB-backed worker backend is included. `django-tasks` as a Django-native direction is promising but the `django-db-tasks-backend` DB driver is young.
+3. **Render deployment constraint** — Only a `web` service + Postgres in `render.yaml`. No Redis. A Postgres-backed broker (Procrastinate, django-tasks) avoids adding Redis; a worker-based broker (Celery, RQ, Dramatiq) would add ~$7/mo for Redis plus another Render Background Worker service.
+
+#### Ranked shortlist
+
+| Option | Broker | Sync-SDK fit | Streaming story | Django fit | Render fit | Migration cost |
+|---|---|---|---|---|---|---|
+| **ThreadPoolExecutor (bounded)** | none | native | unchanged (DB polling) | manual | works on current plan | **minimal** |
+| **Procrastinate (Postgres broker)** | Postgres (already have) | good | unchanged | `django-procrastinate` | add BG worker service | medium |
+| **django-tasks (DB backend, third-party)** | Postgres | good | unchanged | excellent | add BG worker service | medium |
+| **Celery / RQ / Dramatiq** | Redis | good | unchanged | mature | add Redis + BG worker | high |
+| **asyncio + ASGI** | none | awkward double-bridge | async SSE possible | requires ASGI | uvicorn worker needed | high |
+
+**Recommendation:** ThreadPoolExecutor short-term (costs nothing, immediately caps capacity and enables deterministic shutdown). Procrastinate medium-term if durability is required.
+
+## Cross-Track Discoveries
+
+These are the findings that emerged from researchers messaging each other — not visible from any single track.
+
+**1. The 30 s gunicorn grace period makes Muddy Zone 8 moot — and worse.**
+Track 1 flagged the 5 s `cmd_thread.join(timeout=5.0)` as the window where a session gets marked `failed` while the Sprite is still executing. Track 2 added the crucial context: gunicorn's default graceful-shutdown is 30 s. So on every deploy during an in-flight turn, the sequence is: SIGTERM → request thread tries to finish → 30 s later SIGKILL → daemon threads die → outer thread never got to the 5 s join at all → session stays `running` forever with zero DB transition. The Muddy Zone 8 zombie becomes a "session row stuck in running" orphan, which is strictly worse than the already-documented "two concurrent executions" hazard.
+
+**2. Worker capacity is 3, not 1.**
+Track 1 initially assumed single-worker capacity. Track 2 corrected: Render starter → 3 sync workers via Gunicorn's `2*CPU+1` default. This changes the math but not the conclusion — three concurrent streaming SSE clients still saturate the pool because each SSE response holds a worker for the turn's full duration.
+
+**3. Prior art explicitly punted — this research is the trigger for reconsidering.**
+Track 3 found the "Celery rejected for v1 simplicity" decision in the 2026-04-16 plan, and the subsequent "not fixing Muddy Zone 8" in the 2026-04-19 plan. Neither document defined a trigger for re-evaluation. Track 4's survey confirms nothing in the codebase has changed the calculus yet — but the **accumulation** of the three operational problems (deploy orphans + capacity pinning + zombie executions) has crossed the threshold, and the ecosystem now offers Postgres-backed options (Procrastinate) that weren't part of the original "Celery vs. threads" framing.
+
+**4. The SDK's secret async loop means ASGI is technically feasible but buys nothing.**
+Track 4 discovered `sprite.command().run()` is internally `asyncio.run_coroutine_threadsafe` against a singleton loop. This means the migration barrier to ASGI views + `sync_to_async` is lower than one would expect from the blocking call surface. But the payoff is also lower than one would hope — you'd still be bridging two event loops, the existing SSE-via-DB pattern wouldn't become materially simpler, and the core problems (worker capacity, deploy shutdown, zombies) aren't caused by sync-ness. Track 4's recommendation to skip ASGI is correct.
+
+**5. Muddy Zone 8 is fixable without a worker migration — it's orthogonal to executor vs. thread.**
+Post-synthesis sync between Tracks 3 and 4 sharpened this: neither ThreadPoolExecutor nor Procrastinate/django-tasks fixes the 5 s join timeout zombie on their own. Three in-place options: (a) guard `send_prompt` so `failed` sessions can't be resumed (blunts the "two executions on one Sprite" hazard without touching threads), (b) propagate cancellation to the Sprite via the SDK's already-cancellable asyncio future + a `threading.Event` set from the outer thread, or (c) simply extend the join timeout past the SDK's own command timeout (so the thread either finishes or the SDK raises). (b) is the right fix long-term; (a) or (c) are one-liner bridges.
+
+**6. SSE saturation is orthogonal to execution-thread concurrency.**
+Track 4 flagged this post-synthesis: even if execution moves to a bounded pool or a worker process, the SSE streaming endpoint still pins a sync Gunicorn worker per active client via `time.sleep(0.5)` (`stream.py:180`). Three concurrent SSE clients = server full, regardless of how executions run. Fixes: Gunicorn `gthread` worker class (`--worker-class=gthread --threads=N`, lowest change), or replace the SSE endpoint with a client-polling `/sessions/{id}/logs?after={id}` endpoint (breaks the SSE API contract, but pure request/response — no worker pinning). ASGI+uvicorn is the third option and the one with the highest cost.
+
+**7. `connection.close()` absence is an active leak, not latent.**
+Track 4 follow-up: since Gunicorn runs without `--max-requests`, workers never recycle voluntarily. Each long turn (up to 600 s) leaves a DB connection held by the daemon thread; the connection never closes until the worker itself dies. On a busy instance, this steadily consumes the Postgres connection budget. The fix is `close_old_connections()` at `run_session_background` entry + `connection.close()` at exit — Django's documented pattern for long-lived threads.
+
+## Code References
+
+| File | Tracks | Findings | Link |
+|---|---|---|---|
+| `src/agent_on_demand/session_service/turn.py:33-38` | 1 | Outer daemon thread spawn | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/src/agent_on_demand/session_service/turn.py#L33-L38) |
+| `src/agent_on_demand/stream.py:126` | 1 | Inner daemon thread spawn | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/src/agent_on_demand/stream.py#L126) |
+| `src/agent_on_demand/stream.py:152` | 1, 3 | 5 s join timeout — zombie window (Muddy Zone 8) | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/src/agent_on_demand/stream.py#L152) |
+| `src/agent_on_demand/stream.py:91-117` | 1 | `_run_command` body — SDK call + queue writer | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/src/agent_on_demand/stream.py#L91-L117) |
+| `src/agent_on_demand/stream.py:129-164` | 1 | Outer thread queue drain + DB writes + join | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/src/agent_on_demand/stream.py#L129-L164) |
+| `src/agent_on_demand/stream.py:180` | 2 | SSE `time.sleep(0.5)` poll loop pinning workers | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/src/agent_on_demand/stream.py#L180) |
+| `render.yaml:18` | 2 | Gunicorn invocation with zero flags | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/render.yaml#L18) |
+| `src/config/settings.py:96` | 2 | `DEFAULT_TIMEOUT = 600` vs. 30 s gunicorn grace | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/a2531b3/src/config/settings.py#L96) |
+
+## Architecture Insights
+
+- **The SSE endpoint and the execution thread are already decoupled** via the `AgentSessionLog` table — streaming reads from DB, writes happen in the thread. This is the single most useful pre-existing property: any migration to an out-of-process worker inherits an already-working streaming story without touching clients.
+- **The pattern is "fire-and-forget 202 + reconnect for SSE"** — the HTTP request doesn't need the thread to complete. This is the right pattern for queued/async execution, just implemented with threads for now.
+- **The threading surface is small** — two spawns, both in files we own. Migration to a pool or a queue is mechanically small; the risk is operational (broker, worker deploy unit, graceful handoff), not code-shaped.
+- **Daemon threads + no ORM cleanup is a latent connection leak** — Django's advice is to `close_old_connections()` when a thread finishes. Today the daemon thread's DB connection just dangles until gunicorn recycles the worker (which it doesn't, because no `--max-requests`).
+
+## Historical Context
+
+- [`thoughts/plans/2026-04-16-session-based-execution.md`](/thoughts/plans/2026-04-16-session-based-execution.md) — Original decision to use daemon threads. Rationale: v1 simplicity. Celery + ASGI explicitly deferred.
+- [`thoughts/research/2026-04-18-sprites-script-setup.md`](/thoughts/research/2026-04-18-sprites-script-setup.md) — First flagged Muddy Zone 8 (the 5 s join zombie) as the single most concerning interaction in the execution model.
+- [`thoughts/research/2026-04-18-session-backend-abstraction.md`](/thoughts/research/2026-04-18-session-backend-abstraction.md) — Noted the state machine is never tested because `threading.Thread` is mocked in every unit test.
+- [`thoughts/plans/2026-04-19-session-service-api-refactor.md`](/thoughts/plans/2026-04-19-session-service-api-refactor.md) — Most recent plan; explicitly deferred fixing the zombie window and threading model.
+
+## Recommended Actions (ranked)
+
+These are grouped by **where they fix a real problem** — several are genuinely independent and can land as separate small PRs.
+
+**Group A: bug fixes, do these regardless of larger architecture choices.**
+
+1. **Add `close_old_connections()` at `run_session_background` entry, `connection.close()` at exit.** Fixes an active DB connection leak (not latent — workers don't recycle because there's no `--max-requests`). Django's documented pattern for long-lived threads. 1-line change.
+2. **Fix Muddy Zone 8 (zombie window).** Preferred: pass a `threading.Event` into `_run_command`, set it from the outer thread on join timeout, and call `future.cancel()` on the SDK's internal asyncio future (already cancellable via `run_coroutine_threadsafe`). Cheaper bridge: guard `send_prompt` so `failed` sessions can't be resumed — blunts the "two executions on one Sprite" hazard without touching the thread code.
+3. **Raise Gunicorn's graceful timeout + add `--max-requests`.** Edit `render.yaml` → `gunicorn ... --graceful-timeout 650 --timeout 700 --workers 3 --max-requests 1000 --max-requests-jitter 50`. Matches the 600 s turn limit so deploys don't kill in-flight turns. Also enables voluntary worker recycling, which incidentally reclaims leaked DB connections if #1 doesn't ship first.
+
+**Group B: capacity + shutdown — pick one, they conflict less than they look.**
+
+4. **Replace raw daemon threads with a bounded `ThreadPoolExecutor`.** Module-level singleton in `session_service/turn.py`, `shutdown(wait=True, cancel_futures=False)` wired to `atexit` + Django's `request_finished` teardown. Picks a capacity cap (10? 50?), makes shutdown semantics explicit, gives a natural hook for state-transition callbacks. **Still in-process — does not survive a deploy.** Pair with #3.
+5. **Switch Gunicorn to `gthread` workers for SSE concurrency.** Add `--worker-class=gthread --threads=8`. Each sync worker process gets a thread pool so the SSE `sleep(0.5)` poll loop no longer pins an entire worker. Low-risk, no code change. Orthogonal to #4 — if executions are still daemon threads, this only helps the streaming side. If executions move to the pool in #4, gthread helps streaming; if executions move out-of-process (#6), gthread also helps streaming.
+6. **Evaluate Procrastinate as a full out-of-process move.** `render.yaml` adds a `worker` service, `pyproject.toml` adds the dep, a migration creates the broker schema, `run_turn` switches from `thread.start()` to `task.enqueue()`. Clients unchanged (SSE still reads DB), deploys can complete without dropping turns, retries + DLQ are natural. The "fix deploy-time data loss" path — but overkill if the actual deploy-loss rate is low.
+
+**Not recommended.**
+
+- **ASGI + uvicorn.** The SDK's own event loop makes this technically feasible with `sync_to_async` but there's no material payoff — the real problems (capacity, shutdown, zombies) aren't caused by sync-ness.
+- **Celery / RQ / Dramatiq.** Adds a Redis dependency for no advantage over Procrastinate when Postgres is already provisioned.
+- **Replacing SSE with client polling.** Was considered — it's a cleaner fit for WSGI, but breaks the existing client API contract for questionable gain over `gthread` mode.
+
+## Open Questions
+
+- **What's the actual observed deploy-loss rate in production?** The theoretical risk is "every deploy during an in-flight turn." Need metrics (turn success rate vs. deploy events) to prioritize 1–5 above.
+- **Is there appetite for a $7/mo Background Worker + the coordination complexity it brings, or is the preference to stay single-service?** This gates item 5.
+- **Should `failed` sessions be non-resumable?** Muddy Zone 2 (from the 2026-04-18 research) — currently they are resumable, which is what makes the zombie window into a two-executions-on-one-Sprite hazard. Flipping this would blunt the zombie risk independently of the threading model.
+- **Does Render offer a longer graceful-shutdown window on paid plans?** Worth a check before committing to a graceful-timeout config change.
+
+## Related Research
+
+- [`thoughts/research/2026-04-18-sprites-script-setup.md`](/thoughts/research/2026-04-18-sprites-script-setup.md) — Execution model deep-dive; origin of Muddy Zone 8.
+- [`thoughts/research/2026-04-18-session-backend-abstraction.md`](/thoughts/research/2026-04-18-session-backend-abstraction.md) — What a backend-abstraction layer would look like and what currently isn't tested.
+- [`thoughts/research/2026-04-16-session-based-execution.md`](/thoughts/research/2026-04-16-session-based-execution.md) — Original decision doc.


### PR DESCRIPTION
## Summary

Three independent fixes driven by [`thoughts/research/2026-04-19-threading-in-web-server.md`](thoughts/research/2026-04-19-threading-in-web-server.md). Does **not** change the threading execution model — the larger "do we keep daemon threads at all" decision is tracked in [`thoughts/plans/2026-04-19-threading-architecture-decision.md`](thoughts/plans/2026-04-19-threading-architecture-decision.md).

**1. DB connection leak in `run_session_background`.** Django's per-request connection lifecycle doesn't apply to daemon threads spawned outside the request cycle. Gunicorn ran without `--max-requests` (now fixed), so workers never recycled voluntarily and the leaked connection was held for the worker's full lifetime. Wrap the body with `close_old_connections()` at entry and `finally` at exit — Django's documented pattern for long-lived threads.

**2. Make `failed` sessions terminal.** `send_prompt` already rejected `running` and `terminated` but accepted `failed`. Combined with Muddy Zone 8's zombie window (outer thread gives up on `join(timeout=5.0)` while inner thread is still streaming and the Sprite is still executing), resuming a failed session risked two concurrent executions on one Sprite. Making `failed` terminal (409 on resume) blunts the hazard with one branch. Deeper fix (propagate cancel to the SDK's asyncio future) deferred to the architecture plan.

**3. Gunicorn config vs. 600 s turn limit.** `render.yaml` ran gunicorn with zero flags — defaults to 30 s graceful-timeout, 20× shorter than `DEFAULT_TIMEOUT=600`. Every deploy during an in-flight turn force-killed the daemon thread, leaving the DB row stuck in `running` and the Sprite still executing. Now explicit:
\`\`\`
--workers 3                (matches Render starter 2*CPU+1 default)
--graceful-timeout 650     (above 600s turn limit with headroom)
--timeout 700              (above graceful-timeout)
--max-requests 1000
--max-requests-jitter 50   (voluntary worker recycling)
\`\`\`

### Behavior change callout

Clients that retried on failure by POSTing a new prompt to the same session will now get a 409. They should POST a new session instead. Worth a note in release notes.

## Test plan

- [x] \`make lint\` + \`make fmt\` clean
- [x] \`make test\` — 202 passed (was 200 + 2 new regression tests)
- [x] \`python -c \"import yaml; yaml.safe_load(open('render.yaml'))\"\` — render.yaml parses
- [ ] Verify Render's platform-level SIGTERM→SIGKILL window accommodates \`--graceful-timeout 650\` on the starter plan. If it's lower, this flag is aspirational and we need to either upgrade the plan or accept the mismatch (item #2 in the PR already handles the worst case)
- [ ] \`AOD_API_TOKEN=… make test-e2e-fast\` on a real deployment before merge
- [ ] Post-deploy: trigger a deploy during an in-flight agent turn, confirm the turn completes rather than orphaning

🤖 Generated with [Claude Code](https://claude.com/claude-code)