### PR TITLE
Default local dev to a Docker Postgres

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,35 @@
 install:
 	uv sync --all-extras
 
+# Start the local Postgres container (docker-compose.yml). Blocks until ready.
+db-up:
+	docker compose up -d db
+	@until docker compose exec -T db pg_isready -U agent_on_demand >/dev/null 2>&1; do \
+		echo "waiting for postgres..."; sleep 1; \
+	done
+	uv run python manage.py migrate
+
+db-down:
+	docker compose down
+
+# Reset local dev DB — destroys the data volume, recreates the container, migrates.
+db-reset:
+	docker compose down -v
+	$(MAKE) db-up
+
 dev:
 	uv run python manage.py runserver 0.0.0.0:8777
 
 # Procrastinate worker. Session execution runs here; `make dev` only handles HTTP.
-# Requires Postgres (Procrastinate does not support SQLite).
+# Requires the Postgres container to be up (`make db-up`).
 worker:
-	uv run procrastinate --app=agent_on_demand.session_service.tasks.procrastinate_app worker
+	uv run python manage.py procrastinate worker
 
-# Unit + integration tests (e2e suite excluded)
+# Unit + integration tests (e2e suite excluded). Tests run against SQLite so
+# Postgres doesn't need to be running; Procrastinate migrations are skipped
+# on non-Postgres backends (see config/settings.py).
 test:
-	uv run pytest tests/ -v --ignore=tests/e2e
+	DATABASE_URL=sqlite:///test.db uv run pytest tests/ -v --ignore=tests/e2e
 
 # E2E tests against a running agent-on-demand deployment.
 # Required:  AOD_API_TOKEN

--- a/README.md
+++ b/README.md
@@ -19,26 +19,30 @@ allow-list at session start — domains outside `allowed_hosts` are blocked
 
 ```bash
 make install       # uv sync --all-extras
-```
-
-Run the dev server on `:8777`:
-
-```bash
-make dev
+make db-up         # start local Postgres (Docker) + run migrations
 ```
 
 Session execution runs on a separate **worker** process (Procrastinate,
 Postgres-backed broker). The web server only accepts requests and enqueues
-work. To run an agent turn locally you need the worker too:
+work; a worker picks them up and runs them.
+
+Run both in separate terminals:
 
 ```bash
-make worker
+make dev           # web — serves HTTP on :8777
+make worker        # worker — runs session turns
 ```
 
-Procrastinate requires Postgres. For local dev against SQLite, the web server
-runs but sessions will stay `pending` forever because the worker can't attach
-to a SQLite broker. Point `DATABASE_URL` at a local Postgres to execute
-sessions end-to-end.
+`docker-compose.yml` provisions Postgres 16 on `:5432`; the default
+`DATABASE_URL` in `config/settings.py` points at that container. Override
+`DATABASE_URL` to point at another DB.
+
+Local teardown:
+
+```bash
+make db-down       # stop the container
+make db-reset      # destroy the volume and re-migrate
+```
 
 ## API surface
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: agent_on_demand
+      POSTGRES_PASSWORD: agent_on_demand
+      POSTGRES_DB: agent_on_demand
+    # Host port 5460 to avoid colliding with Homebrew/OS Postgres on 5432.
+    # If 5460 is also taken, override AOD_DB_PORT when running `make db-up`.
+    ports:
+      - "${AOD_DB_PORT:-5460}:5432"
+    volumes:
+      - aod-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U agent_on_demand"]
+      interval: 2s
+      timeout: 3s
+      retries: 20
+
+volumes:
+  aod-postgres-data:

--- a/render.yaml
+++ b/render.yaml
@@ -46,9 +46,7 @@ projects:
             plan: starter
             buildCommand: pip install uv && uv sync
             startCommand: >-
-              uv run procrastinate
-              --app=agent_on_demand.session_service.tasks.procrastinate_app
-              worker
+              uv run python manage.py procrastinate worker
             envVars:
               - key: DATABASE_URL
                 fromDatabase:

--- a/src/agent_on_demand/tasks.py
+++ b/src/agent_on_demand/tasks.py
@@ -1,0 +1,11 @@
+"""Procrastinate task auto-discovery entry point.
+
+`procrastinate.contrib.django.AUTODISCOVER_MODULE_NAME = "tasks"` — Procrastinate
+scans each INSTALLED_APP for a top-level `tasks` module and imports it so
+`@app.task` decorators register. The real task lives in
+`session_service/tasks.py`; this file just imports it to wire up discovery.
+"""
+
+from agent_on_demand.session_service.tasks import execute_turn
+
+__all__ = ["execute_turn"]

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -61,17 +61,21 @@ APPEND_SLASH = False
 
 CORS_ALLOW_ALL_ORIGINS = True
 
+# Local default points at the Postgres container in docker-compose.yml
+# (`make db-up`). Override via DATABASE_URL for production (Render injects it)
+# or to point at another DB. Procrastinate requires Postgres; SQLite fallback
+# is only useful for running the Django test suite without Postgres running.
 DATABASES = {
     "default": dj_database_url.config(
-        default=f"sqlite:///{BASE_DIR / 'agent_on_demand.db'}",
+        default="postgres://agent_on_demand:agent_on_demand@localhost:5460/agent_on_demand",
         conn_max_age=600,
     )
 }
 
-# Procrastinate requires Postgres. On non-Postgres backends (local SQLite dev,
-# pytest on SQLite), skip its migrations so `manage.py migrate` doesn't blow up
-# on CREATE EXTENSION statements. Unit tests override the app connector with
-# InMemoryConnector and don't need the schema.
+# Procrastinate requires Postgres — skip its migrations on non-Postgres
+# backends so `manage.py migrate` and the SQLite-backed test suite don't
+# blow up on CREATE EXTENSION statements. Unit tests stub `execute_turn.defer`
+# directly and don't need the Procrastinate schema.
 if "postgresql" not in DATABASES["default"].get("ENGINE", ""):
     MIGRATION_MODULES = {"procrastinate": None}
 


### PR DESCRIPTION
## Summary

Follow-up to #49. Procrastinate is Postgres-only, so local dev without Postgres means enqueued tasks never run. Make `make install && make db-up && make dev && make worker` just work.

- **`docker-compose.yml`** — Postgres 16 on host port **5460** (not 5432, to avoid collisions with Homebrew / OS Postgres). Override via `AOD_DB_PORT` env var.
- **`config/settings.py`** — default `DATABASE_URL` now points at the Docker container. Render injects its own `DATABASE_URL` in prod, so the default is local-only.
- **`Makefile`** — adds `db-up`, `db-down`, `db-reset`. Also fixes the worker command to use `python manage.py procrastinate worker` (the stand-alone `procrastinate` CLI doesn't load Django settings, so it couldn't import the task module). `make test` sets `DATABASE_URL=sqlite:///test.db` so the unit suite doesn't require Postgres.
- **`render.yaml`** — worker service `startCommand` uses the same management-command form so task autodiscovery works.
- **`src/agent_on_demand/tasks.py`** (new) — re-exports `execute_turn`. Procrastinate's autodiscover scans each `INSTALLED_APP` for a top-level `tasks` module; the real task still lives in `session_service/tasks.py`.
- **`README.md`** — documents the two-terminal local workflow.

## Verified locally

- `make db-up` → Postgres boots, 41 Procrastinate migrations apply green
- `python manage.py procrastinate healthchecks` → DB + migrations + app + worker all OK
- `execute_turn` appears in `app.tasks` after autodiscover
- `make test` → 206 pass (runs against SQLite)
- `make lint` + `make fmt` clean

## Test plan

- [x] `make lint` + `make fmt` + `make test` locally
- [x] `make db-up` succeeds against a clean state
- [x] Procrastinate healthchecks pass against the local container
- [ ] After merge: redeploy to Render; confirm the worker service startCommand (now using `python manage.py procrastinate worker`) comes up green

🤖 Generated with [Claude Code](https://claude.com/claude-code)