### PR TITLE
Fix PostHog init: restore api_key attr and exercise real init in tests

### DIFF
--- a/src/agent_on_demand/observability.py
+++ b/src/agent_on_demand/observability.py
@@ -123,10 +123,21 @@ def init_posthog() -> None:
         return
     import posthog
 
-    # posthog-python 7.x renamed `api_key` to `project_api_key`; both still
-    # exist as module attrs but only the latter is wired up in the new API.
-    posthog.project_api_key = api_key
+    # `posthog.project_api_key` exists as a module attr in v7 but is unused
+    # by `setup()`, which still reads `posthog.api_key`. Setting the wrong
+    # one makes every `capture()` call raise ValueError at first invocation.
+    posthog.api_key = api_key
     posthog.host = os.environ.get("POSTHOG_HOST", DEFAULT_POSTHOG_HOST)
+
+    # Build the singleton client now, not lazily on first capture, so a bad
+    # config (missing/invalid key, bad host) fails at process boot instead
+    # of silently dropping the first N events.
+    try:
+        posthog.setup()
+    except Exception:
+        logger.exception("posthog.setup() failed — events will not be captured")
+        return
+
     _posthog_initialized = True
 
 
@@ -153,8 +164,10 @@ def track(
     distinct = distinct_id_for_user(user) if user is not None else "aod-system"
     try:
         # posthog-python 7.x: capture(event, **kwargs) — distinct_id is a kwarg.
-        # The old `capture(distinct, event, props)` positional form silently
-        # mis-binds (event = distinct_id) and drops the rest.
+        # The old `capture(distinct, event, props)` positional form raises
+        # TypeError because **kwargs doesn't accept positional args.
         posthog.capture(event, distinct_id=distinct, properties=properties or {})
     except Exception:
-        logger.warning("posthog.capture failed for event=%s", event, exc_info=True)
+        # Surface at error so a bad signature/config is visible in logs;
+        # we still swallow so a PostHog outage doesn't take the API down.
+        logger.exception("posthog.capture failed for event=%s", event)

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -47,21 +47,31 @@ def runtime_keys(user):
 
 
 @pytest.fixture
-def captured_events(mocker):
-    """Force PostHog to look initialized + capture every track() call.
+def captured_events(monkeypatch, mocker):
+    """Set POSTHOG_API_KEY, run the real `init_posthog()`, then mock at the
+    Client level so the entire posthog module-level proxy chain
+    (`_proxy → setup → default_client.capture`) executes for real.
 
-    The fake `_capture` mirrors the real posthog-python 7.x signature
-    `capture(event, *, distinct_id=None, properties=None, ...)`. Using
-    keyword-only kwargs here means a regression to the old positional form
-    in `track()` will raise TypeError instead of silently doing nothing.
+    Mocking `posthog.capture` directly (the previous approach) bypasses
+    `setup()`, so a misconfigured init silently passes the test suite while
+    failing in production. Mocking the Client method exercises everything.
     """
-    mocker.patch.object(observability, "_posthog_initialized", True)
+    import posthog
+
+    monkeypatch.setenv("POSTHOG_API_KEY", "phc_test_key_for_unit_tests")
+    monkeypatch.setattr(observability, "_posthog_initialized", False)
+    monkeypatch.setattr(posthog, "default_client", None)
+
     events: list[dict[str, Any]] = []
 
-    def _capture(event, *, distinct_id=None, properties=None, **_kwargs):
+    def _client_capture(event, *, distinct_id=None, properties=None, **_kwargs):
         events.append({"distinct_id": distinct_id, "event": event, "properties": properties})
+        return "fake-uuid"
 
-    mocker.patch("posthog.capture", side_effect=_capture)
+    mocker.patch("posthog.client.Client.capture", autospec=False, side_effect=_client_capture)
+
+    observability.init_posthog()
+    assert observability._posthog_initialized, "init_posthog() must succeed for these tests"
     return events
 
 


### PR DESCRIPTION
## Summary
PR #52 introduced two bugs that combined to drop every PostHog event silently:

1. **Wrong module attr.** I switched `posthog.api_key = …` to `posthog.project_api_key = …`. The v7 module attr `project_api_key` exists but is unused by `setup()`, which still reads `api_key` when building the singleton client. Every `capture()` call raised `ValueError: API key is required`, which `track()` swallowed at WARNING. Restored the correct attr.

2. **Test fixture bypassed init.** The fixture mocked `posthog.capture` directly, skipping the `_proxy → setup → default_client.capture` chain — so `setup()` never ran in tests and the broken init looked fine in CI. The new fixture sets `POSTHOG_API_KEY`, runs the real `init_posthog()`, and mocks at the `Client.capture` level. A regression to the wrong attr now fails at `assert observability._posthog_initialized` because `setup()` raises `ValueError`.

## Other changes
- `init_posthog()` eagerly calls `posthog.setup()` so config errors fail at boot, not on first event.
- `track()` logs `capture` exceptions at ERROR (was WARNING) so future regressions are visible in worker/web logs.

## Test plan
- [x] `make test` — full unit suite green (213 passed)
- [x] Verified the broken pattern (`project_api_key` only) raises `ValueError` from `setup()`, which the new fixture catches via the `_posthog_initialized` assertion
- [ ] Post-deploy: create an agent, confirm `agent.created` appears in PostHog Live Events