### PR TITLE
Scale streaming capacity: gthread, concurrency, Postgres bump

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ projects:
       - name: production
         databases:
           - name: agent-on-demand-db
-            plan: basic-256mb
+            plan: standard-1gb
             databaseName: agent_on_demand
             postgresMajorVersion: "16"
 
@@ -19,6 +19,8 @@ projects:
               uv run gunicorn config.wsgi:application
               --bind 0.0.0.0:$PORT
               --workers 3
+              --worker-class gthread
+              --threads 8
               --graceful-timeout 650
               --timeout 700
               --max-requests 1000
@@ -55,6 +57,7 @@ projects:
             buildCommand: pip install uv && uv sync
             startCommand: >-
               uv run python manage.py procrastinate worker
+              --concurrency 4
             envVars:
               - key: DATABASE_URL
                 fromDatabase:


### PR DESCRIPTION
## Summary

Atomic infra PR: raise SSE streaming capacity from 3 to 24 concurrent clients, enable concurrent turn execution, and upgrade Postgres to accommodate the higher connection budget.

- **Web service** → `--worker-class gthread --threads 8` (sync workers previously capped SSE clients at 3)
- **Worker service** → `--concurrency 4` (default was 1; turns serialized)
- **Postgres** → `standard-1gb` (basic-256mb's 25 max_connections is too tight for 3 workers × 8 threads plus worker connections)

All three must ship together: the Postgres bump is mandatory for the connection math at the new thread count.

## Motivation

Full research and plan:
- `thoughts/research/2026-04-19-streaming-high-volume-readiness.md`
- `thoughts/plans/2026-04-19-streaming-high-volume-readiness.md`

Prior research identified the SSE saturation issue (`thoughts/research/2026-04-19-threading-in-web-server.md`) and specified the gthread fix; it had not yet shipped.

## Test plan

- [ ] After deploy, `GET /health` stays 200 under ~10 parallel `curl` SSE streams against a completed session
- [ ] `pg_stat_activity` settles around 4–12 connections at rest, not near the 97 ceiling
- [ ] Procrastinate worker log shows up to 4 concurrent task executions under load (observe via Honeycomb `session.execute_turn` span overlap)
- [ ] Verify Procrastinate's `--concurrency=4` actually caps effective concurrency (sync tasks dispatch via `run_in_executor`; if observed concurrent turns exceed 4, follow up with explicit executor pool config)

## Rollback

Revert this commit and push; Render redeploys the previous config. Postgres plan downgrade requires a subsequent manual plan change in the Render dashboard.

## Follow-ups

Two more PRs land after a 24h prod soak:
1. Producer + consumer robustness (retry, backpressure, slow-client timeout, `Last-Event-ID` cursor)
2. Operational hygiene (log retention + stuck-session watchdog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)