### PR TITLE
Move Sprite destroy to the background worker

### DIFF
--- a/src/agent_on_demand/session_service/__init__.py
+++ b/src/agent_on_demand/session_service/__init__.py
@@ -14,7 +14,7 @@ from .errors import (
 )
 from .provisioning import destroy_session, provision_session, resume_session
 from .specs import McpServerSpec, RepoSpec, SessionSpec, SkillSpec
-from .tasks import provision_session_task
+from .tasks import destroy_session_task, provision_session_task
 from .turn import run_turn
 
 __all__ = [
@@ -27,6 +27,7 @@ __all__ = [
     "SessionSpec",
     "SkillSpec",
     "destroy_session",
+    "destroy_session_task",
     "get_client",
     "provision_session",
     "provision_session_task",

--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -1,12 +1,15 @@
 """Procrastinate tasks for session lifecycle.
 
-Two tasks live here, both running in the worker process:
+Three tasks live here, all running in the worker process:
 
 - `provision_session_task` creates the Sprite and runs setup stages, then
   enqueues the first turn. Moving this off the web process is what keeps
   `POST /sessions` snappy — provisioning is the slow step.
 - `execute_turn` drives one turn of the agent: DB state machine, blocking
   SDK call, log chunk persistence, finalize.
+- `destroy_session_task` deletes the Sprite behind `POST /terminate` and
+  `DELETE /sessions/{id}`. The Sprites delete call can take ~1s; moving
+  it off the web process keeps those endpoints snappy.
 
 The inner daemon thread that wraps `sprite.command().run()` in `execute_turn`
 stays here — it's load-bearing for the producer-consumer pattern against the
@@ -17,7 +20,8 @@ Retry policy: **none**. Turn-level retries against a Sprite that may be
 half-torn-down would not heal anything; failures surface as session status
 `failed` and the caller starts a new session. Provision failures follow the
 same rule — a half-provisioned Sprite is torn down and the session is
-marked `failed`.
+marked `failed`. Destroy failures are log-and-swallow, matching the
+pre-existing `best_effort_delete` contract.
 """
 
 from __future__ import annotations
@@ -28,6 +32,7 @@ import queue
 import threading
 
 import posthog
+from django.contrib.auth import get_user_model
 from django.db import close_old_connections
 from django.utils import timezone
 from procrastinate.contrib.django import app as procrastinate_app
@@ -43,7 +48,7 @@ from agent_on_demand.observability import get_tracer
 from agent_on_demand.runtimes import RUNTIMES, RuntimeConfig
 
 from .errors import NoSpritesKeyError, ProvisionError
-from .provisioning import provision_session, resume_session
+from .provisioning import destroy_session, provision_session, resume_session
 from .specs import McpServerSpec, RepoSpec, SessionSpec, SkillSpec
 
 logger = logging.getLogger(__name__)
@@ -425,3 +430,30 @@ def _execute_turn_body(
                 "mode": mode,
             },
         )
+
+
+@procrastinate_app.task(queue="sessions", name="destroy_session", pass_context=False)
+def destroy_session_task(*, user_id: int, sprite_name: str) -> None:
+    """Delete a Sprite on the worker. Best-effort — failures are logged,
+    not retried, matching the pre-existing `destroy_session` contract.
+
+    User resolution lives inside the task (rather than the view passing a
+    client/token) so there's nothing sensitive on the Procrastinate queue.
+    If the user row is gone by the time the worker picks up, we skip
+    cleanup — the Sprite will eventually time out server-side.
+    """
+    close_old_connections()
+    try:
+        User = get_user_model()
+        try:
+            user = User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            logger.warning(
+                "destroy_session_task: user %s gone, skipping Sprite %s",
+                user_id,
+                sprite_name,
+            )
+            return
+        destroy_session(user, sprite_name)
+    finally:
+        close_old_connections()

--- a/src/agent_on_demand/signals.py
+++ b/src/agent_on_demand/signals.py
@@ -7,5 +7,11 @@ from agent_on_demand.models import AgentSession
 
 @receiver(pre_delete, sender=AgentSession)
 def delete_sprite_on_session_delete(sender, instance, **kwargs):
-    """Clean up the Sprite container when a session is deleted, regardless of deletion path."""
-    session_service.destroy_session(instance.user, instance.sprite_name)
+    """Enqueue Sprite cleanup when a session is deleted, regardless of
+    deletion path. Runs async so DELETE /sessions/{id} doesn't block on the
+    Sprites API."""
+    if not instance.sprite_name:
+        return
+    session_service.destroy_session_task.defer(
+        user_id=instance.user_id, sprite_name=instance.sprite_name
+    )

--- a/src/agent_on_demand/views/sessions.py
+++ b/src/agent_on_demand/views/sessions.py
@@ -450,11 +450,15 @@ def terminate_session(request, session_id):
     if session.status == "terminated":
         return JsonResponse({"detail": "Session is already terminated"}, status=409)
 
-    session_service.destroy_session(request.user, session.sprite_name)
-
+    sprite_name = session.sprite_name
     session.status = "terminated"
     session.sprite_name = ""
     session.save(update_fields=["status", "sprite_name", "updated_at"])
+
+    if sprite_name:
+        session_service.destroy_session_task.defer(
+            user_id=request.user.id, sprite_name=sprite_name
+        )
 
     with posthog.new_context():
         posthog.identify_context(str(request.user.id))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,10 +31,17 @@ def fake_sprites(mocker):
     mocker.patch("agent_on_demand.session_service.tasks.execute_turn.defer")
     mocker.patch("agent_on_demand.session_service.turn.execute_turn.defer")
 
-    from agent_on_demand.session_service.tasks import provision_session_task
+    from agent_on_demand.session_service.tasks import (
+        destroy_session_task,
+        provision_session_task,
+    )
 
-    def _inline_defer(**kwargs):
+    def _inline_provision(**kwargs):
         provision_session_task(**kwargs)
 
-    mocker.patch.object(provision_session_task, "defer", side_effect=_inline_defer)
+    def _inline_destroy(**kwargs):
+        destroy_session_task(**kwargs)
+
+    mocker.patch.object(provision_session_task, "defer", side_effect=_inline_provision)
+    mocker.patch.object(destroy_session_task, "defer", side_effect=_inline_destroy)
     return fake

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -365,14 +365,13 @@ def test_stream_session_failed_with_no_exit_code(client: Client, auth_headers, u
 
 
 @pytest.mark.django_db
-def test_terminate_session(client: Client, auth_headers, user, mocker):
-    """Terminate destroys the Sprite but keeps the session record."""
-    from tests.fakes.sprite import RecordingSpritesClient
+def test_terminate_session(client: Client, auth_headers, sprites_key, user, fake_sprites):
+    """Terminate flips the DB state and enqueues the Sprite delete.
 
-    fake = RecordingSpritesClient()
-    mocker.patch("agent_on_demand.session_service.client.get_client", return_value=fake)
-    mocker.patch("agent_on_demand.session_service.get_client", return_value=fake)
-
+    The `fake_sprites` fixture runs `destroy_session_task.defer` inline, so
+    we can still assert on the recorded delete — but the view itself returns
+    without blocking on the Sprites API call.
+    """
     session = AgentSession.objects.create(
         user=user, runtime="claude", prompt="test", sprite_name="aod-abc123", status="completed"
     )
@@ -385,7 +384,7 @@ def test_terminate_session(client: Client, auth_headers, user, mocker):
     assert session.status == "terminated"
     assert session.sprite_name == ""
 
-    assert fake.deleted == ["aod-abc123"]
+    assert fake_sprites.deleted == ["aod-abc123"]
 
 
 @pytest.mark.django_db

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -21,7 +21,11 @@ from agent_on_demand.models import (
     UserRuntimeKey,
     UserSpritesKey,
 )
-from agent_on_demand.session_service.tasks import execute_turn, provision_session_task
+from agent_on_demand.session_service.tasks import (
+    destroy_session_task,
+    execute_turn,
+    provision_session_task,
+)
 
 
 @pytest.fixture
@@ -368,3 +372,34 @@ def test_provision_task_marks_failed_when_runtime_key_missing(
     assert session.status == "failed"
     assert fake_sprites.created == []
     assert defer_spy.call_count == 0
+
+
+# --------------------------------------------------------------------------
+# destroy_session_task tests
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_destroy_task_deletes_sprite(provision_user, fake_sprites):
+    destroy_session_task(user_id=provision_user.id, sprite_name="aod-xyz")
+    assert fake_sprites.deleted == ["aod-xyz"]
+
+
+@pytest.mark.django_db
+def test_destroy_task_noop_when_user_gone(fake_sprites):
+    """If the user row is gone by the time the worker picks up, skip
+    cleanup rather than raise. The Sprite will time out server-side."""
+    destroy_session_task(user_id=999_999, sprite_name="aod-xyz")
+    assert fake_sprites.deleted == []
+
+
+@pytest.mark.django_db
+def test_destroy_task_swallows_sprite_errors(provision_user, fake_sprites, mocker):
+    """Matches the pre-existing `best_effort_delete` contract — errors are
+    logged, not raised. Re-raising would let Procrastinate keep retrying a
+    call that might never succeed."""
+    mocker.patch.object(
+        fake_sprites, "delete_sprite", side_effect=SpriteError("transient")
+    )
+    destroy_session_task(user_id=provision_user.id, sprite_name="aod-xyz")
+    # Assertion is "no exception raised".


### PR DESCRIPTION
## Summary
- `POST /sessions/{id}/terminate` and `DELETE /sessions/{id}` no longer block on the ~1s Sprites delete call. Both flip the DB state synchronously and enqueue a new `destroy_session` Procrastinate task.
- Failures stay log-and-swallow, matching the pre-existing `best_effort_delete` contract. Admin bulk terminate remains sync since it reports a real count.
- **API contract shift**: the 200 response no longer guarantees the Sprite is gone, only that teardown is queued. Safe here since sprite_names are random UUIDs (no name-reuse races).

## Test plan
- [x] `make test` — 217 passing, including 3 new unit tests for the destroy task (happy path, user-gone no-op, SpriteError swallowed)
- [x] `make lint` — clean
- [ ] Manual: terminate a session and confirm the response is near-instant (vs ~1s before)
- [ ] Manual: delete a session and confirm the Sprite gets cleaned up by the worker within a few seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)