### PR TITLE
Log PostHog init state so silent no-ops are visible

### DIFF
--- a/src/agent_on_demand/observability.py
+++ b/src/agent_on_demand/observability.py
@@ -120,6 +120,7 @@ def init_posthog() -> None:
         return
     api_key = os.environ.get("POSTHOG_API_KEY")
     if not api_key:
+        logger.warning("POSTHOG_API_KEY not set — PostHog events disabled")
         return
     import posthog
 
@@ -139,6 +140,11 @@ def init_posthog() -> None:
         return
 
     _posthog_initialized = True
+    logger.warning(
+        "PostHog initialized host=%s key_suffix=…%s",
+        posthog.host,
+        api_key[-4:],
+    )
 
 
 def distinct_id_for_user(user) -> str:


### PR DESCRIPTION
## Summary

- `init_posthog()` returned silently when `POSTHOG_API_KEY` was unset and logged nothing on success, making a misconfigured deploy indistinguishable from a working one.
- Emit a WARNING on both paths (missing-key and initialized) so boot logs tell you unambiguously whether PostHog is live on the running process.
- Prod symptom this unblocks diagnosing: no PostHog events delivered, but also no `posthog` log lines at all (observed on `agent-on-demand-api`).

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (213/213)
- [ ] After deploy, `agent-on-demand-api` boot logs show either `POSTHOG_API_KEY not set` or `PostHog initialized host=… key_suffix=…qxpe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)