### PR TITLE
Move session provisioning to the background worker

### DIFF
--- a/src/agent_on_demand/session_service/__init__.py
+++ b/src/agent_on_demand/session_service/__init__.py
@@ -14,6 +14,7 @@ from .errors import (
 )
 from .provisioning import destroy_session, provision_session, resume_session
 from .specs import McpServerSpec, RepoSpec, SessionSpec, SkillSpec
+from .tasks import provision_session_task
 from .turn import run_turn
 
 __all__ = [
@@ -28,6 +29,7 @@ __all__ = [
     "destroy_session",
     "get_client",
     "provision_session",
+    "provision_session_task",
     "resume_session",
     "run_turn",
 ]

--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -1,17 +1,23 @@
-"""Procrastinate task: execute one turn of an agent session.
+"""Procrastinate tasks for session lifecycle.
 
-This runs in the worker process, not the web process. Its job is to drive the
-per-turn DB state machine, run the blocking SDK call, persist log chunks to
-`AgentSessionLog`, and finalize.
+Two tasks live here, both running in the worker process:
 
-The inner daemon thread that wraps `sprite.command().run()` stays here — it's
-load-bearing for the producer-consumer pattern against the SDK's own
-event-loop thread (which pushes log chunks into a queue via
+- `provision_session_task` creates the Sprite and runs setup stages, then
+  enqueues the first turn. Moving this off the web process is what keeps
+  `POST /sessions` snappy — provisioning is the slow step.
+- `execute_turn` drives one turn of the agent: DB state machine, blocking
+  SDK call, log chunk persistence, finalize.
+
+The inner daemon thread that wraps `sprite.command().run()` in `execute_turn`
+stays here — it's load-bearing for the producer-consumer pattern against the
+SDK's own event-loop thread (which pushes log chunks into a queue via
 `TaggingQueueWriter`). Eliminating it is a separate optimization.
 
 Retry policy: **none**. Turn-level retries against a Sprite that may be
 half-torn-down would not heal anything; failures surface as session status
-`failed` and the caller starts a new session.
+`failed` and the caller starts a new session. Provision failures follow the
+same rule — a half-provisioned Sprite is torn down and the session is
+marked `failed`.
 """
 
 from __future__ import annotations
@@ -27,11 +33,18 @@ from django.utils import timezone
 from procrastinate.contrib.django import app as procrastinate_app
 from sprites import ExecError
 
-from agent_on_demand.models import AgentSession, AgentSessionLog, SessionTurn
+from agent_on_demand.models import (
+    AgentSession,
+    AgentSessionLog,
+    SessionTurn,
+    UserRuntimeKey,
+)
 from agent_on_demand.observability import get_tracer
 from agent_on_demand.runtimes import RUNTIMES, RuntimeConfig
 
-from .provisioning import resume_session
+from .errors import NoSpritesKeyError, ProvisionError
+from .provisioning import provision_session, resume_session
+from .specs import McpServerSpec, RepoSpec, SessionSpec, SkillSpec
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +94,166 @@ def build_turn_command(runtime: RuntimeConfig, mode: str) -> str:
     """
     runtime_cmd = runtime.cmd if mode == "run" else runtime.continue_cmd
     return f"set -a; source /tmp/aod-env; set +a; PROMPT=$(cat); export PROMPT; exec {runtime_cmd}"
+
+
+@procrastinate_app.task(queue="sessions", name="provision_session", pass_context=False)
+def provision_session_task(
+    *,
+    session_id: str,
+    turn_id: int,
+    prompt: str,
+    mode: str,
+    timeout: float,
+) -> None:
+    """Provision the Sprite on the worker, then enqueue the first turn.
+
+    The session and turn rows already exist in the DB (created by the view in
+    `pending` state). On success we chain into `execute_turn`. On any
+    provision failure we mark the session + turn `failed` and stop; the
+    client sees the outcome via `GET /sessions/{id}` or the stream endpoint.
+    """
+    close_old_connections()
+    try:
+        _provision_session_inner(
+            session_id=session_id,
+            turn_id=turn_id,
+            prompt=prompt,
+            mode=mode,
+            timeout=timeout,
+        )
+    finally:
+        close_old_connections()
+
+
+def _provision_session_inner(
+    *,
+    session_id: str,
+    turn_id: int,
+    prompt: str,
+    mode: str,
+    timeout: float,
+) -> None:
+    session = AgentSession.objects.select_related("user", "agent", "environment").get(
+        pk=session_id
+    )
+    # If the client terminated before the worker picked this up, skip.
+    if session.status == "terminated":
+        return
+
+    spec = _build_spec_for_session(session)
+    if spec is None:
+        _mark_provision_failed(
+            session, turn_id, f"No API key configured for runtime: {session.runtime}"
+        )
+        return
+
+    tracer = get_tracer()
+    with tracer.start_as_current_span(
+        "session.provision_task",
+        attributes={
+            "aod.session_id": session_id,
+            "aod.runtime": session.runtime,
+        },
+    ) as span:
+        try:
+            provision_session(session.user, spec)
+        except NoSpritesKeyError as e:
+            span.set_attribute("aod.failure_stage", "no_sprites_key")
+            _mark_provision_failed(session, turn_id, str(e))
+            return
+        except ProvisionError as e:
+            span.set_attribute("aod.failure_stage", e.stage)
+            logger.warning("provision failed at stage=%s: %s", e.stage, e)
+            _mark_provision_failed(session, turn_id, str(e))
+            return
+
+    execute_turn.defer(
+        session_id=session_id,
+        turn_id=turn_id,
+        prompt=prompt,
+        mode=mode,
+        timeout=timeout,
+    )
+
+
+def _build_spec_for_session(session: AgentSession) -> SessionSpec | None:
+    """Rehydrate a SessionSpec from persisted session state. Returns None when
+    the user no longer has an API key configured for the session's runtime."""
+    api_key = UserRuntimeKey.get_key_for(session.user, session.runtime)
+    if api_key is None:
+        return None
+
+    agent = session.agent
+    mcp_servers: list[McpServerSpec] = []
+    skills: list[SkillSpec] = []
+    if agent is not None:
+        for s in agent.mcp_servers or []:
+            mcp_servers.append(
+                McpServerSpec(
+                    name=s["name"],
+                    type=s.get("type", "url"),
+                    url=s.get("url", ""),
+                    headers=s.get("headers", {}),
+                    command=s.get("command", ""),
+                    args=s.get("args", []),
+                    env=s.get("env", {}),
+                )
+            )
+        for s in agent.skills or []:
+            skills.append(SkillSpec(name=s["name"], content=s["content"]))
+
+    repos = [
+        RepoSpec(url=r.url, mount_path=r.mount_path, token=r.get_token())
+        for r in session.resources.all()
+    ]
+
+    return SessionSpec(
+        name=session.sprite_name,
+        runtime=RUNTIMES[session.runtime],
+        api_key=api_key,
+        runtime_session_id=str(session.runtime_session_id)
+        if session.runtime_session_id
+        else None,
+        environment=session.environment,
+        repos=repos,
+        mcp_servers=mcp_servers,
+        skills=skills,
+    )
+
+
+def _mark_provision_failed(session: AgentSession, turn_id: int, message: str) -> None:
+    """Record a provision failure: log stderr chunk, mark session + turn failed,
+    clear sprite_name (nothing was left behind — provision_session deletes on
+    failure), and emit the posthog event."""
+    AgentSessionLog.objects.create(
+        session=session,
+        turn_id=turn_id,
+        stream="stderr",
+        data=f"provision failed: {message}\n",
+    )
+    now = timezone.now()
+
+    session.refresh_from_db(fields=["status"])
+    if session.status != "terminated":
+        session.status = "failed"
+        session.sprite_name = ""
+        session.save(update_fields=["status", "sprite_name", "updated_at"])
+
+    SessionTurn.objects.filter(pk=turn_id).update(
+        status="failed",
+        ended_at=now,
+    )
+
+    with posthog.new_context():
+        posthog.identify_context(str(session.user_id))
+        posthog.capture(
+            "session.provision_failed",
+            properties={
+                "session_id": str(session.id),
+                "runtime": session.runtime,
+                "message": message,
+            },
+        )
 
 
 @procrastinate_app.task(queue="sessions", name="execute_turn", pass_context=False)

--- a/src/agent_on_demand/views/sessions.py
+++ b/src/agent_on_demand/views/sessions.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import re
 import uuid
 from typing import Literal
@@ -25,48 +24,7 @@ from agent_on_demand.models import (
     UserRuntimeKey,
 )
 from agent_on_demand.runtimes import RUNTIMES
-from agent_on_demand.session_service import (
-    McpServerSpec,
-    RepoSpec,
-    SessionSpec,
-    SkillSpec,
-)
 from agent_on_demand.stream import stream_session_from_db
-
-logger = logging.getLogger(__name__)
-
-
-def _mcp_servers_to_specs(mcp_servers: list[dict]) -> list[McpServerSpec]:
-    """Convert agent's mcp_servers JSON to McpServerSpec list."""
-    return [
-        McpServerSpec(
-            name=s["name"],
-            type=s.get("type", "url"),
-            url=s.get("url", ""),
-            headers=s.get("headers", {}),
-            command=s.get("command", ""),
-            args=s.get("args", []),
-            env=s.get("env", {}),
-        )
-        for s in mcp_servers
-    ]
-
-
-def _skills_to_specs(skills: list[dict]) -> list[SkillSpec]:
-    """Convert agent's skills JSON to SkillSpec list for materialization."""
-    return [SkillSpec(name=s["name"], content=s["content"]) for s in skills]
-
-
-def _resources_to_repo_specs(resources: list) -> list[RepoSpec]:
-    """Convert GitHubRepoResource list to RepoSpec list for the wrapper script."""
-    return [
-        RepoSpec(
-            url=r.url,
-            mount_path=r.resolved_mount_path(),
-            token=r.authorization_token,
-        )
-        for r in resources
-    ]
 
 
 def _serialize_resources(session: AgentSession) -> list[dict]:
@@ -240,7 +198,11 @@ def _create_session(request):
             status=400,
         )
 
-    config = RUNTIMES[runtime]
+    # Sync pre-check so missing Sprites creds return 400 immediately rather
+    # than surfacing as a failed session the client has to poll for.
+    if session_service.get_client(request.user) is None:
+        return JsonResponse({"detail": "No Sprites API key configured"}, status=400)
+
     name = f"{settings.SPRITE_NAME_PREFIX}-{uuid.uuid4().hex[:12]}"
     runtime_session_id = str(uuid.uuid4())
 
@@ -249,25 +211,6 @@ def _create_session(request):
     effective_prompt = req.prompt
     if agent_obj.system:
         effective_prompt = f"{agent_obj.system}\n\n{req.prompt}"
-
-    spec = SessionSpec(
-        name=name,
-        runtime=config,
-        api_key=api_key,
-        runtime_session_id=runtime_session_id,
-        environment=environment_obj,
-        repos=_resources_to_repo_specs(req.resources),
-        mcp_servers=_mcp_servers_to_specs(agent_obj.mcp_servers),
-        skills=_skills_to_specs(agent_obj.skills),
-    )
-
-    try:
-        sprite = session_service.provision_session(request.user, spec)
-    except session_service.NoSpritesKeyError as e:
-        return JsonResponse({"detail": str(e)}, status=400)
-    except session_service.ProvisionError as e:
-        logger.warning("provision failed at stage=%s: %s", e.stage, e)
-        return JsonResponse({"detail": str(e)}, status=502)
 
     with transaction.atomic():
         session = AgentSession.objects.create(
@@ -298,7 +241,13 @@ def _create_session(request):
                 sr.set_token(resource.authorization_token)
             sr.save()
 
-    session_service.run_turn(session, turn, sprite, effective_prompt, "run", float(req.timeout))
+    session_service.provision_session_task.defer(
+        session_id=str(session.id),
+        turn_id=turn.id,
+        prompt=effective_prompt,
+        mode="run",
+        timeout=float(req.timeout),
+    )
 
     with posthog.new_context():
         posthog.identify_context(str(request.user.id))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,17 +11,30 @@ def client():
 
 @pytest.fixture
 def fake_sprites(mocker):
-    """Swap the real SpritesClient for a recording fake and stub the
-    Procrastinate task enqueue so create_session doesn't hit the real
-    broker.
+    """Swap the real SpritesClient for a recording fake, run the provision
+    task inline, and stub the per-turn task enqueue.
 
     Returns the RecordingSpritesClient; use `.last_sprite()` or `.sprites`
     to reach the RecordingSprite(s) created by the test under inspection.
+
+    `provision_session_task.defer` is patched to execute the task body
+    synchronously against the fake client. That keeps HTTP-layer tests
+    able to assert on the Sprite writes/commands that provisioning made —
+    even though in production they'd happen on the worker. The downstream
+    `execute_turn.defer` that the provision task would otherwise chain
+    into is stubbed so the turn itself stays unrun.
     """
     fake = RecordingSpritesClient()
     mocker.patch("agent_on_demand.session_service.client.get_client", return_value=fake)
     mocker.patch("agent_on_demand.session_service.get_client", return_value=fake)
-    # Stub task enqueue — tests that care about the enqueue can spy on this
-    # directly via `mocker.spy(execute_turn, "defer")` in their body.
+
+    mocker.patch("agent_on_demand.session_service.tasks.execute_turn.defer")
     mocker.patch("agent_on_demand.session_service.turn.execute_turn.defer")
+
+    from agent_on_demand.session_service.tasks import provision_session_task
+
+    def _inline_defer(**kwargs):
+        provision_session_task(**kwargs)
+
+    mocker.patch.object(provision_session_task, "defer", side_effect=_inline_defer)
     return fake

--- a/tests/test_networking_wiring.py
+++ b/tests/test_networking_wiring.py
@@ -148,11 +148,14 @@ class TestSessionNetworkingIntegration:
     def test_policy_apply_failure_cleans_up_sprite(
         self, client: Client, auth_headers, runtime_key, user, agent, fake_sprites, mocker
     ):
-        """update_network_policy failing mid-provision tears the Sprite back down."""
+        """update_network_policy failing mid-provision tears the Sprite back
+        down and marks the session failed. The HTTP response is still 202
+        because provisioning now runs on the worker — the failure surfaces
+        through session.status, not the create response."""
+        from agent_on_demand.models import AgentSession
+
         env = _make_env(user, networking_type="limited", allowed_hosts=["api.anthropic.com"])
 
-        # Arrange: the next Sprite created by the service will raise on
-        # update_network_policy. We do this by wrapping create_sprite.
         original_create = fake_sprites.create_sprite
 
         def wrapped(name):
@@ -174,9 +177,11 @@ class TestSessionNetworkingIntegration:
             content_type="application/json",
             **auth_headers,
         )
-        assert resp.status_code == 502
-        assert "Failed to prepare Sprite" in resp.json()["detail"]
-        assert fake_sprites.deleted  # cleanup ran
+        assert resp.status_code == 202
+
+        session = AgentSession.objects.get(pk=resp.json()["id"])
+        assert session.status == "failed"
+        assert fake_sprites.deleted  # provision_session tore the Sprite back down
 
     def test_limited_with_empty_allowed_hosts_denies_all(
         self, client: Client, auth_headers, runtime_key, user, agent, fake_sprites

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,25 +1,27 @@
-"""Unit tests for `session_service.tasks.execute_turn`.
+"""Unit tests for `session_service.tasks`.
 
-These invoke the task body as a plain function (Procrastinate tasks are
-callable in-process — they only hit the broker when `.defer()` is used).
-That lets us cover the per-turn state-machine contract without spinning up
-a worker or needing Postgres locally.
+These invoke task bodies as plain functions (Procrastinate tasks are callable
+in-process — they only hit the broker when `.defer()` is used). That lets us
+cover the per-turn state-machine contract and the provision-then-enqueue
+contract without spinning up a worker or needing Postgres locally.
 """
 
 from __future__ import annotations
 
 import pytest
 from django.contrib.auth.models import User
-from sprites import ExecError
+from sprites import ExecError, SpriteError
 
 from agent_on_demand.models import (
+    Agent,
     AgentSession,
     AgentSessionLog,
     APIKey,
     SessionTurn,
+    UserRuntimeKey,
     UserSpritesKey,
 )
-from agent_on_demand.session_service.tasks import execute_turn
+from agent_on_demand.session_service.tasks import execute_turn, provision_session_task
 
 
 @pytest.fixture
@@ -228,3 +230,141 @@ def test_execute_turn_writes_log_chunks_via_tagging_writer(user, mocker):
     assert any("first chunk" in log.data for log in logs)
     assert any("second chunk" in log.data for log in logs)
     assert all(log.turn_id == turn.id for log in logs)
+
+
+# --------------------------------------------------------------------------
+# provision_session_task tests
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def provision_user(db):
+    u = User.objects.create_user(username="prov", password="p")
+    APIKey.create_key(u, "test-key")
+    usk = UserSpritesKey(user=u)
+    usk.set_api_key("fake-sprites-token")
+    usk.save()
+    urk = UserRuntimeKey(user=u, runtime="claude")
+    urk.set_api_key("fake-anthropic-key")
+    urk.save()
+    return u
+
+
+def _make_pending_session(user):
+    agent = Agent.objects.create(
+        user=user, name="a", model="claude-sonnet-4-6", runtime="claude", version=1
+    )
+    session = AgentSession.objects.create(
+        user=user,
+        agent=agent,
+        runtime="claude",
+        prompt="hi",
+        sprite_name="sprite-prov",
+        runtime_session_id="11111111-2222-3333-4444-555555555555",
+        status="pending",
+    )
+    turn = SessionTurn.objects.create(
+        session=session, turn_number=1, prompt="hi", status="pending"
+    )
+    return session, turn
+
+
+@pytest.mark.django_db
+def test_provision_task_enqueues_execute_turn_on_success(
+    provision_user, fake_sprites, mocker
+):
+    session, turn = _make_pending_session(provision_user)
+    defer_spy = mocker.patch("agent_on_demand.session_service.tasks.execute_turn.defer")
+
+    provision_session_task(
+        session_id=str(session.id),
+        turn_id=turn.id,
+        prompt="hi",
+        mode="run",
+        timeout=10.0,
+    )
+
+    # Sprite was created and set up.
+    assert "sprite-prov" in fake_sprites.sprites
+    # Downstream turn task was enqueued with the same args.
+    kwargs = defer_spy.call_args.kwargs
+    assert kwargs["session_id"] == str(session.id)
+    assert kwargs["turn_id"] == turn.id
+    assert kwargs["prompt"] == "hi"
+    assert kwargs["mode"] == "run"
+
+    session.refresh_from_db()
+    assert session.status == "pending"  # worker hands off to execute_turn
+
+
+@pytest.mark.django_db
+def test_provision_task_marks_failed_on_sprite_error(provision_user, fake_sprites, mocker):
+    session, turn = _make_pending_session(provision_user)
+    fake_sprites.raise_on_create(SpriteError("boom"))
+    defer_spy = mocker.patch("agent_on_demand.session_service.tasks.execute_turn.defer")
+
+    provision_session_task(
+        session_id=str(session.id),
+        turn_id=turn.id,
+        prompt="hi",
+        mode="run",
+        timeout=10.0,
+    )
+
+    session.refresh_from_db()
+    turn.refresh_from_db()
+    assert session.status == "failed"
+    # sprite_name is cleared so DELETE /sessions doesn't try to delete a
+    # Sprite that was never created.
+    assert session.sprite_name == ""
+    assert turn.status == "failed"
+    assert turn.ended_at is not None
+    assert defer_spy.call_count == 0
+
+    # An stderr log chunk captures the message for the stream endpoint.
+    logs = AgentSessionLog.objects.filter(session=session, stream="stderr")
+    assert logs.exists()
+
+
+@pytest.mark.django_db
+def test_provision_task_skips_if_session_terminated(provision_user, fake_sprites, mocker):
+    session, turn = _make_pending_session(provision_user)
+    session.status = "terminated"
+    session.save(update_fields=["status"])
+    defer_spy = mocker.patch("agent_on_demand.session_service.tasks.execute_turn.defer")
+
+    provision_session_task(
+        session_id=str(session.id),
+        turn_id=turn.id,
+        prompt="hi",
+        mode="run",
+        timeout=10.0,
+    )
+
+    # Nothing provisioned, nothing enqueued.
+    assert fake_sprites.created == []
+    assert defer_spy.call_count == 0
+
+
+@pytest.mark.django_db
+def test_provision_task_marks_failed_when_runtime_key_missing(
+    provision_user, fake_sprites, mocker
+):
+    """If the user's runtime key was deleted between create and provision,
+    the task surfaces that as a failed session rather than raising."""
+    session, turn = _make_pending_session(provision_user)
+    UserRuntimeKey.objects.filter(user=provision_user, runtime="claude").delete()
+    defer_spy = mocker.patch("agent_on_demand.session_service.tasks.execute_turn.defer")
+
+    provision_session_task(
+        session_id=str(session.id),
+        turn_id=turn.id,
+        prompt="hi",
+        mode="run",
+        timeout=10.0,
+    )
+
+    session.refresh_from_db()
+    assert session.status == "failed"
+    assert fake_sprites.created == []
+    assert defer_spy.call_count == 0


### PR DESCRIPTION
## Summary
- `POST /sessions` no longer blocks on Sprite creation + setup. The work moves into a new `provision_session` Procrastinate task that chains into `execute_turn` on success.
- Sync validation stays on the web side (auth, agent/env lookup, runtime key, Sprites key presence) so obviously-bad requests still fail fast.
- Sprite-level provision failures are now surfaced via `session.status = failed` + an stderr log chunk, not a 502 on create. **This is a breaking API-contract change** for clients that expected sync 502s on bad environments/policies.

## Test plan
- [x] `make test` — 214 passing, including 4 new unit tests for the provision task (success, SpriteError, terminated short-circuit, missing runtime key)
- [x] `make lint` — clean
- [ ] Manual: create a session, confirm the response returns within a few hundred ms rather than after full provision
- [ ] Manual: create a session with a broken environment (e.g. bad apt package) and confirm the session lands in `failed` with a stderr log chunk rather than a 502
- [ ] `make test-e2e-fast` before landing since this touches session execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)