### PR TITLE
Add PostHog product analytics and OTel/Honeycomb tracing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,14 @@ dependencies = [
     "gunicorn>=23.0",
     "whitenoise>=6.7",
     "procrastinate[django]>=3.0",
+    "posthog>=3.7",
+    "opentelemetry-api>=1.29",
+    "opentelemetry-sdk>=1.29",
+    "opentelemetry-exporter-otlp-proto-http>=1.29",
+    "opentelemetry-instrumentation-django>=0.50b0",
+    "opentelemetry-instrumentation-psycopg>=0.50b0",
+    "opentelemetry-instrumentation-requests>=0.50b0",
+    "opentelemetry-instrumentation-logging>=0.50b0",
 ]
 
 [project.optional-dependencies]

--- a/render.yaml
+++ b/render.yaml
@@ -39,6 +39,14 @@ projects:
                 value: aod.ravi.id,agent-on-demand-api.onrender.com
               - key: PYTHON_VERSION
                 value: "3.11.9"
+              - key: OTEL_SERVICE_NAME
+                value: aod-web
+              - key: HONEYCOMB_API_KEY
+                sync: false
+              - key: POSTHOG_API_KEY
+                sync: false
+              - key: POSTHOG_HOST
+                value: https://us.i.posthog.com
 
           - type: worker
             name: agent-on-demand-worker
@@ -68,3 +76,17 @@ projects:
                 value: aod.ravi.id,agent-on-demand-api.onrender.com
               - key: PYTHON_VERSION
                 value: "3.11.9"
+              - key: OTEL_SERVICE_NAME
+                value: aod-worker
+              - key: HONEYCOMB_API_KEY
+                fromService:
+                  name: agent-on-demand-api
+                  type: web
+                  envVarKey: HONEYCOMB_API_KEY
+              - key: POSTHOG_API_KEY
+                fromService:
+                  name: agent-on-demand-api
+                  type: web
+                  envVarKey: POSTHOG_API_KEY
+              - key: POSTHOG_HOST
+                value: https://us.i.posthog.com

--- a/src/agent_on_demand/apps.py
+++ b/src/agent_on_demand/apps.py
@@ -9,6 +9,11 @@ class AgentOnDemandConfig(AppConfig):
     def ready(self):
         import agent_on_demand.signals  # noqa: F401 — register signal handlers
 
+        from agent_on_demand.observability import init_otel, init_posthog
+
+        init_otel()
+        init_posthog()
+
         from django.db.backends.signals import connection_created
 
         def _set_sqlite_pragmas(sender, connection, **kwargs):

--- a/src/agent_on_demand/observability.py
+++ b/src/agent_on_demand/observability.py
@@ -1,0 +1,155 @@
+"""OpenTelemetry → Honeycomb (traces + logs) and PostHog (product events).
+
+Both subsystems are no-ops when their API keys are unset, so unit tests and
+local dev without credentials behave identically to today. Honeycomb routes
+each `service.name` into its own dataset by default, so the web service emits
+to one dataset and the worker to another by setting `OTEL_SERVICE_NAME`.
+
+Event-property safety: callers must pass only counts, lengths, IDs, and other
+non-sensitive metadata. Never raw prompt text, env-var values, or repo URLs.
+This module does not enforce that — it's the caller's responsibility.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+HONEYCOMB_OTLP_ENDPOINT = "https://api.honeycomb.io"
+DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com"
+TRACER_NAME = "agent_on_demand"
+
+_otel_initialized = False
+_posthog_initialized = False
+
+
+def init_otel(service_name: str | None = None) -> None:
+    """Configure the OTel SDK + OTLP/HTTP exporter pointed at Honeycomb.
+
+    Idempotent. No-op if HONEYCOMB_API_KEY is unset. Service name resolution
+    order: explicit arg → OTEL_SERVICE_NAME env → "aod-web".
+    """
+    global _otel_initialized
+    if _otel_initialized:
+        return
+    api_key = os.environ.get("HONEYCOMB_API_KEY")
+    if not api_key:
+        return
+
+    from opentelemetry import trace
+    from opentelemetry._logs import set_logger_provider
+    from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+    from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    resolved = service_name or os.environ.get("OTEL_SERVICE_NAME") or "aod-web"
+    resource = Resource.create({"service.name": resolved})
+    headers = {"x-honeycomb-team": api_key}
+
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(
+        BatchSpanProcessor(
+            OTLPSpanExporter(
+                endpoint=f"{HONEYCOMB_OTLP_ENDPOINT}/v1/traces",
+                headers=headers,
+            )
+        )
+    )
+    trace.set_tracer_provider(tracer_provider)
+
+    logger_provider = LoggerProvider(resource=resource)
+    logger_provider.add_log_record_processor(
+        BatchLogRecordProcessor(
+            OTLPLogExporter(
+                endpoint=f"{HONEYCOMB_OTLP_ENDPOINT}/v1/logs",
+                headers=headers,
+            )
+        )
+    )
+    set_logger_provider(logger_provider)
+    logging.getLogger().addHandler(
+        LoggingHandler(level=logging.INFO, logger_provider=logger_provider)
+    )
+
+    _instrument_libraries()
+    _otel_initialized = True
+
+
+def _instrument_libraries() -> None:
+    """Attach auto-instrumentations. Each is wrapped so a single missing
+    optional dep can't take the whole process down."""
+    try:
+        from opentelemetry.instrumentation.django import DjangoInstrumentor
+
+        DjangoInstrumentor().instrument()
+    except Exception:
+        logger.warning("OTel Django instrumentation failed", exc_info=True)
+    try:
+        from opentelemetry.instrumentation.psycopg import PsycopgInstrumentor
+
+        PsycopgInstrumentor().instrument(enable_commenter=True)
+    except Exception:
+        logger.warning("OTel psycopg instrumentation failed", exc_info=True)
+    try:
+        from opentelemetry.instrumentation.requests import RequestsInstrumentor
+
+        RequestsInstrumentor().instrument()
+    except Exception:
+        logger.warning("OTel requests instrumentation failed", exc_info=True)
+
+
+def get_tracer():
+    """Always returns a tracer — no-op tracer when OTel hasn't been initialized."""
+    from opentelemetry import trace
+
+    return trace.get_tracer(TRACER_NAME)
+
+
+def init_posthog() -> None:
+    """Configure the PostHog client. Idempotent. No-op if POSTHOG_API_KEY unset."""
+    global _posthog_initialized
+    if _posthog_initialized:
+        return
+    api_key = os.environ.get("POSTHOG_API_KEY")
+    if not api_key:
+        return
+    import posthog
+
+    posthog.api_key = api_key
+    posthog.host = os.environ.get("POSTHOG_HOST", DEFAULT_POSTHOG_HOST)
+    _posthog_initialized = True
+
+
+def distinct_id_for_user(user) -> str:
+    """Stable per-user identifier. Hashes user.id so PostHog never sees the
+    raw db PK."""
+    return hashlib.sha256(f"aod-user:{user.id}".encode()).hexdigest()[:32]
+
+
+def track(
+    event: str,
+    user=None,
+    properties: dict[str, Any] | None = None,
+) -> None:
+    """Capture a product-analytics event. No-op when PostHog isn't configured.
+
+    Properties MUST contain only non-sensitive metadata (counts, lengths, IDs,
+    runtime, model, status). Callers are responsible — see module docstring.
+    """
+    if not _posthog_initialized:
+        return
+    import posthog
+
+    distinct = distinct_id_for_user(user) if user is not None else "aod-system"
+    try:
+        posthog.capture(distinct, event, properties or {})
+    except Exception:
+        logger.warning("posthog.capture failed for event=%s", event, exc_info=True)

--- a/src/agent_on_demand/session_service/provisioning.py
+++ b/src/agent_on_demand/session_service/provisioning.py
@@ -15,6 +15,7 @@ import shlex
 from sprites import NetworkPolicy, PolicyRule, Sprite, SpriteError
 
 from agent_on_demand.models import Environment
+from agent_on_demand.observability import get_tracer
 
 from .client import best_effort_delete, require_client
 from .errors import ProvisionError
@@ -40,28 +41,45 @@ def provision_session(user, spec: SessionSpec) -> Sprite:
     On any failure the Sprite is best-effort deleted before a `ProvisionError`
     is re-raised.
     """
-    client = require_client(user)
-    try:
-        sprite = client.create_sprite(spec.name)
-    except SpriteError as e:
-        raise ProvisionError(f"Failed to create Sprite: {e}", stage="create") from e
+    env = spec.environment
+    tracer = get_tracer()
+    with tracer.start_as_current_span(
+        "session.provision",
+        attributes={
+            "aod.runtime": spec.runtime.name,
+            "aod.repo_count": len(spec.repos),
+            "aod.skill_count": len(spec.skills),
+            "aod.mcp_server_count": len(spec.mcp_servers),
+            "aod.env_var_count": len((env.env_vars or {})) if env else 0,
+            "aod.networking_type": env.networking_type if env else "none",
+            "aod.has_setup_script": bool((env.setup_script or "").strip()) if env else False,
+        },
+    ) as span:
+        client = require_client(user)
+        try:
+            sprite = client.create_sprite(spec.name)
+        except SpriteError as e:
+            span.set_attribute("aod.failure_stage", "create")
+            raise ProvisionError(f"Failed to create Sprite: {e}", stage="create") from e
 
-    try:
-        _apply_network_policy(sprite, spec.environment)
-        _write_env_file(sprite, spec)
-        _install_packages(sprite, spec.environment)
-        _clone_repos(sprite, spec.repos)
-        _run_user_setup(sprite, spec.environment)
-        _write_mcp_config(sprite, spec.runtime.name, spec.mcp_servers)
-        _write_skills(sprite, spec.runtime.name, spec.skills)
-    except ProvisionError:
-        best_effort_delete(client, spec.name)
-        raise
-    except SpriteError as e:
-        best_effort_delete(client, spec.name)
-        raise ProvisionError(f"Failed to prepare Sprite: {e}", stage="unknown") from e
+        try:
+            _apply_network_policy(sprite, env)
+            _write_env_file(sprite, spec)
+            _install_packages(sprite, env)
+            _clone_repos(sprite, spec.repos)
+            _run_user_setup(sprite, env)
+            _write_mcp_config(sprite, spec.runtime.name, spec.mcp_servers)
+            _write_skills(sprite, spec.runtime.name, spec.skills)
+        except ProvisionError as e:
+            span.set_attribute("aod.failure_stage", e.stage)
+            best_effort_delete(client, spec.name)
+            raise
+        except SpriteError as e:
+            span.set_attribute("aod.failure_stage", "unknown")
+            best_effort_delete(client, spec.name)
+            raise ProvisionError(f"Failed to prepare Sprite: {e}", stage="unknown") from e
 
-    return sprite
+        return sprite
 
 
 def resume_session(user, sprite_name: str) -> Sprite:

--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -27,6 +27,7 @@ from procrastinate.contrib.django import app as procrastinate_app
 from sprites import ExecError
 
 from agent_on_demand.models import AgentSession, AgentSessionLog, SessionTurn
+from agent_on_demand.observability import get_tracer, track
 from agent_on_demand.runtimes import RUNTIMES, RuntimeConfig
 
 from .provisioning import resume_session
@@ -121,7 +122,26 @@ def _execute_turn_inner(
     session = AgentSession.objects.select_related("user").get(pk=session_id)
     turn = SessionTurn.objects.get(pk=turn_id)
     runtime = RUNTIMES[session.runtime]
-    sprite = resume_session(session.user, session.sprite_name)
+
+    tracer = get_tracer()
+    with tracer.start_as_current_span(
+        "session.execute_turn",
+        attributes={
+            "aod.session_id": session_id,
+            "aod.turn_number": turn.turn_number,
+            "aod.runtime": session.runtime,
+            "aod.mode": mode,
+            "aod.prompt_length": len(prompt),
+            "aod.timeout": timeout,
+        },
+    ) as span:
+        sprite = resume_session(session.user, session.sprite_name)
+        _execute_turn_body(session, turn, runtime, sprite, prompt, mode, timeout, span)
+
+
+def _execute_turn_body(
+    session, turn, runtime, sprite, prompt, mode, timeout, span
+) -> None:
 
     output_q: queue.Queue = queue.Queue(maxsize=4096)
     db_buffer: list[AgentSessionLog] = []
@@ -211,3 +231,22 @@ def _execute_turn_inner(
     turn.exit_code = exit_code
     turn.ended_at = ended
     turn.save(update_fields=["status", "exit_code", "ended_at"])
+
+    duration_seconds = (ended - now).total_seconds()
+    span.set_attribute("aod.final_status", final_status)
+    if exit_code is not None:
+        span.set_attribute("aod.exit_code", exit_code)
+    span.set_attribute("aod.duration_seconds", duration_seconds)
+
+    track(
+        f"session.{final_status}",
+        user=session.user,
+        properties={
+            "session_id": str(session.id),
+            "turn_number": turn.turn_number,
+            "runtime": session.runtime,
+            "exit_code": exit_code,
+            "duration_seconds": duration_seconds,
+            "mode": mode,
+        },
+    )

--- a/src/agent_on_demand/views/agents.py
+++ b/src/agent_on_demand/views/agents.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from agent_on_demand.auth import require_api_key
 from agent_on_demand.models import Agent, AgentVersion, Environment
+from agent_on_demand.observability import track
 from agent_on_demand.runtimes import RUNTIMES, AgentModel
 
 
@@ -262,6 +263,22 @@ def agents_list_create(request):
         )
         _snapshot_version(agent)
 
+        track(
+            "agent.created",
+            user=request.user,
+            properties={
+                "agent_id": str(agent.id),
+                "runtime": agent.runtime,
+                "model": agent.model,
+                "has_environment": agent.environment_id is not None,
+                "system_length": len(agent.system or ""),
+                "description_length": len(agent.description or ""),
+                "skill_count": len(agent.skills or []),
+                "mcp_server_count": len(agent.mcp_servers or []),
+                "metadata_key_count": len(agent.metadata or {}),
+            },
+        )
+
         return JsonResponse(_serialize_agent(agent), status=201)
 
     elif request.method == "GET":
@@ -346,6 +363,16 @@ def agent_detail(request, agent_id):
             agent.version += 1
             agent.save()
             _snapshot_version(agent)
+            track(
+                "agent.updated",
+                user=request.user,
+                properties={
+                    "agent_id": str(agent.id),
+                    "version": agent.version,
+                    "runtime": agent.runtime,
+                    "model": agent.model,
+                },
+            )
 
         return JsonResponse(_serialize_agent(agent))
 
@@ -367,6 +394,8 @@ def agent_archive(request, agent_id):
 
     agent.archived_at = timezone.now()
     agent.save(update_fields=["archived_at", "updated_at"])
+
+    track("agent.archived", user=request.user, properties={"agent_id": str(agent.id)})
 
     return JsonResponse(_serialize_agent(agent))
 

--- a/src/agent_on_demand/views/environments.py
+++ b/src/agent_on_demand/views/environments.py
@@ -9,6 +9,21 @@ from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from agent_on_demand.auth import require_api_key
 from agent_on_demand.models import Environment, EnvironmentVersion
+from agent_on_demand.observability import track
+
+
+def _env_safe_props(env: Environment) -> dict:
+    """Counts/flags only — never raw env_var values, names, or scripts."""
+    return {
+        "environment_id": str(env.id),
+        "package_count": sum(len(pkgs) for pkgs in (env.packages or {}).values()),
+        "package_managers": sorted((env.packages or {}).keys()),
+        "env_var_count": len(env.env_vars or {}),
+        "has_setup_script": bool((env.setup_script or "").strip()),
+        "setup_script_length": len(env.setup_script or ""),
+        "networking_type": env.networking_type,
+        "allowed_hosts_count": len((env.networking_config or {}).get("allowed_hosts", [])),
+    }
 
 
 VALID_PACKAGE_MANAGERS = {"apt", "cargo", "gem", "go", "npm", "pip"}
@@ -157,6 +172,8 @@ def environments_list_create(request):
         )
         _snapshot_environment_version(env)
 
+        track("environment.created", user=request.user, properties=_env_safe_props(env))
+
         return JsonResponse(_serialize_environment(env), status=201)
 
     elif request.method == "GET":
@@ -229,6 +246,11 @@ def environment_detail(request, environment_id):
             env.version += 1
             env.save()
             _snapshot_environment_version(env)
+            track(
+                "environment.updated",
+                user=request.user,
+                properties={**_env_safe_props(env), "version": env.version},
+            )
 
         return JsonResponse(_serialize_environment(env))
 
@@ -250,6 +272,12 @@ def environment_archive(request, environment_id):
 
     env.archived_at = timezone.now()
     env.save(update_fields=["archived_at", "updated_at"])
+
+    track(
+        "environment.archived",
+        user=request.user,
+        properties={"environment_id": str(env.id)},
+    )
 
     return JsonResponse(_serialize_environment(env))
 

--- a/src/agent_on_demand/views/sessions.py
+++ b/src/agent_on_demand/views/sessions.py
@@ -23,6 +23,7 @@ from agent_on_demand.models import (
     SessionTurn,
     UserRuntimeKey,
 )
+from agent_on_demand.observability import track
 from agent_on_demand.runtimes import RUNTIMES
 from agent_on_demand.session_service import (
     McpServerSpec,
@@ -299,6 +300,24 @@ def _create_session(request):
 
     session_service.run_turn(session, turn, sprite, effective_prompt, "run", float(req.timeout))
 
+    track(
+        "session.created",
+        user=request.user,
+        properties={
+            "session_id": str(session.id),
+            "agent_id": str(agent_obj.id),
+            "environment_id": str(environment_obj.id) if environment_obj else None,
+            "runtime": runtime,
+            "model": agent_obj.model,
+            "prompt_length": len(req.prompt),
+            "repo_count": len(req.resources),
+            "mcp_server_count": len(agent_obj.mcp_servers or []),
+            "skill_count": len(agent_obj.skills or []),
+            "env_var_count": len((environment_obj.env_vars or {})) if environment_obj else 0,
+            "timeout": req.timeout,
+        },
+    )
+
     return JsonResponse(
         {
             "id": str(session.id),
@@ -432,6 +451,17 @@ def send_prompt(request, session_id):
 
     session_service.run_turn(session, turn, sprite, req.prompt, "continue", float(req.timeout))
 
+    track(
+        "session.prompt_sent",
+        user=request.user,
+        properties={
+            "session_id": str(session.id),
+            "turn_number": turn.turn_number,
+            "prompt_length": len(req.prompt),
+            "timeout": req.timeout,
+        },
+    )
+
     return JsonResponse(
         {
             "id": str(session.id),
@@ -474,6 +504,12 @@ def terminate_session(request, session_id):
     session.status = "terminated"
     session.sprite_name = ""
     session.save(update_fields=["status", "sprite_name", "updated_at"])
+
+    track(
+        "session.terminated",
+        user=request.user,
+        properties={"session_id": str(session.id)},
+    )
 
     return JsonResponse(
         {

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,247 @@
+"""PostHog event firing + sensitive-data leak guards.
+
+These tests do NOT touch the network — they patch `posthog.capture` and force
+`_posthog_initialized=True` so `track()` calls reach the mock. The init
+helpers themselves are validated as no-ops when their env vars are unset.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+
+from agent_on_demand import observability
+from agent_on_demand.models import APIKey, UserRuntimeKey, UserSpritesKey
+
+
+SENSITIVE_PROMPT = "PLEASE_DO_NOT_LEAK_THIS_PROMPT_TEXT_2026"
+SENSITIVE_REPO_URL = "https://github.com/secret-org/super-private-repo"
+SENSITIVE_ENV_VALUE = "PLEASE_DO_NOT_LEAK_THIS_SECRET_VALUE"
+SENSITIVE_ENV_KEY = "AOD_TEST_SUPER_SECRET"
+SENSITIVE_SETUP_SCRIPT = "echo PLEASE_DO_NOT_LEAK_SETUP_SCRIPT_BODY"
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="obs", password="pass")
+
+
+@pytest.fixture
+def auth_headers(user):
+    _, raw = APIKey.create_key(user, "k")
+    return {"HTTP_AUTHORIZATION": f"Bearer {raw}"}
+
+
+@pytest.fixture
+def runtime_keys(user):
+    usk = UserSpritesKey(user=user)
+    usk.set_api_key("fake-sprites")
+    usk.save()
+    urk = UserRuntimeKey(user=user, runtime="claude")
+    urk.set_api_key("fake-anthropic")
+    urk.save()
+
+
+@pytest.fixture
+def captured_events(mocker):
+    """Force PostHog to look initialized + capture every track() call."""
+    mocker.patch.object(observability, "_posthog_initialized", True)
+    events: list[dict[str, Any]] = []
+
+    def _capture(distinct_id, event, properties):
+        events.append({"distinct_id": distinct_id, "event": event, "properties": properties})
+
+    mocker.patch("posthog.capture", side_effect=_capture)
+    return events
+
+
+def _all_property_strings(events: list[dict[str, Any]]) -> str:
+    """Concatenate every property value (including nested) into one searchable
+    blob for substring leak assertions."""
+    return json.dumps(events, default=str)
+
+
+# --- init helpers no-op when env unset ---
+
+
+def test_init_otel_noop_without_api_key(monkeypatch):
+    monkeypatch.delenv("HONEYCOMB_API_KEY", raising=False)
+    monkeypatch.setattr(observability, "_otel_initialized", False)
+    observability.init_otel()
+    assert observability._otel_initialized is False
+
+
+def test_init_posthog_noop_without_api_key(monkeypatch):
+    monkeypatch.delenv("POSTHOG_API_KEY", raising=False)
+    monkeypatch.setattr(observability, "_posthog_initialized", False)
+    observability.init_posthog()
+    assert observability._posthog_initialized is False
+
+
+def test_track_noop_when_posthog_uninitialized(monkeypatch, mocker):
+    monkeypatch.setattr(observability, "_posthog_initialized", False)
+    spy = mocker.patch("posthog.capture")
+    observability.track("anything", user=None, properties={"x": 1})
+    spy.assert_not_called()
+
+
+def test_distinct_id_is_stable_and_hashed(user):
+    a = observability.distinct_id_for_user(user)
+    b = observability.distinct_id_for_user(user)
+    assert a == b
+    assert len(a) == 32
+    # Hex-only — never the raw username or any other identifying field
+    assert all(c in "0123456789abcdef" for c in a)
+    assert user.username not in a
+
+
+# --- agent.created event + leak guard ---
+
+
+@pytest.mark.django_db
+def test_agent_created_event_fires_with_safe_props(client: Client, auth_headers, captured_events):
+    resp = client.post(
+        "/agents",
+        data=json.dumps(
+            {
+                "name": "obs-agent",
+                "model": "claude-sonnet-4-6",
+                "runtime": "claude",
+                "system": "SYSTEM_PROMPT_BODY_SHOULD_NOT_LEAK",
+                "skills": [
+                    {
+                        "name": "skill-one",
+                        "description": "SKILL_DESC_SHOULD_NOT_LEAK",
+                        "content": "---\nname: skill-one\ndescription: x\n---\nSKILL_BODY",
+                    }
+                ],
+            }
+        ),
+        content_type="application/json",
+        **auth_headers,
+    )
+    assert resp.status_code == 201
+    matched = [e for e in captured_events if e["event"] == "agent.created"]
+    assert len(matched) == 1
+    props = matched[0]["properties"]
+    assert props["runtime"] == "claude"
+    assert props["model"] == "claude-sonnet-4-6"
+    assert props["skill_count"] == 1
+    assert props["system_length"] == len("SYSTEM_PROMPT_BODY_SHOULD_NOT_LEAK")
+
+    blob = _all_property_strings(captured_events)
+    assert "SYSTEM_PROMPT_BODY_SHOULD_NOT_LEAK" not in blob
+    assert "SKILL_DESC_SHOULD_NOT_LEAK" not in blob
+    assert "SKILL_BODY" not in blob
+
+
+# --- environment.created event + leak guard ---
+
+
+@pytest.mark.django_db
+def test_environment_created_event_excludes_secret_values(
+    client: Client, auth_headers, captured_events
+):
+    resp = client.post(
+        "/environments",
+        data=json.dumps(
+            {
+                "name": "obs-env",
+                "packages": {"pip": ["requests", "httpx"]},
+                "env_vars": {SENSITIVE_ENV_KEY: SENSITIVE_ENV_VALUE},
+                "setup_script": SENSITIVE_SETUP_SCRIPT,
+                "networking": {"type": "limited", "allowed_hosts": ["api.example.com"]},
+            }
+        ),
+        content_type="application/json",
+        **auth_headers,
+    )
+    assert resp.status_code == 201
+    matched = [e for e in captured_events if e["event"] == "environment.created"]
+    assert len(matched) == 1
+    props = matched[0]["properties"]
+    assert props["env_var_count"] == 1
+    assert props["package_count"] == 2
+    assert props["package_managers"] == ["pip"]
+    assert props["networking_type"] == "limited"
+    assert props["allowed_hosts_count"] == 1
+    assert props["has_setup_script"] is True
+
+    blob = _all_property_strings(captured_events)
+    assert SENSITIVE_ENV_KEY not in blob
+    assert SENSITIVE_ENV_VALUE not in blob
+    assert "PLEASE_DO_NOT_LEAK_SETUP_SCRIPT_BODY" not in blob
+
+
+# --- session.created event + leak guard (prompt + repo URL must not appear) ---
+
+
+@pytest.mark.django_db
+def test_session_created_event_excludes_prompt_and_repo_url(
+    client: Client, auth_headers, runtime_keys, fake_sprites, captured_events
+):
+    # Create env + agent
+    env_resp = client.post(
+        "/environments",
+        data=json.dumps(
+            {
+                "name": "obs-env",
+                "env_vars": {SENSITIVE_ENV_KEY: SENSITIVE_ENV_VALUE},
+            }
+        ),
+        content_type="application/json",
+        **auth_headers,
+    )
+    env_id = env_resp.json()["id"]
+
+    agent_resp = client.post(
+        "/agents",
+        data=json.dumps(
+            {
+                "name": "a",
+                "model": "claude-sonnet-4-6",
+                "runtime": "claude",
+                "environment_id": env_id,
+            }
+        ),
+        content_type="application/json",
+        **auth_headers,
+    )
+    agent_id = agent_resp.json()["id"]
+
+    # Drop pre-session events so the assertion blob is just the session ones
+    captured_events.clear()
+
+    resp = client.post(
+        "/sessions",
+        data=json.dumps(
+            {
+                "agent_id": agent_id,
+                "prompt": SENSITIVE_PROMPT,
+                "resources": [
+                    {"type": "github_repository", "url": SENSITIVE_REPO_URL}
+                ],
+            }
+        ),
+        content_type="application/json",
+        **auth_headers,
+    )
+    assert resp.status_code == 202
+
+    matched = [e for e in captured_events if e["event"] == "session.created"]
+    assert len(matched) == 1
+    props = matched[0]["properties"]
+    assert props["runtime"] == "claude"
+    assert props["repo_count"] == 1
+    assert props["env_var_count"] == 1
+    assert props["prompt_length"] == len(SENSITIVE_PROMPT)
+
+    blob = _all_property_strings(captured_events)
+    assert SENSITIVE_PROMPT not in blob
+    assert SENSITIVE_REPO_URL not in blob
+    assert SENSITIVE_ENV_KEY not in blob
+    assert SENSITIVE_ENV_VALUE not in blob

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,14 @@ dependencies = [
     { name = "django", version = "6.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "django-cors-headers" },
     { name = "gunicorn" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-django" },
+    { name = "opentelemetry-instrumentation-logging" },
+    { name = "opentelemetry-instrumentation-psycopg" },
+    { name = "opentelemetry-instrumentation-requests" },
+    { name = "opentelemetry-sdk" },
+    { name = "posthog" },
     { name = "procrastinate", extra = ["django"] },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
@@ -54,7 +62,15 @@ requires-dist = [
     { name = "gunicorn", specifier = ">=23.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
+    { name = "opentelemetry-api", specifier = ">=1.29" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.29" },
+    { name = "opentelemetry-instrumentation-django", specifier = ">=0.50b0" },
+    { name = "opentelemetry-instrumentation-logging", specifier = ">=0.50b0" },
+    { name = "opentelemetry-instrumentation-psycopg", specifier = ">=0.50b0" },
+    { name = "opentelemetry-instrumentation-requests", specifier = ">=0.50b0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.29" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
+    { name = "posthog", specifier = ">=3.7" },
     { name = "procrastinate", extras = ["django"], specifier = ">=3.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
@@ -129,6 +145,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
 ]
 
 [[package]]
@@ -586,6 +611,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "dj-database-url"
 version = "3.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -677,6 +711,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.74.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254, upload-time = "2026-04-02T21:23:26.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743, upload-time = "2026-04-02T21:22:49.108Z" },
+]
+
+[[package]]
 name = "gunicorn"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -732,6 +778,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
 ]
 
 [[package]]
@@ -1153,6 +1211,200 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/8e/3778a7e87801d994869a9396b9fc2a289e5f9be91ff54a27d41eace494b0/opentelemetry_api-1.41.0.tar.gz", hash = "sha256:9421d911326ec12dee8bc933f7839090cad7a3f13fcfb0f9e82f8174dc003c09", size = 71416, upload-time = "2026-04-09T14:38:34.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/ee/99ab786653b3bda9c37ade7e24a7b607a1b1f696063172768417539d876d/opentelemetry_api-1.41.0-py3-none-any.whl", hash = "sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f", size = 69007, upload-time = "2026-04-09T14:38:11.833Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/28/e8eca94966fe9a1465f6094dc5ddc5398473682180279c94020bc23b4906/opentelemetry_exporter_otlp_proto_common-1.41.0.tar.gz", hash = "sha256:966bbce537e9edb166154779a7c4f8ab6b8654a03a28024aeaf1a3eacb07d6ee", size = 20411, upload-time = "2026-04-09T14:38:36.572Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/c4/78b9bf2d9c1d5e494f44932988d9d91c51a66b9a7b48adf99b62f7c65318/opentelemetry_exporter_otlp_proto_common-1.41.0-py3-none-any.whl", hash = "sha256:7a99177bf61f85f4f9ed2072f54d676364719c066f6d11f515acc6c745c7acf0", size = 18366, upload-time = "2026-04-09T14:38:15.135Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/63/d9f43cd75f3fabb7e01148c89cfa9491fc18f6580a6764c554ff7c953c46/opentelemetry_exporter_otlp_proto_http-1.41.0.tar.gz", hash = "sha256:dcd6e0686f56277db4eecbadd5262124e8f2cc739cadbc3fae3d08a12c976cf5", size = 24139, upload-time = "2026-04-09T14:38:38.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b5/a214cd907eedc17699d1c2d602288ae17cb775526df04db3a3b3585329d2/opentelemetry_exporter_otlp_proto_http-1.41.0-py3-none-any.whl", hash = "sha256:a9c4ee69cce9c3f4d7ee736ad1b44e3c9654002c0816900abbafd9f3cf289751", size = 22673, upload-time = "2026-04-09T14:38:18.349Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/fd/b8e90bb340957f059084376f94cff336b0e871a42feba7d3f7342365e987/opentelemetry_instrumentation-0.62b0.tar.gz", hash = "sha256:aa1b0b9ab2e1722c2a8a5384fb016fc28d30bba51826676c8036074790d2861e", size = 34042, upload-time = "2026-04-09T14:40:22.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b6/3356d2e335e3c449c5183e9b023f30f04f1b7073a6583c68745ea2e704b1/opentelemetry_instrumentation-0.62b0-py3-none-any.whl", hash = "sha256:30d4e76486eae64fb095264a70c2c809c4bed17b73373e53091470661f7d477c", size = 34158, upload-time = "2026-04-09T14:39:21.428Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-dbapi"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/bd/1030ec9d77d70bd8273ae6d84e32b144f9cff23c2a0ea053425db52d8dae/opentelemetry_instrumentation_dbapi-0.62b0.tar.gz", hash = "sha256:d573e388fb7da1cbe8c34b138167dd5c28f840bdcffb25ff0e33dc54fb3e4da7", size = 16849, upload-time = "2026-04-09T14:40:33.504Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/92/0cb608b4c113aa5ee8db613e4681ba05baa8f2ef14441dc2957ae1f3c1cf/opentelemetry_instrumentation_dbapi-0.62b0-py3-none-any.whl", hash = "sha256:5c65e03ac68a71159f2d227b2229714feb03e57294658e54e9f5435d2e55edd2", size = 14186, upload-time = "2026-04-09T14:39:38.94Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-django"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-wsgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c6/8fb4956e1ce6a203c0077c155d098aa3577b0c27779fa75c2021b2cc4dbb/opentelemetry_instrumentation_django-0.62b0.tar.gz", hash = "sha256:b38042f7bf7ae415cd3df164613c7699907d98a28319d8799d1123c42b69cb8b", size = 26023, upload-time = "2026-04-09T14:40:34.127Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/0f/adc8d0ae119317cd4ffa1d9d2b02ee8df876ed2c752def5183cef25e7152/opentelemetry_instrumentation_django-0.62b0-py3-none-any.whl", hash = "sha256:dd0ccc312f71a11a0ee719d58677386233d79b2a770ada4c3a174c8fbb3ebe58", size = 20782, upload-time = "2026-04-09T14:39:39.842Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-logging"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/47/8b81b7f007addf4dfd2b2f0753326e62822e1fec674605d0ec7c39d479b0/opentelemetry_instrumentation_logging-0.62b0.tar.gz", hash = "sha256:61f23be960e047054b3aa38998e7d1eb1fd9bef6f52097e28bc113af8b6f3bd8", size = 18968, upload-time = "2026-04-09T14:40:40.733Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/36/135fd0f4a154ea225de0a418d36f8cf9cf273ad31d41a3a2aaa91862b817/opentelemetry_instrumentation_logging-0.62b0-py3-none-any.whl", hash = "sha256:9a27b6c3d419170d96dedcea7d38cc0418f0dd1054365f52499a0a1eb70b8faf", size = 17489, upload-time = "2026-04-09T14:39:49.384Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-psycopg"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-dbapi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/73/77772cd3c62ccf2ae46d763793495bdcc86248af064ec916d881b748a98c/opentelemetry_instrumentation_psycopg-0.62b0.tar.gz", hash = "sha256:403d17299f75094c43fc206d2d6bd42a88a74a4474b6b7d4a7851e386da7da37", size = 11927, upload-time = "2026-04-09T14:40:43.729Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/bd/ed5238d5f66bf64ffc2c019bd4501039335d5fdf1a85653efda901d1a879/opentelemetry_instrumentation_psycopg-0.62b0-py3-none-any.whl", hash = "sha256:c80aa4bb0733ded3cefa9da999444fdf9cbc857bdcab48405217eed791f79849", size = 11661, upload-time = "2026-04-09T14:39:53.44Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-requests"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/77/bbc89f2264e03b53fc3e9462a69415f30c23e88c7f0f5e6ebf594471355e/opentelemetry_instrumentation_requests-0.62b0.tar.gz", hash = "sha256:4534f961729393e8070cd5b779fa42937f5b7380ef481107ffd4042b31816ce2", size = 18398, upload-time = "2026-04-09T14:40:49.615Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/54/a73d688d969283f344de96c43366912addb94bdbef413bcebac22979545e/opentelemetry_instrumentation_requests-0.62b0-py3-none-any.whl", hash = "sha256:edf61785ecb3ec6923e33c24074c82067f286a418f817b2b82546956d120e6d6", size = 14209, upload-time = "2026-04-09T14:40:02.987Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-wsgi"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/5c/ed45ff053d76c94c59173f2bcde3d61052adb10214f70f028f760aa56625/opentelemetry_instrumentation_wsgi-0.62b0.tar.gz", hash = "sha256:d179f969ecce0c29a15ffd4d982580dfae57c8ff2fd4d9366e299a6d4815e668", size = 19922, upload-time = "2026-04-09T14:40:56.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/cb/753dbbe624df88594fa35a3ff26302fea22623385ed64462f6c8ee7c81eb/opentelemetry_instrumentation_wsgi-0.62b0-py3-none-any.whl", hash = "sha256:2714ab5ab2f35e67dc181ffa3a43fa15313c85c09b4d024c36d72cf1efa29c9a", size = 14628, upload-time = "2026-04-09T14:40:13.529Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/d9/08e3dc6156878713e8c811682bc76151f5fe1a3cb7f3abda3966fd56e71e/opentelemetry_proto-1.41.0.tar.gz", hash = "sha256:95d2e576f9fb1800473a3e4cfcca054295d06bdb869fda4dc9f4f779dc68f7b6", size = 45669, upload-time = "2026-04-09T14:38:45.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/8c/65ef7a9383a363864772022e822b5d5c6988e6f9dabeebb9278f5b86ebc3/opentelemetry_proto-1.41.0-py3-none-any.whl", hash = "sha256:b970ab537309f9eed296be482c3e7cca05d8aca8165346e929f658dbe153b247", size = 72074, upload-time = "2026-04-09T14:38:29.38Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/0e/a586df1186f9f56b5a0879d52653effc40357b8e88fc50fe300038c3c08b/opentelemetry_sdk-1.41.0.tar.gz", hash = "sha256:7bddf3961131b318fc2d158947971a8e37e38b1cd23470cfb72b624e7cc108bd", size = 230181, upload-time = "2026-04-09T14:38:47.225Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/13/a7825118208cb32e6a4edcd0a99f925cbef81e77b3b0aedfd9125583c543/opentelemetry_sdk-1.41.0-py3-none-any.whl", hash = "sha256:a596f5687964a3e0d7f8edfdcf5b79cbca9c93c7025ebf5fb00f398a9443b0bd", size = 180214, upload-time = "2026-04-09T14:38:30.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/b0/c14f723e86c049b7bf8ff431160d982519b97a7be2857ed2247377397a24/opentelemetry_semantic_conventions-0.62b0.tar.gz", hash = "sha256:cbfb3c8fc259575cf68a6e1b94083cc35adc4a6b06e8cf431efa0d62606c0097", size = 145753, upload-time = "2026-04-09T14:38:48.274Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/6c/5e86fa1759a525ef91c2d8b79d668574760ff3f900d114297765eb8786cb/opentelemetry_semantic_conventions-0.62b0-py3-none-any.whl", hash = "sha256:0ddac1ce59eaf1a827d9987ab60d9315fb27aea23304144242d1fcad9e16b489", size = 231619, upload-time = "2026-04-09T14:38:32.394Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/e7/830f7c57135158eb8a8efd3f94ab191a89e3b8a49bed314a35ee501da3f2/opentelemetry_util_http-0.62b0.tar.gz", hash = "sha256:a62e4b19b8a432c0de657f167dee3455516136bb9c6ed463ca8063019970d835", size = 11393, upload-time = "2026-04-09T14:40:59.442Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/7f/5c1b7d4385852b9e5eacd4e7f9d8b565d3d351d17463b24916ad098adf1a/opentelemetry_util_http-0.62b0-py3-none-any.whl", hash = "sha256:c20462808d8cc95b69b0dc4a3e02a9d36beb663347e96c931f51ffd78bd318ad", size = 9294, upload-time = "2026-04-09T14:40:19.014Z" },
+]
+
+[[package]]
 name = "packageurl-python"
 version = "0.17.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1262,6 +1514,23 @@ wheels = [
 ]
 
 [[package]]
+name = "posthog"
+version = "7.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+    { name = "six" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/cc/cbebc13accaa015f733a67c74261ae13b86860cdf84e86a65e77c6125d8c/posthog-7.12.0.tar.gz", hash = "sha256:9385b207b87e642f17b784d74c18e6f28952ac7cde781d31675097d1a4dbc14e", size = 193445, upload-time = "2026-04-16T08:39:08.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/4b/40894963647d5044f591099cfe10fe16b688e8e6fb6ed980ccc2c784a3f5/posthog-7.12.0-py3-none-any.whl", hash = "sha256:df1444aa485b45318207f7b5100d955cde4d585e2e7f5b736ade45dcc6d2a60d", size = 226894, upload-time = "2026-04-16T08:39:05.896Z" },
+]
+
+[[package]]
 name = "procrastinate"
 version = "3.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1283,6 +1552,21 @@ wheels = [
 django = [
     { name = "django", version = "5.2.13", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "django", version = "6.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -2020,4 +2304,88 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cb/2a/55b3f3a4ec326cd077c1c3defeee656b9298372a69229134d930151acd01/whitenoise-6.12.0.tar.gz", hash = "sha256:f723ebb76a112e98816ff80fcea0a6c9b8ecde835f8ddda25df7a30a3c2db6ad", size = 26841, upload-time = "2026-02-27T00:05:42.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/eb/d5583a11486211f3ebd4b385545ae787f32363d453c19fffd81106c9c138/whitenoise-6.12.0-py3-none-any.whl", hash = "sha256:fc5e8c572e33ebf24795b47b6a7da8da3c00cff2349f5b04c02f28d0cc5a3cc2", size = 20302, upload-time = "2026-02-27T00:05:40.086Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/81/60c4471fce95afa5922ca09b88a25f03c93343f759aae0f31fb4412a85c7/wrapt-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96159a0ee2b0277d44201c3b5be479a9979cf154e8c82fa5df49586a8e7679bb", size = 60666, upload-time = "2026-03-06T02:52:58.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/be/80e80e39e7cb90b006a0eaf11c73ac3a62bbfb3068469aec15cc0bc795de/wrapt-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98ba61833a77b747901e9012072f038795de7fc77849f1faa965464f3f87ff2d", size = 61601, upload-time = "2026-03-06T02:53:00.487Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/be/d7c88cd9293c859fc74b232abdc65a229bb953997995d6912fc85af18323/wrapt-2.1.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:767c0dbbe76cae2a60dd2b235ac0c87c9cccf4898aef8062e57bead46b5f6894", size = 114057, upload-time = "2026-03-06T02:52:44.08Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/25/36c04602831a4d685d45a93b3abea61eca7fe35dab6c842d6f5d570ef94a/wrapt-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c691a6bc752c0cc4711cc0c00896fcd0f116abc253609ef64ef930032821842", size = 116099, upload-time = "2026-03-06T02:54:56.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4e/98a6eb417ef551dc277bec1253d5246b25003cf36fdf3913b65cb7657a56/wrapt-2.1.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f3b7d73012ea75aee5844de58c88f44cf62d0d62711e39da5a82824a7c4626a8", size = 112457, upload-time = "2026-03-06T02:53:52.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/a6/a6f7186a5297cad8ec53fd7578533b28f795fdf5372368c74bd7e6e9841c/wrapt-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:577dff354e7acd9d411eaf4bfe76b724c89c89c8fc9b7e127ee28c5f7bcb25b6", size = 115351, upload-time = "2026-03-06T02:53:32.684Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6f/06e66189e721dbebd5cf20e138acc4d1150288ce118462f2fcbff92d38db/wrapt-2.1.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d7b6fd105f8b24e5bd23ccf41cb1d1099796524bcc6f7fbb8fe576c44befbc9", size = 111748, upload-time = "2026-03-06T02:53:08.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/43/4808b86f499a51370fbdbdfa6cb91e9b9169e762716456471b619fca7a70/wrapt-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:866abdbf4612e0b34764922ef8b1c5668867610a718d3053d59e24a5e5fcfc15", size = 113783, upload-time = "2026-03-06T02:53:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2c/a3f28b8fa7ac2cefa01cfcaca3471f9b0460608d012b693998cd61ef43df/wrapt-2.1.2-cp311-cp311-win32.whl", hash = "sha256:5a0a0a3a882393095573344075189eb2d566e0fd205a2b6414e9997b1b800a8b", size = 57977, upload-time = "2026-03-06T02:53:27.844Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c3/2b1c7bd07a27b1db885a2fab469b707bdd35bddf30a113b4917a7e2139d2/wrapt-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1", size = 60336, upload-time = "2026-03-06T02:54:28.104Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/5c/76ece7b401b088daa6503d6264dd80f9a727df3e6042802de9a223084ea2/wrapt-2.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a", size = 58756, upload-time = "2026-03-06T02:53:16.319Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]


### PR DESCRIPTION
## Summary
- Adds PostHog for product usage events (agent/env lifecycle, session create/prompt/complete/fail/terminate). Properties are counts/lengths/IDs only — no prompts, env-var values, repo URLs, or system text.
- Adds OpenTelemetry → Honeycomb (traces + logs) with auto-instrumentation for Django, psycopg, and requests, plus manual spans around `provision_session` and `execute_turn`.
- Web and worker services use distinct `OTEL_SERVICE_NAME` values (`aod-web`, `aod-worker`) so Honeycomb routes them into separate datasets.
- Both subsystems are no-ops when their API keys are unset, so dev/CI behave identically without secrets.

## Deploy
After merge, set in the Render `agent-on-demand-api` service env (worker inherits via `fromService`):
- `HONEYCOMB_API_KEY`
- `POSTHOG_API_KEY`

## Test plan
- [x] `make test` — full unit suite green (213 passed)
- [x] `make lint` — ruff clean
- [x] New `tests/test_observability.py` asserts (a) events fire with safe props, (b) sensitive sentinels (prompt text, repo URL, env-var key/value, setup-script body) never appear in any captured payload, (c) `init_otel`/`init_posthog`/`track` are no-ops without keys
- [ ] Post-deploy: confirm `aod-web` and `aod-worker` datasets appear in Honeycomb and a `session.created` event lands in PostHog

🤖 Generated with [Claude Code](https://claude.com/claude-code)