### PR TITLE
Flush PostHog's async buffer on process exit

### DIFF
--- a/src/agent_on_demand/apps.py
+++ b/src/agent_on_demand/apps.py
@@ -1,3 +1,4 @@
+import atexit
 import os
 
 import posthog
@@ -25,6 +26,12 @@ class AgentOnDemandConfig(AppConfig):
         posthog.api_key = api_key or "disabled"
         posthog.host = os.environ.get("POSTHOG_HOST", DEFAULT_POSTHOG_HOST)
         posthog.disabled = not api_key
+        # Render SIGTERMs both the web and worker processes on deploy. Gunicorn
+        # and Procrastinate each catch SIGTERM, drain, and exit cleanly — atexit
+        # runs on that clean exit and flushes PostHog's async buffer so events
+        # from the final requests/tasks aren't dropped.
+        if api_key:
+            atexit.register(posthog.shutdown)
 
         from django.db.backends.signals import connection_created
 


### PR DESCRIPTION
## Summary
- Register `atexit.register(posthog.shutdown)` from `AppConfig.ready()` so both the `web` (Gunicorn) and `worker` (Procrastinate) processes flush PostHog's buffer before exit.
- Only registered when `POSTHOG_API_KEY` is set, so local dev / tests (where PostHog is disabled) don't pay the shutdown cost.

## Why atexit instead of a SIGTERM handler
Render sends SIGTERM on every deploy. Gunicorn and Procrastinate each already catch SIGTERM, drain their in-flight work, and call `sys.exit` cleanly — `atexit` handlers fire on that clean exit. Installing our own SIGTERM handler would either have to chain to theirs (fragile) or replace them (breaks graceful drain). `atexit` piggybacks on what's already working.

`posthog.shutdown()` is documented as blocking until the buffer flushes, which is exactly what we want at process-exit time.

## Test plan
- [x] `make test` — 210 passing
- [x] `make lint` — clean
- [ ] Deploy and confirm events from the final seconds before a deploy show up in PostHog

🤖 Generated with [Claude Code](https://claude.com/claude-code)