### PR TITLE
Fix PostHog capture call for SDK v7

### DIFF
--- a/src/agent_on_demand/observability.py
+++ b/src/agent_on_demand/observability.py
@@ -123,7 +123,9 @@ def init_posthog() -> None:
         return
     import posthog
 
-    posthog.api_key = api_key
+    # posthog-python 7.x renamed `api_key` to `project_api_key`; both still
+    # exist as module attrs but only the latter is wired up in the new API.
+    posthog.project_api_key = api_key
     posthog.host = os.environ.get("POSTHOG_HOST", DEFAULT_POSTHOG_HOST)
     _posthog_initialized = True
 
@@ -150,6 +152,9 @@ def track(
 
     distinct = distinct_id_for_user(user) if user is not None else "aod-system"
     try:
-        posthog.capture(distinct, event, properties or {})
+        # posthog-python 7.x: capture(event, **kwargs) — distinct_id is a kwarg.
+        # The old `capture(distinct, event, props)` positional form silently
+        # mis-binds (event = distinct_id) and drops the rest.
+        posthog.capture(event, distinct_id=distinct, properties=properties or {})
     except Exception:
         logger.warning("posthog.capture failed for event=%s", event, exc_info=True)

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -48,11 +48,17 @@ def runtime_keys(user):
 
 @pytest.fixture
 def captured_events(mocker):
-    """Force PostHog to look initialized + capture every track() call."""
+    """Force PostHog to look initialized + capture every track() call.
+
+    The fake `_capture` mirrors the real posthog-python 7.x signature
+    `capture(event, *, distinct_id=None, properties=None, ...)`. Using
+    keyword-only kwargs here means a regression to the old positional form
+    in `track()` will raise TypeError instead of silently doing nothing.
+    """
     mocker.patch.object(observability, "_posthog_initialized", True)
     events: list[dict[str, Any]] = []
 
-    def _capture(distinct_id, event, properties):
+    def _capture(event, *, distinct_id=None, properties=None, **_kwargs):
         events.append({"distinct_id": distinct_id, "event": event, "properties": properties})
 
     mocker.patch("posthog.capture", side_effect=_capture)


### PR DESCRIPTION
## Summary
- `posthog-python` 7.x changed `capture()` to `capture(event, **kwargs)` — `distinct_id` is now keyword-only — and renamed `api_key` → `project_api_key`. Our positional `capture(distinct, event, props)` silently mis-bound (event was set to the distinct_id), so no events reached PostHog after the merge.
- Switches the call to the v7 keyword form and uses `project_api_key`.
- Hardens the test fixture so the fake `posthog.capture` requires the v7 keyword-only signature — a future regression to positional args will fail the test instead of silently dropping events.

## Test plan
- [x] `make test` — observability tests pass with the strict-signature fixture
- [ ] Post-deploy: create an agent, confirm `agent.created` event appears in PostHog Live Events