### PR TITLE
Simplify PostHog setup to match the official Django pattern

### DIFF
--- a/src/agent_on_demand/apps.py
+++ b/src/agent_on_demand/apps.py
@@ -1,4 +1,10 @@
+import os
+
+import posthog
 from django.apps import AppConfig
+
+
+DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com"
 
 
 class AgentOnDemandConfig(AppConfig):
@@ -9,10 +15,16 @@ class AgentOnDemandConfig(AppConfig):
     def ready(self):
         import agent_on_demand.signals  # noqa: F401 — register signal handlers
 
-        from agent_on_demand.observability import init_otel, init_posthog
+        from agent_on_demand.observability import init_otel
 
         init_otel()
-        init_posthog()
+
+        # posthog.capture() raises ValueError when api_key is unset; use a
+        # placeholder + disabled=True so local dev and tests no-op cleanly.
+        api_key = os.environ.get("POSTHOG_API_KEY")
+        posthog.api_key = api_key or "disabled"
+        posthog.host = os.environ.get("POSTHOG_HOST", DEFAULT_POSTHOG_HOST)
+        posthog.disabled = not api_key
 
         from django.db.backends.signals import connection_created
 

--- a/src/agent_on_demand/observability.py
+++ b/src/agent_on_demand/observability.py
@@ -1,30 +1,22 @@
-"""OpenTelemetry → Honeycomb (traces + logs) and PostHog (product events).
+"""OpenTelemetry → Honeycomb (traces + logs).
 
-Both subsystems are no-ops when their API keys are unset, so unit tests and
-local dev without credentials behave identically to today. Honeycomb routes
-each `service.name` into its own dataset by default, so the web service emits
-to one dataset and the worker to another by setting `OTEL_SERVICE_NAME`.
-
-Event-property safety: callers must pass only counts, lengths, IDs, and other
-non-sensitive metadata. Never raw prompt text, env-var values, or repo URLs.
-This module does not enforce that — it's the caller's responsibility.
+No-op when HONEYCOMB_API_KEY is unset, so unit tests and local dev without
+credentials behave identically to today. Honeycomb routes each `service.name`
+into its own dataset by default, so the web service emits to one dataset and
+the worker to another by setting `OTEL_SERVICE_NAME`.
 """
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import os
-from typing import Any
 
 logger = logging.getLogger(__name__)
 
 HONEYCOMB_OTLP_ENDPOINT = "https://api.honeycomb.io"
-DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com"
 TRACER_NAME = "agent_on_demand"
 
 _otel_initialized = False
-_posthog_initialized = False
 
 
 def init_otel(service_name: str | None = None) -> None:
@@ -124,73 +116,3 @@ def get_tracer():
     from opentelemetry import trace
 
     return trace.get_tracer(TRACER_NAME)
-
-
-def init_posthog() -> None:
-    """Configure the PostHog client. Idempotent. No-op if POSTHOG_API_KEY unset."""
-    global _posthog_initialized
-    if _posthog_initialized:
-        return
-    api_key = os.environ.get("POSTHOG_API_KEY")
-    if not api_key:
-        logger.warning("POSTHOG_API_KEY not set — PostHog events disabled")
-        return
-    import posthog
-
-    # `posthog.project_api_key` exists as a module attr in v7 but is unused
-    # by `setup()`, which still reads `posthog.api_key`. Setting the wrong
-    # one makes every `capture()` call raise ValueError at first invocation.
-    posthog.api_key = api_key
-    posthog.host = os.environ.get("POSTHOG_HOST", DEFAULT_POSTHOG_HOST)
-
-    # Build the singleton client now, not lazily on first capture, so a bad
-    # config (missing/invalid key, bad host) fails at process boot instead
-    # of silently dropping the first N events.
-    try:
-        posthog.setup()
-    except Exception:
-        logger.exception("posthog.setup() failed — events will not be captured")
-        return
-
-    _posthog_initialized = True
-    logger.warning(
-        "PostHog initialized host=%s key_suffix=…%s",
-        posthog.host,
-        api_key[-4:],
-    )
-
-
-def distinct_id_for_user(user) -> str:
-    """Stable per-user identifier. Hashes user.id so PostHog never sees the
-    raw db PK."""
-    return hashlib.sha256(f"aod-user:{user.id}".encode()).hexdigest()[:32]
-
-
-def track(
-    event: str,
-    user=None,
-    properties: dict[str, Any] | None = None,
-) -> None:
-    """Capture a product-analytics event. No-op when PostHog isn't configured.
-
-    Properties MUST contain only non-sensitive metadata (counts, lengths, IDs,
-    runtime, model, status). Callers are responsible — see module docstring.
-    """
-    logger.warning("track called for event=%s", event) 
-    if not _posthog_initialized:
-        logger.warning("PostHog not initialized — dropping event=%s", event)
-        return
-    import posthog
-    logger.warning("posthog should get this event event=%s", event) 
-
-    distinct = distinct_id_for_user(user) if user is not None else "aod-system"
-    logger.warning("posthog.capture should get this event event=%s distinct_id=%s properties=%s", event, distinct, properties)
-    try:
-        # posthog-python 7.x: capture(event, **kwargs) — distinct_id is a kwarg.
-        # The old `capture(distinct, event, props)` positional form raises
-        # TypeError because **kwargs doesn't accept positional args.
-        posthog.capture(event, distinct_id=distinct, properties=properties or {})
-    except Exception:
-        # Surface at error so a bad signature/config is visible in logs;
-        # we still swallow so a PostHog outage doesn't take the API down.
-        logger.exception("posthog.capture failed for event=%s", event)

--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -21,13 +21,14 @@ import logging
 import queue
 import threading
 
+import posthog
 from django.db import close_old_connections
 from django.utils import timezone
 from procrastinate.contrib.django import app as procrastinate_app
 from sprites import ExecError
 
 from agent_on_demand.models import AgentSession, AgentSessionLog, SessionTurn
-from agent_on_demand.observability import get_tracer, track
+from agent_on_demand.observability import get_tracer
 from agent_on_demand.runtimes import RUNTIMES, RuntimeConfig
 
 from .provisioning import resume_session
@@ -238,15 +239,16 @@ def _execute_turn_body(
         span.set_attribute("aod.exit_code", exit_code)
     span.set_attribute("aod.duration_seconds", duration_seconds)
 
-    track(
-        f"session.{final_status}",
-        user=session.user,
-        properties={
-            "session_id": str(session.id),
-            "turn_number": turn.turn_number,
-            "runtime": session.runtime,
-            "exit_code": exit_code,
-            "duration_seconds": duration_seconds,
-            "mode": mode,
-        },
-    )
+    with posthog.new_context():
+        posthog.identify_context(str(session.user_id))
+        posthog.capture(
+            f"session.{final_status}",
+            properties={
+                "session_id": str(session.id),
+                "turn_number": turn.turn_number,
+                "runtime": session.runtime,
+                "exit_code": exit_code,
+                "duration_seconds": duration_seconds,
+                "mode": mode,
+            },
+        )

--- a/src/agent_on_demand/ui/views.py
+++ b/src/agent_on_demand/ui/views.py
@@ -1,3 +1,4 @@
+import posthog
 from django.contrib import messages
 from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required
@@ -13,7 +14,6 @@ from agent_on_demand.models import (
     Environment,
     UserSpritesKey,
 )
-from agent_on_demand.observability import track
 from agent_on_demand.ui.forms import APIKeyCreateForm, RegisterForm, SpritesKeyForm
 
 
@@ -39,7 +39,9 @@ def register(request):
             login(request, user)
             request.session["onboarding_raw_key"] = raw_key
 
-            track("user.registered", user=user)
+            with posthog.new_context():
+                posthog.identify_context(str(user.id))
+                posthog.capture("user.registered")
 
             return redirect("ui-welcome")
     else:

--- a/src/agent_on_demand/views/agents.py
+++ b/src/agent_on_demand/views/agents.py
@@ -1,6 +1,7 @@
 import json
 import re
 
+import posthog
 from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
@@ -10,7 +11,6 @@ from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from agent_on_demand.auth import require_api_key
 from agent_on_demand.models import Agent, AgentVersion, Environment
-from agent_on_demand.observability import track
 from agent_on_demand.runtimes import RUNTIMES, AgentModel
 
 
@@ -263,21 +263,22 @@ def agents_list_create(request):
         )
         _snapshot_version(agent)
 
-        track(
-            "agent.created",
-            user=request.user,
-            properties={
-                "agent_id": str(agent.id),
-                "runtime": agent.runtime,
-                "model": agent.model,
-                "has_environment": agent.environment_id is not None,
-                "system_length": len(agent.system or ""),
-                "description_length": len(agent.description or ""),
-                "skill_count": len(agent.skills or []),
-                "mcp_server_count": len(agent.mcp_servers or []),
-                "metadata_key_count": len(agent.metadata or {}),
-            },
-        )
+        with posthog.new_context():
+            posthog.identify_context(str(request.user.id))
+            posthog.capture(
+                "agent.created",
+                properties={
+                    "agent_id": str(agent.id),
+                    "runtime": agent.runtime,
+                    "model": agent.model,
+                    "has_environment": agent.environment_id is not None,
+                    "system_length": len(agent.system or ""),
+                    "description_length": len(agent.description or ""),
+                    "skill_count": len(agent.skills or []),
+                    "mcp_server_count": len(agent.mcp_servers or []),
+                    "metadata_key_count": len(agent.metadata or {}),
+                },
+            )
 
         return JsonResponse(_serialize_agent(agent), status=201)
 
@@ -363,16 +364,17 @@ def agent_detail(request, agent_id):
             agent.version += 1
             agent.save()
             _snapshot_version(agent)
-            track(
-                "agent.updated",
-                user=request.user,
-                properties={
-                    "agent_id": str(agent.id),
-                    "version": agent.version,
-                    "runtime": agent.runtime,
-                    "model": agent.model,
-                },
-            )
+            with posthog.new_context():
+                posthog.identify_context(str(request.user.id))
+                posthog.capture(
+                    "agent.updated",
+                    properties={
+                        "agent_id": str(agent.id),
+                        "version": agent.version,
+                        "runtime": agent.runtime,
+                        "model": agent.model,
+                    },
+                )
 
         return JsonResponse(_serialize_agent(agent))
 
@@ -395,7 +397,9 @@ def agent_archive(request, agent_id):
     agent.archived_at = timezone.now()
     agent.save(update_fields=["archived_at", "updated_at"])
 
-    track("agent.archived", user=request.user, properties={"agent_id": str(agent.id)})
+    with posthog.new_context():
+        posthog.identify_context(str(request.user.id))
+        posthog.capture("agent.archived", properties={"agent_id": str(agent.id)})
 
     return JsonResponse(_serialize_agent(agent))
 

--- a/src/agent_on_demand/views/environments.py
+++ b/src/agent_on_demand/views/environments.py
@@ -1,5 +1,6 @@
 import json
 
+import posthog
 from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
@@ -9,7 +10,6 @@ from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from agent_on_demand.auth import require_api_key
 from agent_on_demand.models import Environment, EnvironmentVersion
-from agent_on_demand.observability import track
 
 
 def _env_safe_props(env: Environment) -> dict:
@@ -172,7 +172,9 @@ def environments_list_create(request):
         )
         _snapshot_environment_version(env)
 
-        track("environment.created", user=request.user, properties=_env_safe_props(env))
+        with posthog.new_context():
+            posthog.identify_context(str(request.user.id))
+            posthog.capture("environment.created", properties=_env_safe_props(env))
 
         return JsonResponse(_serialize_environment(env), status=201)
 
@@ -246,11 +248,12 @@ def environment_detail(request, environment_id):
             env.version += 1
             env.save()
             _snapshot_environment_version(env)
-            track(
-                "environment.updated",
-                user=request.user,
-                properties={**_env_safe_props(env), "version": env.version},
-            )
+            with posthog.new_context():
+                posthog.identify_context(str(request.user.id))
+                posthog.capture(
+                    "environment.updated",
+                    properties={**_env_safe_props(env), "version": env.version},
+                )
 
         return JsonResponse(_serialize_environment(env))
 
@@ -273,11 +276,12 @@ def environment_archive(request, environment_id):
     env.archived_at = timezone.now()
     env.save(update_fields=["archived_at", "updated_at"])
 
-    track(
-        "environment.archived",
-        user=request.user,
-        properties={"environment_id": str(env.id)},
-    )
+    with posthog.new_context():
+        posthog.identify_context(str(request.user.id))
+        posthog.capture(
+            "environment.archived",
+            properties={"environment_id": str(env.id)},
+        )
 
     return JsonResponse(_serialize_environment(env))
 
@@ -303,7 +307,9 @@ def environment_delete(request, environment_id):
     env_id_str = str(env.id)
     env.delete()
 
-    track("environment.deleted", user=request.user, properties={"environment_id": env_id_str})
+    with posthog.new_context():
+        posthog.identify_context(str(request.user.id))
+        posthog.capture("environment.deleted", properties={"environment_id": env_id_str})
 
     return JsonResponse({"detail": "Environment deleted"}, status=200)
 

--- a/src/agent_on_demand/views/sessions.py
+++ b/src/agent_on_demand/views/sessions.py
@@ -4,6 +4,7 @@ import re
 import uuid
 from typing import Literal
 
+import posthog
 from django.conf import settings
 from django.db import transaction
 from django.db.models import Max
@@ -23,7 +24,6 @@ from agent_on_demand.models import (
     SessionTurn,
     UserRuntimeKey,
 )
-from agent_on_demand.observability import track
 from agent_on_demand.runtimes import RUNTIMES
 from agent_on_demand.session_service import (
     McpServerSpec,
@@ -300,23 +300,24 @@ def _create_session(request):
 
     session_service.run_turn(session, turn, sprite, effective_prompt, "run", float(req.timeout))
 
-    track(
-        "session.created",
-        user=request.user,
-        properties={
-            "session_id": str(session.id),
-            "agent_id": str(agent_obj.id),
-            "environment_id": str(environment_obj.id) if environment_obj else None,
-            "runtime": runtime,
-            "model": agent_obj.model,
-            "prompt_length": len(req.prompt),
-            "repo_count": len(req.resources),
-            "mcp_server_count": len(agent_obj.mcp_servers or []),
-            "skill_count": len(agent_obj.skills or []),
-            "env_var_count": len((environment_obj.env_vars or {})) if environment_obj else 0,
-            "timeout": req.timeout,
-        },
-    )
+    with posthog.new_context():
+        posthog.identify_context(str(request.user.id))
+        posthog.capture(
+            "session.created",
+            properties={
+                "session_id": str(session.id),
+                "agent_id": str(agent_obj.id),
+                "environment_id": str(environment_obj.id) if environment_obj else None,
+                "runtime": runtime,
+                "model": agent_obj.model,
+                "prompt_length": len(req.prompt),
+                "repo_count": len(req.resources),
+                "mcp_server_count": len(agent_obj.mcp_servers or []),
+                "skill_count": len(agent_obj.skills or []),
+                "env_var_count": len((environment_obj.env_vars or {})) if environment_obj else 0,
+                "timeout": req.timeout,
+            },
+        )
 
     return JsonResponse(
         {
@@ -451,16 +452,17 @@ def send_prompt(request, session_id):
 
     session_service.run_turn(session, turn, sprite, req.prompt, "continue", float(req.timeout))
 
-    track(
-        "session.prompt_sent",
-        user=request.user,
-        properties={
-            "session_id": str(session.id),
-            "turn_number": turn.turn_number,
-            "prompt_length": len(req.prompt),
-            "timeout": req.timeout,
-        },
-    )
+    with posthog.new_context():
+        posthog.identify_context(str(request.user.id))
+        posthog.capture(
+            "session.prompt_sent",
+            properties={
+                "session_id": str(session.id),
+                "turn_number": turn.turn_number,
+                "prompt_length": len(req.prompt),
+                "timeout": req.timeout,
+            },
+        )
 
     return JsonResponse(
         {
@@ -505,11 +507,12 @@ def terminate_session(request, session_id):
     session.sprite_name = ""
     session.save(update_fields=["status", "sprite_name", "updated_at"])
 
-    track(
-        "session.terminated",
-        user=request.user,
-        properties={"session_id": str(session.id)},
-    )
+    with posthog.new_context():
+        posthog.identify_context(str(request.user.id))
+        posthog.capture(
+            "session.terminated",
+            properties={"session_id": str(session.id)},
+        )
 
     return JsonResponse(
         {
@@ -537,10 +540,11 @@ def delete_session(request, session_id):
     session_id_str = str(session.id)
     session.delete()  # pre_delete signal handles Sprite cleanup
 
-    track(
-        "session.deleted",
-        user=request.user,
-        properties={"session_id": session_id_str},
-    )
+    with posthog.new_context():
+        posthog.identify_context(str(request.user.id))
+        posthog.capture(
+            "session.deleted",
+            properties={"session_id": session_id_str},
+        )
 
     return JsonResponse({"detail": "Session deleted"}, status=200)

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,8 +1,11 @@
 """PostHog event firing + sensitive-data leak guards.
 
-These tests do NOT touch the network — they patch `posthog.capture` and force
-`_posthog_initialized=True` so `track()` calls reach the mock. The init
-helpers themselves are validated as no-ops when their env vars are unset.
+These tests do NOT touch the network — they patch `posthog.client.Client.capture`
+so every `posthog.capture()` call reaches the spy through the SDK's normal
+module-level proxy chain (`_proxy → setup → default_client.capture`).
+
+Mocking `posthog.capture` directly would bypass `setup()`, hiding misconfigured
+init bugs in production. Mocking the Client method exercises everything.
 """
 
 from __future__ import annotations
@@ -10,6 +13,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+import posthog
 import pytest
 from django.contrib.auth.models import User
 from django.test import Client
@@ -48,18 +52,9 @@ def runtime_keys(user):
 
 @pytest.fixture
 def captured_events(monkeypatch, mocker):
-    """Set POSTHOG_API_KEY, run the real `init_posthog()`, then mock at the
-    Client level so the entire posthog module-level proxy chain
-    (`_proxy → setup → default_client.capture`) executes for real.
-
-    Mocking `posthog.capture` directly (the previous approach) bypasses
-    `setup()`, so a misconfigured init silently passes the test suite while
-    failing in production. Mocking the Client method exercises everything.
-    """
-    import posthog
-
-    monkeypatch.setenv("POSTHOG_API_KEY", "phc_test_key_for_unit_tests")
-    monkeypatch.setattr(observability, "_posthog_initialized", False)
+    """Patch Client.capture so real proxy init runs but no network calls fire."""
+    monkeypatch.setattr(posthog, "api_key", "phc_test_key_for_unit_tests")
+    monkeypatch.setattr(posthog, "disabled", False)
     monkeypatch.setattr(posthog, "default_client", None)
 
     events: list[dict[str, Any]] = []
@@ -69,9 +64,6 @@ def captured_events(monkeypatch, mocker):
         return "fake-uuid"
 
     mocker.patch("posthog.client.Client.capture", autospec=False, side_effect=_client_capture)
-
-    observability.init_posthog()
-    assert observability._posthog_initialized, "init_posthog() must succeed for these tests"
     return events
 
 
@@ -81,41 +73,11 @@ def _all_property_strings(events: list[dict[str, Any]]) -> str:
     return json.dumps(events, default=str)
 
 
-# --- init helpers no-op when env unset ---
-
-
 def test_init_otel_noop_without_api_key(monkeypatch):
     monkeypatch.delenv("HONEYCOMB_API_KEY", raising=False)
     monkeypatch.setattr(observability, "_otel_initialized", False)
     observability.init_otel()
     assert observability._otel_initialized is False
-
-
-def test_init_posthog_noop_without_api_key(monkeypatch):
-    monkeypatch.delenv("POSTHOG_API_KEY", raising=False)
-    monkeypatch.setattr(observability, "_posthog_initialized", False)
-    observability.init_posthog()
-    assert observability._posthog_initialized is False
-
-
-def test_track_noop_when_posthog_uninitialized(monkeypatch, mocker):
-    monkeypatch.setattr(observability, "_posthog_initialized", False)
-    spy = mocker.patch("posthog.capture")
-    observability.track("anything", user=None, properties={"x": 1})
-    spy.assert_not_called()
-
-
-def test_distinct_id_is_stable_and_hashed(user):
-    a = observability.distinct_id_for_user(user)
-    b = observability.distinct_id_for_user(user)
-    assert a == b
-    assert len(a) == 32
-    # Hex-only — never the raw username or any other identifying field
-    assert all(c in "0123456789abcdef" for c in a)
-    assert user.username not in a
-
-
-# --- agent.created event + leak guard ---
 
 
 @pytest.mark.django_db
@@ -155,9 +117,6 @@ def test_agent_created_event_fires_with_safe_props(client: Client, auth_headers,
     assert "SKILL_BODY" not in blob
 
 
-# --- environment.created event + leak guard ---
-
-
 @pytest.mark.django_db
 def test_environment_created_event_excludes_secret_values(
     client: Client, auth_headers, captured_events
@@ -193,14 +152,10 @@ def test_environment_created_event_excludes_secret_values(
     assert "PLEASE_DO_NOT_LEAK_SETUP_SCRIPT_BODY" not in blob
 
 
-# --- session.created event + leak guard (prompt + repo URL must not appear) ---
-
-
 @pytest.mark.django_db
 def test_session_created_event_excludes_prompt_and_repo_url(
     client: Client, auth_headers, runtime_keys, fake_sprites, captured_events
 ):
-    # Create env + agent
     env_resp = client.post(
         "/environments",
         data=json.dumps(
@@ -229,7 +184,6 @@ def test_session_created_event_excludes_prompt_and_repo_url(
     )
     agent_id = agent_resp.json()["id"]
 
-    # Drop pre-session events so the assertion blob is just the session ones
     captured_events.clear()
 
     resp = client.post(


### PR DESCRIPTION
## Summary
- Drop our custom `init_posthog` / `track` wrappers in `observability.py` — the SDK already handles init, and per the Django docs the tracking pattern is `posthog.new_context()` → `posthog.identify_context(user.id)` → `posthog.capture(event, properties=...)`.
- Set `posthog.api_key` / `host` directly in `AppConfig.ready`. When `POSTHOG_API_KEY` is unset, flip `posthog.disabled = True` with a placeholder key so `capture()` no-ops cleanly for local dev and tests instead of raising `ValueError`.
- Inline the `new_context` / `identify_context` / `capture` trio at every former `track()` call site (agents, environments, sessions, UI register, worker task finalizer).
- Simplify `test_observability.py` — drop tests for helpers that no longer exist; keep the sensitive-data leak guards, mocking `posthog.client.Client.capture` so the proxy chain still runs for real.
- Remove the stray debug logging added in 95bb396.

Net: 8 files, +140 / -234.

Note: we previously hashed `user.id` into a 32-char distinct_id so PostHog never saw the raw DB PK. The docs pattern uses `user.id` directly, which is what this PR does. Easy to re-add if we want the hash back.

## Test plan
- [x] `make test` — 210 passing
- [x] `make lint` — clean
- [ ] Verify events arrive in PostHog on the deployed service
- [ ] Confirm local dev still runs cleanly with no `POSTHOG_API_KEY` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)