### PR TITLE
Mirror app logs to stderr when OTel is configured

### DIFF
--- a/src/agent_on_demand/observability.py
+++ b/src/agent_on_demand/observability.py
@@ -75,9 +75,20 @@ def init_otel(service_name: str | None = None) -> None:
         )
     )
     set_logger_provider(logger_provider)
-    logging.getLogger().addHandler(
-        LoggingHandler(level=logging.INFO, logger_provider=logger_provider)
-    )
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(LoggingHandler(level=logging.INFO, logger_provider=logger_provider))
+    # Attaching the OTel handler disables Python's implicit stderr fallback,
+    # so nothing from app loggers reaches platform log collectors (Render, etc.)
+    # unless we put a StreamHandler back ourselves.
+    if not any(
+        isinstance(h, logging.StreamHandler) and not isinstance(h, LoggingHandler)
+        for h in root.handlers
+    ):
+        stream = logging.StreamHandler()
+        stream.setLevel(logging.INFO)
+        stream.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+        root.addHandler(stream)
 
     _instrument_libraries()
     _otel_initialized = True


### PR DESCRIPTION
## Summary

- When `init_otel` attaches an OTel `LoggingHandler` to the root logger, Python's "last resort" stderr fallback stops firing. That means once `HONEYCOMB_API_KEY` is set, every `logger.warning`/`logger.exception` call goes to Honeycomb only — Render (and any stdout/stderr-based collector) sees nothing.
- Attach an explicit `StreamHandler` to root alongside the OTel handler so logs reach **both** destinations.
- Set root to INFO so intentional INFO/WARNING app logs propagate.

Symptom this resolves: the PostHog init warning from #54 was being emitted but only visible in Honeycomb — Render logs had no `posthog` lines at all.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (213/213)
- [x] Local repro: with `HONEYCOMB_API_KEY` set, `logger.warning("visible on stderr?")` now reaches stderr (verified)
- [ ] After deploy, Render web logs show `WARNING agent_on_demand.observability: PostHog initialized host=… key_suffix=…qxpe` (or the not-set counterpart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)