### PR TITLE
Harden SSE streaming: retries, backpressure, cursor resume

### DIFF
--- a/.claude/skills/agent-on-demand-api.md
+++ b/.claude/skills/agent-on-demand-api.md
@@ -174,37 +174,43 @@ If you see `400 {"detail":"No API key configured for runtime: <name>"}` at sessi
 
 `GET /sessions/{id}/stream` — `Content-Type: text/event-stream`, `X-Accel-Buffering: no`.
 
-Event types (`data: <json>\n\n`):
+Event types (`data: <json>\n\n`). Every event except `start` includes an `"id": <log_row_id>` field in the JSON payload and an SSE `id:` line.
 
-| Type         | Payload                                                            |
-| ------------ | ------------------------------------------------------------------ |
-| `start`      | `{"type":"start","runtime":"claude","session_id":"<uuid>"}` (always first) |
-| `output`     | `{"type":"output","stream":"stdout"\|"stderr","data":"..."}`       |
-| `exit`       | `{"type":"exit","code":0}` — terminal                              |
-| `error`      | `{"type":"error","message":"..."}` — terminal (exception path)     |
-| `terminated` | `{"type":"terminated","message":"Session terminated"}` — terminal  |
+| Type         | Payload                                                                          |
+| ------------ | -------------------------------------------------------------------------------- |
+| `start`      | `{"type":"start","runtime":"claude","session_id":"<uuid>"}` (always first, no `id`) |
+| `turn_start` | `{"type":"turn_start","id":<int>,"turn":<int>}` — before first output of each turn |
+| `output`     | `{"type":"output","id":<int>,"stream":"stdout"\|"stderr","data":"...","turn":<int>}` |
+| `exit`       | `{"type":"exit","id":<int>,"code":0}` — terminal                                |
+| `error`      | `{"type":"error","id":<int>,"message":"..."}` — terminal (exception path)       |
+| `terminated` | `{"type":"terminated","id":<int>,"message":"Session terminated"}` — terminal    |
+| `stale`      | `{"type":"stale","id":<int>,"message":"No output for 600s"}` — terminal; session may still be `running` |
 
-Heartbeats are lines starting with `: ` (skip them). Stream always replays **everything** from the start on every connection — then tails live output if still running, or emits terminal event + closes if already terminal. Reconnects are safe and idempotent.
+Heartbeats are lines starting with `: ` (skip them). Stream replays everything from the start by default; supply the last received `id` via `Last-Event-ID` header or `?since=<id>` query param to resume without re-receiving old events. If both are supplied, the header wins. `since=0` or omitting it gives a full replay. Non-integer `since` returns `400`.
 
 Reference client:
 
 ```python
 import json, requests
 
-resp = requests.get(
-    f"{BASE}/sessions/{sid}/stream",
-    headers={"Authorization": f"Bearer {TOKEN}"},
-    stream=True,
-)
-resp.raise_for_status()
-for line in resp.iter_lines(decode_unicode=True):
-    if not line or line.startswith(":"):
-        continue
-    event = json.loads(line[len("data: "):])
-    if event["type"] == "output":
-        print(event["data"], end="")
-    elif event["type"] in ("exit", "error", "terminated"):
-        break
+last_event_id = 0
+while True:
+    headers = {"Authorization": f"Bearer {TOKEN}"}
+    if last_event_id:
+        headers["Last-Event-ID"] = str(last_event_id)
+    with requests.get(f"{BASE}/sessions/{sid}/stream", headers=headers, stream=True) as resp:
+        resp.raise_for_status()
+        for line in resp.iter_lines(decode_unicode=True):
+            if not line or line.startswith(":"):
+                continue
+            if line.startswith("id: "):
+                last_event_id = int(line[4:])
+            elif line.startswith("data: "):
+                event = json.loads(line[6:])
+                if event["type"] == "output":
+                    print(event["data"], end="")
+                elif event["type"] in ("exit", "error", "terminated", "stale"):
+                    return
 ```
 
 ## Minimum Viable curl Recipes

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -350,6 +350,20 @@ paths:
     get:
       tags: [sessions]
       summary: Server-sent events stream of session output
+      description: >
+        Streams session output as Server-Sent Events. Event types: `start`,
+        `turn_start`, `output`, `exit`, `error`, `terminated`, `stale`.
+        Every event except `start` includes an `"id"` field in its JSON payload
+        and an SSE `id:` line. Clients can resume a disconnected stream via
+        the `Last-Event-ID` header or the `since` query parameter.
+      parameters:
+        - name: since
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+          description: "Resume after this event id. Omit for full replay."
       responses:
         "200":
           description: text/event-stream
@@ -357,6 +371,8 @@ paths:
             text/event-stream:
               schema:
                 type: string
+        "400":
+          description: Bad request (e.g. since is not a non-negative integer)
 
 components:
   securitySchemes:

--- a/site/docs/api/streaming.md
+++ b/site/docs/api/streaming.md
@@ -13,19 +13,23 @@ Agent on Demand streams session output as [Server-Sent Events](https://developer
 - `Cache-Control: no-cache`
 - `X-Accel-Buffering: no`
 
-Each event is a line of the form `data: <json>\n\n`.
+Each event is a line of the form `data: <json>\n\n`, preceded by an `id: <int>\n` line for every event except `start`.
 
 ## Event types
 
 | Type | Payload | Notes |
 |------|---------|-------|
-| `start` | `{"type":"start","runtime":"claude","session_id":"<uuid>"}` | Always the first event, before any replayed output |
-| `output` | `{"type":"output","stream":"stdout"\|"stderr","data":"..."}` | One chunk of agent output; may contain multiple lines |
-| `exit` | `{"type":"exit","code":0}` | Terminal. Emitted when the runtime exits (code 0 = success, non-zero = failure) |
-| `error` | `{"type":"error","message":"..."}` | Terminal. Emitted on unhandled exception — no exit code available |
-| `terminated` | `{"type":"terminated","message":"Session terminated"}` | Terminal. Emitted after `POST /sessions/{id}/terminate` |
+| `start` | `{"type":"start","runtime":"claude","session_id":"<uuid>"}` | Always the first event, before any replayed output. No `id` field. |
+| `turn_start` | `{"type":"turn_start","id":42,"turn":1}` | Emitted before the first `output` event of each turn. Turn numbers start at 1. |
+| `output` | `{"type":"output","id":42,"stream":"stdout"\|"stderr","data":"...","turn":1}` | One chunk of agent output; may contain multiple lines |
+| `exit` | `{"type":"exit","id":42,"code":0}` | Terminal. Emitted when the runtime exits (code 0 = success, non-zero = failure) |
+| `error` | `{"type":"error","id":42,"message":"..."}` | Terminal. Emitted on unhandled exception — no exit code available |
+| `terminated` | `{"type":"terminated","id":42,"message":"Session terminated"}` | Terminal. Emitted after `POST /sessions/{id}/terminate` |
+| `stale` | `{"type":"stale","id":42,"message":"No output for 600s"}` | Terminal. Emitted if the server sees no new log chunks for 10 minutes on a still-`running` session. The session row may remain `running`; clients should treat this as terminal and reconnect if desired. |
 
-The stream closes after the terminal event (`exit`, `error`, or `terminated`).
+Every event except `start` includes an `"id"` field in its JSON payload, set to the log row ID. For terminal events (`exit`, `error`, `terminated`, `stale`), `id` is set to the last seen log row.
+
+The stream closes after any terminal event.
 
 ## Heartbeats
 
@@ -35,28 +39,49 @@ Every 15 seconds with no output, Agent on Demand sends a heartbeat to keep the c
 : heartbeat
 ```
 
-**Skip any line that starts with `:`.**
+**Skip any line that starts with `:`** — heartbeat lines are not JSON.
 
 ## Replay behavior
 
 Connecting to a stream always replays all stored output from the beginning:
 
 - **Session still running**: you get everything buffered so far, then live output as it arrives.
-- **Session already terminal**: you get `start` → all buffered `output` events → the terminal event, then the stream closes immediately.
-
-This means you can safely disconnect and reconnect — you won't miss output.
+- **Session already terminal**: you get `start` → all buffered events → the terminal event, then the stream closes immediately.
 
 ## Example stream
 
 ```
-data: {"type":"start","runtime":"claude","session_id":"<uuid>"}
+data: {"type": "start", "runtime": "claude", "session_id": "..."}
 
-data: {"type":"output","stream":"stdout","data":"Hello from the agent\n"}
+id: 1
+data: {"type": "turn_start", "id": 1, "turn": 1}
 
-data: {"type":"output","stream":"stdout","data":"Done.\n"}
+id: 1
+data: {"type": "output", "id": 1, "stream": "stdout", "data": "hello\n", "turn": 1}
 
-data: {"type":"exit","code":0}
+id: 2
+data: {"type": "output", "id": 2, "stream": "stdout", "data": "world\n", "turn": 1}
+
+id: 2
+data: {"type": "exit", "id": 2, "code": 0}
 ```
+
+## Resuming a stream
+
+Every event other than `start` carries an `id`. To resume after a disconnect,
+pass the last `id` you received in either:
+
+- The `Last-Event-ID` HTTP header (automatic for browser `EventSource` clients)
+- A `?since=<id>` query parameter (useful for `fetch`, `requests`, or curl)
+
+If both are supplied, the header wins.
+
+The server resumes from the next event after the supplied `id`. If the event
+no longer exists (for example, logs older than 30 days are purged), the
+stream silently resumes from the nearest surviving event rather than failing.
+Pass `since=0` (or omit) for a full replay.
+
+If the `id` is not a non-negative integer, the server returns `400`.
 
 ## Client examples
 
@@ -76,31 +101,21 @@ The `-N` flag disables output buffering.
 import json
 import requests
 
-resp = requests.get(
-    f"{BASE}/sessions/{session_id}/stream",
-    headers={"Authorization": f"Bearer {TOKEN}"},
-    stream=True,
-)
-resp.raise_for_status()
-
-for line in resp.iter_lines(decode_unicode=True):
-    if not line or line.startswith(":"):
-        continue  # blank line between events, or heartbeat
-    if not line.startswith("data: "):
-        continue  # defensive
-    event = json.loads(line[6:])
-    if event["type"] == "output":
-        print(event["data"], end="")
-    elif event["type"] in ("exit", "error", "terminated"):
-        print(f"\n[{event['type']}] {event.get('code', event.get('message', ''))}")
-        break
+last_event_id = 0
+while True:
+    headers = {"Authorization": f"Bearer {token}"}
+    if last_event_id:
+        headers["Last-Event-ID"] = str(last_event_id)
+    with requests.get(url, headers=headers, stream=True) as r:
+        for line in r.iter_lines(decode_unicode=True):
+            if not line or line.startswith(":"):
+                continue  # blank line between events, or heartbeat
+            if line.startswith("id: "):
+                last_event_id = int(line[4:])
+            elif line.startswith("data: "):
+                event = json.loads(line[6:])
+                # handle event...
+                if event["type"] in ("exit", "error", "terminated", "stale"):
+                    return
+    # loop reconnects with Last-Event-ID preserved
 ```
-
-## Reconnect guidance
-
-Because Agent on Demand replays all output on every new connection, reconnecting is safe and cheap:
-
-1. On connection error, wait briefly, then reconnect with the same request.
-2. You will receive duplicate output starting from `start`, but you won't miss anything.
-
-If you want to deduplicate, track how many `output` events you've received and skip that many at the start of a reconnect. Since `start` is always first and output events are append-only, counting is reliable.

--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -30,6 +30,7 @@ import io
 import logging
 import queue
 import threading
+import time
 
 import posthog
 from django.contrib.auth import get_user_model
@@ -55,6 +56,7 @@ logger = logging.getLogger(__name__)
 
 _SENTINEL = object()
 FLUSH_SIZE = 20
+_BULK_CREATE_DELAYS = (0.1, 0.3, 1.0)
 
 
 class TaggedChunk:
@@ -77,13 +79,19 @@ class TaggingQueueWriter(io.RawIOBase):
     def __init__(self, q: queue.Queue, stream: str):
         self._queue = q
         self._stream = stream
+        self.drop_count = 0
 
     def writable(self) -> bool:
         return True
 
     def write(self, b) -> int:  # type: ignore[override]
         data = bytes(b)
-        self._queue.put(TaggedChunk(self._stream, data))
+        try:
+            self._queue.put(TaggedChunk(self._stream, data), timeout=5.0)
+        except queue.Full:
+            self.drop_count += 1
+            if self.drop_count == 1:
+                logger.warning("TaggingQueueWriter: output queue full, dropping chunks")
         return len(data)
 
 
@@ -138,9 +146,7 @@ def _provision_session_inner(
     mode: str,
     timeout: float,
 ) -> None:
-    session = AgentSession.objects.select_related("user", "agent", "environment").get(
-        pk=session_id
-    )
+    session = AgentSession.objects.select_related("user", "agent", "environment").get(pk=session_id)
     # If the client terminated before the worker picked this up, skip.
     if session.status == "terminated":
         return
@@ -216,9 +222,7 @@ def _build_spec_for_session(session: AgentSession) -> SessionSpec | None:
         name=session.sprite_name,
         runtime=RUNTIMES[session.runtime],
         api_key=api_key,
-        runtime_session_id=str(session.runtime_session_id)
-        if session.runtime_session_id
-        else None,
+        runtime_session_id=str(session.runtime_session_id) if session.runtime_session_id else None,
         environment=session.environment,
         repos=repos,
         mcp_servers=mcp_servers,
@@ -318,18 +322,39 @@ def _execute_turn_inner(
         _execute_turn_body(session, turn, runtime, sprite, prompt, mode, timeout, span)
 
 
-def _execute_turn_body(
-    session, turn, runtime, sprite, prompt, mode, timeout, span
-) -> None:
+def _execute_turn_body(session, turn, runtime, sprite, prompt, mode, timeout, span) -> None:
 
     output_q: queue.Queue = queue.Queue(maxsize=4096)
     db_buffer: list[AgentSessionLog] = []
     result_holder: list = []
+    stdout_writer = TaggingQueueWriter(output_q, "stdout")
+    stderr_writer = TaggingQueueWriter(output_q, "stderr")
 
     def _flush_buffer():
-        if db_buffer:
-            AgentSessionLog.objects.bulk_create(db_buffer)
-            db_buffer.clear()
+        if not db_buffer:
+            return
+        for attempt, delay in enumerate(_BULK_CREATE_DELAYS, 1):
+            try:
+                AgentSessionLog.objects.bulk_create(db_buffer)
+                db_buffer.clear()
+                return
+            except Exception:
+                if attempt == len(_BULK_CREATE_DELAYS):
+                    logger.exception("bulk_create exhausted retries")
+                    with posthog.new_context():
+                        posthog.identify_context(str(session.user_id))
+                        posthog.capture(
+                            "session.log_write_retry_exhausted",
+                            properties={
+                                "session_id": str(session.id),
+                                "turn_number": turn.turn_number,
+                                "runtime": session.runtime,
+                                "dropped_chunks": len(db_buffer),
+                            },
+                        )
+                    raise
+                close_old_connections()
+                time.sleep(delay)
 
     def _run_command():
         # NOTE: if you add DB writes inside this inner thread, wrap the body
@@ -343,8 +368,8 @@ def _execute_turn_body(
                 timeout=timeout,
             )
             cmd.stdin = io.BytesIO(prompt.encode("utf-8"))
-            cmd.stdout = TaggingQueueWriter(output_q, "stdout")
-            cmd.stderr = TaggingQueueWriter(output_q, "stderr")
+            cmd.stdout = stdout_writer
+            cmd.stderr = stderr_writer
             cmd.run()
             result_holder.append(("exit", 0))
         except ExecError as e:
@@ -385,7 +410,38 @@ def _execute_turn_body(
             _flush_buffer()
 
     _flush_buffer()
+
+    total_drops = stdout_writer.drop_count + stderr_writer.drop_count
+    if total_drops > 0:
+        with posthog.new_context():
+            posthog.identify_context(str(session.user_id))
+            posthog.capture(
+                "session.output_chunks_dropped",
+                properties={
+                    "session_id": str(session.id),
+                    "turn_number": turn.turn_number,
+                    "runtime": session.runtime,
+                    "dropped_count": total_drops,
+                },
+            )
+
     cmd_thread.join(timeout=5.0)
+    if cmd_thread.is_alive():
+        logger.error(
+            "session %s turn %s: command thread still alive after join",
+            session.id,
+            turn.turn_number,
+        )
+        with posthog.new_context():
+            posthog.identify_context(str(session.user_id))
+            posthog.capture(
+                "session.cmd_thread_leaked",
+                properties={
+                    "session_id": str(session.id),
+                    "turn_number": turn.turn_number,
+                    "runtime": session.runtime,
+                },
+            )
 
     if result_holder:
         kind, value = result_holder[0]

--- a/src/agent_on_demand/stream.py
+++ b/src/agent_on_demand/stream.py
@@ -4,18 +4,26 @@ from collections.abc import Generator
 
 from agent_on_demand.models import AgentSession, AgentSessionLog
 
+STREAM_IDLE_LIMIT = 600  # seconds of no new chunks before emitting `stale` and exiting
 
-def stream_session_from_db(session_id: str) -> Generator[str, None, None]:
-    """Yield SSE event strings by tailing the AgentSessionLog table.
 
-    1. Replay all existing rows (emitting turn_start when the log's turn advances)
-    2. Poll for new rows every 500ms
-    3. Send heartbeat every 15s
-    4. Stop when session is complete/failed AND no new rows remain
+def _format(event_type: str, log_id: int, payload: dict) -> str:
+    return json.dumps({"type": event_type, "id": log_id, **payload})
+
+
+def stream_session_from_db(session_id: str, since: int = 0) -> Generator[str, None, None]:
+    """Yield SSE event strings by tailing AgentSessionLog.
+
+    - Starts after `since` (exclusive). 0 = from the beginning.
+    - Stale cursors (log row deleted by retention) silently resume from the
+      next surviving row — `id__gt=since` naturally handles this.
+    - Exits when the session reaches a terminal state with no new rows, OR
+      when no new chunks have arrived for STREAM_IDLE_LIMIT seconds.
     """
-    last_id = 0
+    last_id = since
     last_turn_id = None
     last_heartbeat = time.time()
+    last_chunk_time = time.time()
 
     while True:
         chunks = list(
@@ -24,29 +32,41 @@ def stream_session_from_db(session_id: str) -> Generator[str, None, None]:
             .values("id", "stream", "data", "turn_id", "turn__turn_number")[:100]
         )
 
+        if chunks:
+            last_chunk_time = time.time()
+
         for chunk in chunks:
             last_id = chunk["id"]
             turn_id = chunk["turn_id"]
             if turn_id is not None and turn_id != last_turn_id:
-                yield json.dumps({"type": "turn_start", "turn": chunk["turn__turn_number"]})
+                yield _format("turn_start", chunk["id"], {"turn": chunk["turn__turn_number"]})
                 last_turn_id = turn_id
-            yield json.dumps(
+            yield _format(
+                "output",
+                chunk["id"],
                 {
-                    "type": "output",
                     "stream": chunk["stream"],
                     "data": chunk["data"],
                     "turn": chunk["turn__turn_number"],
-                }
+                },
             )
 
         session = AgentSession.objects.get(pk=session_id)
         if session.status in ("completed", "failed", "terminated") and not chunks:
             if session.status == "terminated":
-                yield json.dumps({"type": "terminated", "message": "Session terminated"})
+                yield _format("terminated", last_id, {"message": "Session terminated"})
             elif session.status == "failed" and session.exit_code is None:
-                yield json.dumps({"type": "error", "message": "Session failed"})
+                yield _format("error", last_id, {"message": "Session failed"})
             else:
-                yield json.dumps({"type": "exit", "code": session.exit_code})
+                yield _format("exit", last_id, {"code": session.exit_code})
+            break
+
+        if time.time() - last_chunk_time > STREAM_IDLE_LIMIT:
+            yield _format(
+                "stale",
+                last_id,
+                {"message": f"No output for {STREAM_IDLE_LIMIT}s"},
+            )
             break
 
         now = time.time()

--- a/src/agent_on_demand/views/sessions.py
+++ b/src/agent_on_demand/views/sessions.py
@@ -305,13 +305,23 @@ def stream_session(request, session_id):
     except (AgentSession.DoesNotExist, ValueError):
         return JsonResponse({"detail": "Session not found"}, status=404)
 
+    raw = request.META.get("HTTP_LAST_EVENT_ID") or request.GET.get("since", "0")
+    try:
+        since = max(0, int(raw))
+    except ValueError:
+        return JsonResponse({"detail": "since must be an integer"}, status=400)
+
     def event_generator():
         yield f"data: {json.dumps({'type': 'start', 'runtime': session.runtime, 'session_id': str(session.id)})}\n\n"
 
-        for event in stream_session_from_db(str(session.id)):
+        for event in stream_session_from_db(str(session.id), since=since):
             if event == "":
                 yield ": heartbeat\n\n"
             else:
+                payload = json.loads(event)
+                log_id = payload.get("id")
+                if log_id:
+                    yield f"id: {log_id}\n"
                 yield f"data: {event}\n\n"
 
     response = StreamingHttpResponse(event_generator(), content_type="text/event-stream")
@@ -456,9 +466,7 @@ def terminate_session(request, session_id):
     session.save(update_fields=["status", "sprite_name", "updated_at"])
 
     if sprite_name:
-        session_service.destroy_session_task.defer(
-            user_id=request.user.id, sprite_name=sprite_name
-        )
+        session_service.destroy_session_task.defer(user_id=request.user.id, sprite_name=sprite_name)
 
     with posthog.new_context():
         posthog.identify_context(str(request.user.id))

--- a/tests/e2e/test_sessions.py
+++ b/tests/e2e/test_sessions.py
@@ -1,5 +1,6 @@
 """E2E tests for session lifecycle, streaming, termination, and multi-turn."""
 
+import json
 import time
 import uuid
 
@@ -331,3 +332,96 @@ class TestMultiTurn:
         if status == "running":
             resp = api.send_prompt(session["id"], prompt="interrupt")
             assert resp.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# SSE reconnect via Last-Event-ID
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_sse_reconnect_via_last_event_id(api, create_agent, create_session):
+    """Reconnect with Last-Event-ID → no duplicate events replayed."""
+    runtime = "claude"
+    agent = create_agent(
+        name=_unique(f"e2e-reconnect-{runtime}"),
+        model=RUNTIME_MODELS[runtime],
+        runtime=runtime,
+    )
+    session = create_session(
+        agent_id=agent["id"],
+        prompt="Print the numbers 1 through 20, one per line.",
+        timeout=120,
+    )
+
+    # First connection: consume a few events then disconnect
+    first_events = []
+    last_seen_id = 0
+
+    resp = api.stream_session_raw(session["id"])
+    resp.raise_for_status()
+    deadline = time.time() + 60
+    try:
+        for line in resp.iter_lines(decode_unicode=True):
+            if time.time() > deadline:
+                break
+            if line.startswith("id: "):
+                last_seen_id = int(line[4:].strip())
+            elif line.startswith("data: "):
+                try:
+                    event = json.loads(line[6:])
+                except json.JSONDecodeError:
+                    continue
+                first_events.append(event)
+                # Stop after seeing a few output events
+                output_count = sum(1 for e in first_events if e.get("type") == "output")
+                if output_count >= 3:
+                    break
+    finally:
+        resp.close()
+
+    # We need at least one id to test reconnection
+    if last_seen_id == 0:
+        pytest.skip("No id: fields received in first stream — cannot test reconnect")
+
+    # Second connection: reconnect with Last-Event-ID
+    second_events = []
+    reconnect_headers = {
+        "Last-Event-ID": str(last_seen_id),
+        "Authorization": api.http.headers["Authorization"],
+    }
+    import requests
+
+    base_url = api.base_url
+    resp2 = requests.get(
+        f"{base_url}/sessions/{session['id']}/stream",
+        headers=reconnect_headers,
+        stream=True,
+        timeout=60,
+    )
+    resp2.raise_for_status()
+    deadline2 = time.time() + 120
+    try:
+        for line in resp2.iter_lines(decode_unicode=True):
+            if time.time() > deadline2:
+                break
+            if not line or line.startswith(":"):
+                continue
+            if line.startswith("data: "):
+                try:
+                    event = json.loads(line[6:])
+                except json.JSONDecodeError:
+                    continue
+                second_events.append(event)
+                if event.get("type") in ("exit", "error", "terminated"):
+                    break
+    finally:
+        resp2.close()
+
+    # Assert no duplicate events: no event in second stream has id <= last_seen_id
+    for event in second_events:
+        eid = event.get("id")
+        if eid is not None and event.get("type") not in ("start",):
+            assert eid > last_seen_id, (
+                f"Reconnect replayed event with id={eid} which is <= last_seen_id={last_seen_id}"
+            )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -596,9 +596,14 @@ def test_stream_emits_turn_start_boundaries(client: Client, auth_headers, user):
     resp = client.get(f"/sessions/{session.id}/stream", **auth_headers)
     content = b"".join(resp.streaming_content).decode()
     # Two turn_start events in order: 1 then 2.
-    i1 = content.index('"type": "turn_start", "turn": 1')
-    i2 = content.index('"type": "turn_start", "turn": 2')
-    assert i1 < i2
+    turn_start_events = [
+        json.loads(line[6:])
+        for line in content.splitlines()
+        if line.startswith("data: ")
+        and json.loads(line[6:]).get("type") == "turn_start"
+    ]
+    turns = [e["turn"] for e in turn_start_events]
+    assert turns == [1, 2]
 
 
 @pytest.mark.django_db

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,0 +1,332 @@
+"""Unit tests for `stream.stream_session_from_db` and the stream view."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+
+from agent_on_demand.models import (
+    APIKey,
+    AgentSession,
+    AgentSessionLog,
+    SessionTurn,
+)
+from agent_on_demand.stream import stream_session_from_db
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="streamuser", password="pass")
+
+
+@pytest.fixture
+def api_key(user):
+    instance, raw_key = APIKey.create_key(user, "test-key")
+    return instance, raw_key
+
+
+@pytest.fixture
+def auth_headers(api_key):
+    _, raw_key = api_key
+    return {"HTTP_AUTHORIZATION": f"Bearer {raw_key}"}
+
+
+@pytest.fixture
+def completed_session(user):
+    session = AgentSession.objects.create(
+        user=user,
+        runtime="claude",
+        prompt="test",
+        status="completed",
+        exit_code=0,
+    )
+    turn = SessionTurn.objects.create(
+        session=session,
+        turn_number=1,
+        prompt="test",
+        status="completed",
+    )
+    return session, turn
+
+
+def _seed_logs(session, turn, count=10, start_id_offset=None):
+    """Create `count` log rows and return the created objects."""
+    logs = []
+    for i in range(count):
+        log = AgentSessionLog.objects.create(
+            session=session,
+            turn=turn,
+            stream="stdout",
+            data=f"chunk-{i + 1}",
+        )
+        logs.append(log)
+    return logs
+
+
+# ---------------------------------------------------------------------------
+# stream_session_from_db — generator tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_stream_replays_from_since_cursor(completed_session):
+    """since=5 → only events with id > 5 are emitted."""
+    session, turn = completed_session
+    logs = _seed_logs(session, turn, count=10)
+    cutoff = logs[4].id  # 5th row (0-indexed)
+
+    events = list(stream_session_from_db(str(session.id), since=cutoff))
+
+    # Filter to output events only (exclude exit)
+    output_events = [e for e in events if json.loads(e).get("type") == "output"]
+    assert len(output_events) == 5
+    emitted_ids = [json.loads(e)["id"] for e in output_events]
+    assert all(eid > cutoff for eid in emitted_ids)
+    assert min(emitted_ids) == logs[5].id
+
+
+@pytest.mark.django_db
+def test_stream_full_replay_when_since_zero(completed_session):
+    """since=0 → all 10 rows replayed."""
+    session, turn = completed_session
+    logs = _seed_logs(session, turn, count=10)
+
+    events = list(stream_session_from_db(str(session.id), since=0))
+
+    output_events = [e for e in events if json.loads(e).get("type") == "output"]
+    assert len(output_events) == 10
+    emitted_ids = [json.loads(e)["id"] for e in output_events]
+    assert emitted_ids[0] == logs[0].id
+
+
+@pytest.mark.django_db
+def test_stream_lenient_on_stale_cursor(completed_session):
+    """since < min(log_id) → all rows still emitted (no error, no replay from 0)."""
+    session, turn = completed_session
+    # Seed 10 rows; their IDs will be > 50 since DB auto-increments
+    logs = _seed_logs(session, turn, count=10)
+    min_id = logs[0].id
+    stale_cursor = max(0, min_id - 100)  # well below range
+
+    events = list(stream_session_from_db(str(session.id), since=stale_cursor))
+
+    output_events = [e for e in events if json.loads(e).get("type") == "output"]
+    assert len(output_events) == 10
+
+
+@pytest.mark.django_db
+def test_stream_emits_stale_event_on_idle_timeout(user, mocker):
+    """When STREAM_IDLE_LIMIT seconds pass with no new chunks, generator emits stale and stops."""
+    session = AgentSession.objects.create(
+        user=user,
+        runtime="claude",
+        prompt="test",
+        status="running",
+    )
+
+    # Patch the `time` module as imported in `agent_on_demand.stream`
+    # so time.time() jumps past STREAM_IDLE_LIMIT immediately.
+    mock_time = mocker.patch("agent_on_demand.stream.time")
+    mock_time.sleep = lambda x: None
+
+    call_count = 0
+
+    def fast_time():
+        nonlocal call_count
+        call_count += 1
+        # First two calls (last_heartbeat, last_chunk_time init) return 0.
+        # Subsequent calls return > STREAM_IDLE_LIMIT to trigger stale.
+        if call_count <= 2:
+            return 0.0
+        return 700.0
+
+    mock_time.time.side_effect = fast_time
+
+    events = list(stream_session_from_db(str(session.id), since=0))
+
+    event_types = [json.loads(e)["type"] for e in events]
+    assert "stale" in event_types
+    # Generator must terminate after stale
+    assert event_types[-1] == "stale"
+
+
+# ---------------------------------------------------------------------------
+# stream view — HTTP tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_stream_emits_id_field_via_view(client: Client, auth_headers, user):
+    """Wire format must include `id: N` before each non-start data line."""
+    session = AgentSession.objects.create(
+        user=user,
+        runtime="claude",
+        prompt="test",
+        status="completed",
+        exit_code=0,
+    )
+    turn = SessionTurn.objects.create(
+        session=session, turn_number=1, prompt="test", status="completed"
+    )
+    AgentSessionLog.objects.create(session=session, turn=turn, stream="stdout", data="hello")
+
+    resp = client.get(f"/sessions/{session.id}/stream", **auth_headers)
+    assert resp.status_code == 200
+    content = b"".join(resp.streaming_content).decode()
+
+    lines = content.splitlines()
+    # Find lines that carry an id: prefix
+    id_lines = [line for line in lines if line.startswith("id: ")]
+    assert len(id_lines) >= 1, f"No id: lines found in:\n{content}"
+
+    # Each id: line should be followed by a data: line
+    for i, line in enumerate(lines):
+        if line.startswith("id: "):
+            assert i + 1 < len(lines), "id: line at end of stream with no data: following"
+            assert lines[i + 1].startswith("data: "), (
+                f"id: line not followed by data: line. Got: {lines[i + 1]!r}"
+            )
+
+
+@pytest.mark.django_db
+def test_stream_view_parses_last_event_id_header(client: Client, auth_headers, user):
+    """HTTP_LAST_EVENT_ID=3 → only rows with id > 3 emitted."""
+    session = AgentSession.objects.create(
+        user=user,
+        runtime="claude",
+        prompt="test",
+        status="completed",
+        exit_code=0,
+    )
+    turn = SessionTurn.objects.create(
+        session=session, turn_number=1, prompt="test", status="completed"
+    )
+    logs = _seed_logs(session, turn, count=5)
+    cutoff = logs[2].id  # after 3rd log
+
+    resp = client.get(
+        f"/sessions/{session.id}/stream",
+        HTTP_LAST_EVENT_ID=str(cutoff),
+        **auth_headers,
+    )
+    assert resp.status_code == 200
+    content = b"".join(resp.streaming_content).decode()
+
+    # Parse data lines
+    data_payloads = [
+        json.loads(line[6:]) for line in content.splitlines() if line.startswith("data: ")
+    ]
+    output_ids = [p["id"] for p in data_payloads if p.get("type") == "output"]
+    assert all(eid > cutoff for eid in output_ids), (
+        f"Expected all output ids > {cutoff}, got {output_ids}"
+    )
+    assert len(output_ids) == 2
+
+
+@pytest.mark.django_db
+def test_stream_view_parses_since_query_param(client: Client, auth_headers, user):
+    """?since=N → only rows with id > N emitted."""
+    session = AgentSession.objects.create(
+        user=user,
+        runtime="claude",
+        prompt="test",
+        status="completed",
+        exit_code=0,
+    )
+    turn = SessionTurn.objects.create(
+        session=session, turn_number=1, prompt="test", status="completed"
+    )
+    logs = _seed_logs(session, turn, count=5)
+    cutoff = logs[2].id
+
+    resp = client.get(
+        f"/sessions/{session.id}/stream?since={cutoff}",
+        **auth_headers,
+    )
+    assert resp.status_code == 200
+    content = b"".join(resp.streaming_content).decode()
+
+    data_payloads = [
+        json.loads(line[6:]) for line in content.splitlines() if line.startswith("data: ")
+    ]
+    output_ids = [p["id"] for p in data_payloads if p.get("type") == "output"]
+    assert len(output_ids) == 2
+    assert all(eid > cutoff for eid in output_ids)
+
+
+@pytest.mark.django_db
+def test_stream_view_header_precedence(client: Client, auth_headers, user):
+    """When both Last-Event-ID header and ?since= param are present, header wins."""
+    session = AgentSession.objects.create(
+        user=user,
+        runtime="claude",
+        prompt="test",
+        status="completed",
+        exit_code=0,
+    )
+    turn = SessionTurn.objects.create(
+        session=session, turn_number=1, prompt="test", status="completed"
+    )
+    logs = _seed_logs(session, turn, count=5)
+    # Header says skip first 5, param says skip first 2 — header should win
+    header_cutoff = logs[4].id  # skip all 5
+    param_cutoff = logs[1].id  # would keep 3
+
+    resp = client.get(
+        f"/sessions/{session.id}/stream?since={param_cutoff}",
+        HTTP_LAST_EVENT_ID=str(header_cutoff),
+        **auth_headers,
+    )
+    assert resp.status_code == 200
+    content = b"".join(resp.streaming_content).decode()
+
+    data_payloads = [
+        json.loads(line[6:]) for line in content.splitlines() if line.startswith("data: ")
+    ]
+    output_ids = [p["id"] for p in data_payloads if p.get("type") == "output"]
+    # Header wins: since=logs[4].id → 0 output events (all 5 skipped)
+    assert output_ids == [], f"Expected 0 output events, got ids: {output_ids}"
+
+
+@pytest.mark.django_db
+def test_stream_view_rejects_non_integer_since(client: Client, auth_headers, user):
+    """?since=abc → 400 with detail message."""
+    session = AgentSession.objects.create(
+        user=user,
+        runtime="claude",
+        prompt="test",
+        status="completed",
+        exit_code=0,
+    )
+    resp = client.get(f"/sessions/{session.id}/stream?since=abc", **auth_headers)
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "since must be an integer"
+
+
+@pytest.mark.django_db
+def test_stream_view_clamps_negative_since_to_zero(client: Client, auth_headers, user):
+    """?since=-5 → treated as 0, full replay."""
+    session = AgentSession.objects.create(
+        user=user,
+        runtime="claude",
+        prompt="test",
+        status="completed",
+        exit_code=0,
+    )
+    turn = SessionTurn.objects.create(
+        session=session, turn_number=1, prompt="test", status="completed"
+    )
+    _seed_logs(session, turn, count=3)
+
+    resp = client.get(f"/sessions/{session.id}/stream?since=-5", **auth_headers)
+    assert resp.status_code == 200
+    content = b"".join(resp.streaming_content).decode()
+
+    data_payloads = [
+        json.loads(line[6:]) for line in content.splitlines() if line.startswith("data: ")
+    ]
+    output_ids = [p["id"] for p in data_payloads if p.get("type") == "output"]
+    assert len(output_ids) == 3

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -8,6 +8,9 @@ contract without spinning up a worker or needing Postgres locally.
 
 from __future__ import annotations
 
+import queue
+import threading
+
 import pytest
 from django.contrib.auth.models import User
 from sprites import ExecError, SpriteError
@@ -22,10 +25,23 @@ from agent_on_demand.models import (
     UserSpritesKey,
 )
 from agent_on_demand.session_service.tasks import (
+    TaggingQueueWriter,
     destroy_session_task,
     execute_turn,
     provision_session_task,
 )
+
+
+@pytest.fixture(autouse=True)
+def mock_close_old_connections(mocker):
+    """Prevent close_old_connections() from closing the test DB connection.
+
+    Tasks call close_old_connections() in entry/exit wrappers and inside
+    _flush_buffer's retry loop. In production that's correct; in tests the
+    call kills the pytest-django test transaction, breaking every subsequent
+    DB query in the same test. Stub it out so test isolation is preserved.
+    """
+    mocker.patch("agent_on_demand.session_service.tasks.close_old_connections")
 
 
 @pytest.fixture
@@ -267,16 +283,12 @@ def _make_pending_session(user):
         runtime_session_id="11111111-2222-3333-4444-555555555555",
         status="pending",
     )
-    turn = SessionTurn.objects.create(
-        session=session, turn_number=1, prompt="hi", status="pending"
-    )
+    turn = SessionTurn.objects.create(session=session, turn_number=1, prompt="hi", status="pending")
     return session, turn
 
 
 @pytest.mark.django_db
-def test_provision_task_enqueues_execute_turn_on_success(
-    provision_user, fake_sprites, mocker
-):
+def test_provision_task_enqueues_execute_turn_on_success(provision_user, fake_sprites, mocker):
     session, turn = _make_pending_session(provision_user)
     defer_spy = mocker.patch("agent_on_demand.session_service.tasks.execute_turn.defer")
 
@@ -351,9 +363,7 @@ def test_provision_task_skips_if_session_terminated(provision_user, fake_sprites
 
 
 @pytest.mark.django_db
-def test_provision_task_marks_failed_when_runtime_key_missing(
-    provision_user, fake_sprites, mocker
-):
+def test_provision_task_marks_failed_when_runtime_key_missing(provision_user, fake_sprites, mocker):
     """If the user's runtime key was deleted between create and provision,
     the task surfaces that as a failed session rather than raising."""
     session, turn = _make_pending_session(provision_user)
@@ -398,8 +408,184 @@ def test_destroy_task_swallows_sprite_errors(provision_user, fake_sprites, mocke
     """Matches the pre-existing `best_effort_delete` contract — errors are
     logged, not raised. Re-raising would let Procrastinate keep retrying a
     call that might never succeed."""
-    mocker.patch.object(
-        fake_sprites, "delete_sprite", side_effect=SpriteError("transient")
-    )
+    mocker.patch.object(fake_sprites, "delete_sprite", side_effect=SpriteError("transient"))
     destroy_session_task(user_id=provision_user.id, sprite_name="aod-xyz")
     # Assertion is "no exception raised".
+
+
+# --------------------------------------------------------------------------
+# Producer robustness tests
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_bulk_create_retries_on_transient_failure(user, mocker):
+    """bulk_create raises once then succeeds → chunks land in DB, no exhaustion event."""
+    session, turn = _make_session_and_turn(user)
+
+    call_count = 0
+    original_bulk_create = AgentSessionLog.objects.bulk_create
+
+    def flaky_bulk_create(objs, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise Exception("transient DB error")
+        return original_bulk_create(objs, **kwargs)
+
+    mocker.patch.object(AgentSessionLog.objects, "bulk_create", side_effect=flaky_bulk_create)
+    mocker.patch("agent_on_demand.session_service.tasks.time.sleep")
+    mock_posthog = mocker.patch("posthog.capture")
+
+    def drive_output(*_, **__):
+        writer = mock_cmd.stdout
+        writer.write(b"chunk-a\n")
+        writer.write(b"chunk-b\n")
+
+    _, mock_cmd = _patch_sprite(mocker, "success")
+    mock_cmd.run.side_effect = drive_output
+
+    execute_turn(
+        session_id=str(session.id),
+        turn_id=turn.id,
+        prompt="t",
+        mode="run",
+        timeout=10.0,
+    )
+
+    # All chunks must be in DB
+    logs = list(AgentSessionLog.objects.filter(session=session).order_by("id"))
+    assert any("chunk-a" in log.data for log in logs)
+    assert any("chunk-b" in log.data for log in logs)
+
+    # Exhaustion posthog event must NOT have been emitted
+    exhaustion_calls = [
+        c
+        for c in mock_posthog.call_args_list
+        if c.args and c.args[0] == "session.log_write_retry_exhausted"
+    ]
+    assert exhaustion_calls == []
+
+
+@pytest.mark.django_db
+def test_bulk_create_exhausts_retries_and_raises(user, mocker):
+    """bulk_create always raises → posthog exhaustion event captured, task re-raises."""
+    session, turn = _make_session_and_turn(user)
+
+    mocker.patch.object(
+        AgentSessionLog.objects,
+        "bulk_create",
+        side_effect=Exception("persistent DB error"),
+    )
+    mocker.patch("agent_on_demand.session_service.tasks.time.sleep")
+    mock_posthog = mocker.patch("posthog.capture")
+
+    def drive_output(*_, **__):
+        writer = mock_cmd.stdout
+        writer.write(b"some chunk\n")
+
+    _, mock_cmd = _patch_sprite(mocker, "success")
+    mock_cmd.run.side_effect = drive_output
+
+    # After exhausting all retries _flush_buffer re-raises, so the task itself raises.
+    with pytest.raises(Exception, match="persistent DB error"):
+        execute_turn(
+            session_id=str(session.id),
+            turn_id=turn.id,
+            prompt="t",
+            mode="run",
+            timeout=10.0,
+        )
+
+    exhaustion_calls = [
+        c
+        for c in mock_posthog.call_args_list
+        if c.args and c.args[0] == "session.log_write_retry_exhausted"
+    ]
+    assert len(exhaustion_calls) == 1
+    props = exhaustion_calls[0].kwargs.get("properties", {})
+    assert props.get("dropped_chunks", 0) > 0
+
+
+@pytest.mark.django_db
+def test_queue_full_drops_chunk_and_counts():
+    """TaggingQueueWriter with full queue increments drop_count and doesn't raise."""
+    q: queue.Queue = queue.Queue(maxsize=1)
+    writer = TaggingQueueWriter(q, "stdout")
+
+    # Fill the queue so the next put will timeout
+    q.put_nowait(object())
+
+    # This write should be dropped, not raise
+    result = writer.write(b"dropped chunk")
+
+    assert writer.drop_count == 1
+    assert result == len(b"dropped chunk")
+
+
+@pytest.mark.django_db
+def test_output_chunks_dropped_posthog_event(user, mocker):
+    """When drop_count > 0 after the turn, session.output_chunks_dropped is captured."""
+    session, turn = _make_session_and_turn(user)
+    mock_posthog = mocker.patch("posthog.capture")
+
+    original_patch_sprite = _patch_sprite(mocker, "success")
+    _, mock_cmd = original_patch_sprite
+
+    original_init = TaggingQueueWriter.__init__
+
+    # Track created writers so we can set drop_count after run
+    writers_created = []
+
+    def tracking_init(self, q, stream):
+        original_init(self, q, stream)
+        writers_created.append(self)
+
+    mocker.patch.object(TaggingQueueWriter, "__init__", tracking_init)
+
+    def drive_and_drop(*_, **__):
+        # Simulate drops by directly incrementing drop_count on the writers
+        for w in writers_created:
+            w.drop_count = 3
+
+    mock_cmd.run.side_effect = drive_and_drop
+
+    execute_turn(
+        session_id=str(session.id),
+        turn_id=turn.id,
+        prompt="t",
+        mode="run",
+        timeout=10.0,
+    )
+
+    drop_calls = [
+        c
+        for c in mock_posthog.call_args_list
+        if c.args and c.args[0] == "session.output_chunks_dropped"
+    ]
+    assert len(drop_calls) == 1
+
+
+@pytest.mark.django_db
+def test_cmd_thread_leak_detected(user, mocker):
+    """When cmd_thread.is_alive() returns True after join, posthog captures session.cmd_thread_leaked."""
+    session, turn = _make_session_and_turn(user)
+    _patch_sprite(mocker, "success")
+    mock_posthog = mocker.patch("posthog.capture")
+
+    mocker.patch.object(threading.Thread, "is_alive", return_value=True)
+
+    execute_turn(
+        session_id=str(session.id),
+        turn_id=turn.id,
+        prompt="t",
+        mode="run",
+        timeout=10.0,
+    )
+
+    leak_calls = [
+        c
+        for c in mock_posthog.call_args_list
+        if c.args and c.args[0] == "session.cmd_thread_leaked"
+    ]
+    assert len(leak_calls) == 1

--- a/thoughts/plans/2026-04-19-streaming-high-volume-readiness.md
+++ b/thoughts/plans/2026-04-19-streaming-high-volume-readiness.md
@@ -1,0 +1,886 @@
+# Streaming High-Volume Readiness Implementation Plan
+
+## Overview
+
+Fix the streaming stack's scalability gaps identified in
+`thoughts/research/2026-04-19-streaming-high-volume-readiness.md`. Three PRs
+land in sequence: (1) config + capacity, (2) producer + consumer
+robustness, (3) operational hygiene (retention + watchdog).
+
+The critical finding: under today's config the web service saturates at
+**3 concurrent SSE clients** and `AgentSessionLog` has no retention — the
+`basic-256mb` Postgres plan fills in ~2 days at 100 sessions/day. Every
+other issue (producer stall, stuck sessions, slow-client DoS, missing
+reconnect cursor) compounds these two.
+
+## Research Summary
+
+Research conducted by two agent teams:
+- **Risk research** (`thoughts/research/2026-04-19-streaming-high-volume-readiness.md`):
+  5 specialist tracks surveyed the SSE consumer, log producer, DB shape,
+  client UX, and prior `thoughts/` context.
+- **Pattern research** (this plan): 5 specialist tracks surveyed config &
+  deploy conventions, producer robustness patterns, scheduling/retention
+  precedents, API-evolution patterns, and test harness conventions — so
+  every fix follows existing style.
+
+### Key discoveries (with refs):
+- **Gunicorn 25.3.0 bundles `gthread`** — no extra dep (`pyproject.toml:28`).
+- **Procrastinate 3.8.1 supports `@app.periodic(cron=...)`** — existing
+  worker process runs periodic tasks. No new Render cron service required
+  (`pyproject.toml:25`).
+- **`AgentSession.updated_at`** (`auto_now=True`, `models/sessions.py:39`)
+  is the right signal for the stuck-session watchdog; `AgentSessionLog`
+  is not indexed on `created_at`.
+- **`render.yaml` `plan:` field controls the Postgres plan** — change
+  there + push to upgrade (`render.yaml:8`).
+- **No staging environment exists** (`render.yaml:1-93`). Direct-to-prod.
+  Each PR needs a rollback plan (revert commit + push).
+- **`stream.py` has zero unit tests today** — new test file needed.
+- **No `freezegun` or `tenacity` in deps** — use `.update(updated_at=...)`
+  to backdate rows in tests; use inline retry loops (no new libs).
+- **`conn_max_age=600` (`settings.py:72`) + gthread `--threads=8` × 3
+  workers = 24 connections**, which exceeds `basic-256mb` Postgres's 25
+  max_connections once worker connections are added. Upgrading Postgres
+  plan is mandatory, not optional, for this rollout.
+
+## Current State Analysis
+
+- **Web**: 3 sync Gunicorn workers. Each SSE stream pins one worker for the
+  session's lifetime (up to ~10 min). Structural cap: 3 concurrent streams.
+- **Worker**: single Procrastinate process, default `--concurrency=1`.
+  Turns serialize.
+- **Producer**: `TaggingQueueWriter.put()` is unconditionally blocking; a
+  slow DB blocks the SDK's stdout thread and can time out the agent. No
+  `bulk_create` retry. `cmd_thread.join(timeout=5.0)` has no follow-up
+  `is_alive()` check — can leak daemon threads silently.
+- **Consumer**: `stream.py` polls every 500 ms. No write-timeout — a
+  stalled client holds a worker indefinitely. No reconnect cursor —
+  every reconnect replays from `id=0`.
+- **DB**: Indexes are correct. `AgentSessionLog` grows unbounded; no
+  retention logic exists anywhere (confirmed by exhaustive grep).
+- **API docs**: `turn_start` event emitted but absent from
+  `site/docs/api/streaming.md` and `docs/openapi.yaml`.
+
+## Desired End State
+
+- **Web**: `gthread` workers with `--threads=8` → up to 24 concurrent SSE
+  streams. Slow clients can no longer pin workers indefinitely.
+- **Worker**: `--concurrency=4` so up to 4 turns can run in parallel.
+- **Producer**: `bulk_create` retries transient DB failures (3 attempts,
+  exponential backoff); queue uses bounded `put(timeout=5.0)` with
+  drop-and-count; leaked daemon threads are detected and reported.
+- **Consumer**: stream closes cleanly if the client stops reading within
+  N seconds; reconnects resume from `Last-Event-ID` (or `?since=<id>`).
+- **DB**: `AgentSessionLog` rows (and their parent sessions) older than
+  30 days are purged nightly. `basic-256mb` → `standard-1gb` Postgres
+  plan (97 max_connections).
+- **Ops**: sessions stuck in `running` > 15 min are automatically marked
+  `failed` by a watchdog, surfacing a terminal event to the SSE stream.
+- **Docs**: `turn_start` event documented; resume cursor documented.
+
+### Verification:
+- After PR 1: `curl` 10 parallel SSE streams simultaneously against a
+  long-running session → all succeed; `/health` still responds.
+- After PR 2: kill a client mid-stream → worker returns within 30 s;
+  reconnect with `Last-Event-ID` → no replay duplication.
+- After PR 3: create a session with `updated_at` backdated 20 min + status
+  `running` → watchdog flips to `failed` within 5 min. Completed session
+  with logs dated 31 days ago → deleted by nightly job.
+
+## What We're NOT Doing
+
+- **Not switching to ASGI** (explicitly rejected in prior research).
+- **Not switching to Redis/Celery/Dramatiq** — Postgres-backed Procrastinate
+  is already in place and adequate.
+- **Not changing the DB-tailing SSE pattern** — it's the right fit.
+- **Not making `failed` sessions resumable** (PR #48 decision stands).
+- **Not eliminating the inner daemon thread in `_execute_turn_body`** —
+  explicitly deferred as a separate optimization per procrastinate-worker plan.
+- **Not adding `AgentSession.completed_at`** — `updated_at` is sufficient
+  for watchdog.
+- **Not validating `Last-Event-ID` against a session-row-existence check** —
+  lenient behavior (silent resume past deleted rows) preserves UX after
+  retention.
+- **Not building an admin audit log of purges** — the periodic task itself
+  logs counts; that's enough for v1.
+
+## Implementation Approach
+
+Three PRs, shipped in order. PR 1 is atomic infrastructure (no code
+changes). PRs 2 and 3 can ship in parallel after PR 1 lands since they
+touch disjoint file sets.
+
+Every PR includes: automated verification (ruff + pytest), manual
+verification against the deployed service, and an explicit rollback
+procedure (revert + push).
+
+## File Ownership Map
+
+| File | PR | Change type |
+|------|----|-------------|
+| `render.yaml` | 1 | modify (web startCommand, worker startCommand, DB plan) |
+| `src/agent_on_demand/session_service/tasks.py` | 2 | modify (retry, backpressure, thread cleanup) |
+| `src/agent_on_demand/stream.py` | 2 | modify (write timeout, emit `id:`, honor cursor) |
+| `src/agent_on_demand/views/sessions.py` | 2 | modify (parse `Last-Event-ID` / `?since`) |
+| `site/docs/api/streaming.md` | 2 | modify (turn_start, resume, `id:` field) |
+| `docs/openapi.yaml` | 2 | modify (`since` param, event list) |
+| `.claude/skills/agent-on-demand-api.md` | 2 | modify (turn_start event) |
+| `tests/test_stream.py` | 2 | create |
+| `tests/test_tasks.py` | 2 | modify (retry/backpressure/cleanup tests) |
+| `tests/e2e/test_sessions.py` | 2 | modify (`Last-Event-ID` e2e, `@slow`) |
+| `src/agent_on_demand/session_service/maintenance.py` | 3 | create |
+| `src/agent_on_demand/migrations/0013_add_maintenance_indexes.py` | 3 | create |
+| `src/agent_on_demand/admin.py` | 3 | modify (bulk-purge action) |
+| `tests/test_maintenance.py` | 3 | create |
+
+No file appears in more than one PR.
+
+---
+
+## PR 1: Config & capacity
+
+### Overview
+Atomic infra bump. No code changes. Switches the web service to gthread
+workers, sets Procrastinate worker concurrency, and upgrades Postgres.
+
+These ship together because gthread `--threads=8` × 3 workers + Procrastinate
+`--concurrency=4` will exceed `basic-256mb`'s 25 max_connections. Upgrading
+Postgres first (or in the same push) is required.
+
+### Changes Required
+
+#### 1. `render.yaml` — web startCommand
+
+**File**: `render.yaml:18-25`
+
+Replace startCommand with:
+
+```yaml
+startCommand: >-
+  uv run gunicorn config.wsgi:application
+  --bind 0.0.0.0:$PORT
+  --workers 3
+  --worker-class gthread
+  --threads 8
+  --graceful-timeout 650
+  --timeout 700
+  --max-requests 1000
+  --max-requests-jitter 50
+```
+
+Changes: add `--worker-class gthread --threads 8`. Everything else
+unchanged. `--timeout 700` stays (arbiter→worker heartbeat, not
+per-request).
+
+#### 2. `render.yaml` — worker startCommand
+
+**File**: `render.yaml:56-57`
+
+Replace with:
+
+```yaml
+startCommand: >-
+  uv run python manage.py procrastinate worker
+  --concurrency 4
+```
+
+Verify during rollout: Procrastinate's `--concurrency` caps in-flight
+coroutines. Our tasks are sync and dispatch via `run_in_executor`. Python's
+default executor is large enough (`min(32, cpu_count+4)`) that the
+`--concurrency=4` semaphore is the effective cap. If under load we observe
+>4 concurrent turns (via posthog), add explicit executor config in a
+follow-up.
+
+#### 3. `render.yaml` — Postgres plan
+
+**File**: `render.yaml:7`
+
+Change:
+
+```yaml
+plan: basic-256mb
+```
+
+to:
+
+```yaml
+plan: standard-1gb
+```
+
+standard-1gb: 1 GB RAM, ~97 max_connections, ~$20/mo.
+
+### Success Criteria
+
+#### Automated:
+- [ ] `render config validate` passes (if available locally)
+
+#### Manual:
+- [ ] After deploy, `GET /health` still 200 under 10 parallel `curl` SSE
+      streams against a completed session.
+- [ ] `SELECT count(*) FROM pg_stat_activity WHERE datname='agent_on_demand'`
+      shows ~4–12 connections at rest, not at the 25 ceiling.
+- [ ] Procrastinate worker log shows up to 4 concurrent task executions under load.
+- [ ] Honeycomb/Posthog: confirm `session.execute_turn` spans can overlap.
+
+### Rollback
+
+Revert the commit and push. Render redeploys the previous `render.yaml`.
+Postgres plan downgrade will require DB plan review in the Render GUI.
+
+### Gate
+
+Hold 24 hours of production observation before merging PR 2 or PR 3.
+
+---
+
+## PR 2: Producer & consumer robustness
+
+### Overview
+Make the hot path survive transient DB failures, bounded queues, leaked
+threads, slow clients, and reconnects — while keeping API contracts
+additive only.
+
+### Parallel tracks within PR 2
+All changes ship in one PR since they touch overlapping files
+(`tasks.py`, `stream.py`, `views/sessions.py`, docs). Splitting further
+would cause merge churn.
+
+### Changes Required
+
+#### 1. `bulk_create` retry with backoff
+
+**File**: `src/agent_on_demand/session_service/tasks.py` (modify around
+line 329-332, inside `_execute_turn_body`)
+
+Replace:
+
+```python
+def _flush_buffer():
+    if db_buffer:
+        AgentSessionLog.objects.bulk_create(db_buffer)
+        db_buffer.clear()
+```
+
+with:
+
+```python
+_BULK_CREATE_DELAYS = (0.1, 0.3, 1.0)
+
+def _flush_buffer():
+    if not db_buffer:
+        return
+    for attempt, delay in enumerate(_BULK_CREATE_DELAYS, 1):
+        try:
+            AgentSessionLog.objects.bulk_create(db_buffer)
+            db_buffer.clear()
+            return
+        except Exception as e:
+            if attempt == len(_BULK_CREATE_DELAYS):
+                logger.exception("bulk_create exhausted retries")
+                with posthog.new_context():
+                    posthog.identify_context(str(session.user_id))
+                    posthog.capture(
+                        "session.log_write_retry_exhausted",
+                        properties={
+                            "session_id": str(session.id),
+                            "turn_number": turn.turn_number,
+                            "runtime": session.runtime,
+                            "dropped_chunks": len(db_buffer),
+                        },
+                    )
+                raise
+            close_old_connections()
+            time.sleep(delay)
+```
+
+Emits a span inside the retry loop (via `tracer.start_as_current_span`) is
+*not* added here — existing span around the whole turn body already covers
+the DB write subspan implicitly, and adding nested spans adds noise.
+
+#### 2. Bounded `queue.put` with drop-and-count
+
+**File**: `src/agent_on_demand/session_service/tasks.py:70-87`
+
+Modify `TaggingQueueWriter`:
+
+```python
+class TaggingQueueWriter(io.RawIOBase):
+    def __init__(self, q: queue.Queue, stream: str):
+        self._queue = q
+        self._stream = stream
+        self.drop_count = 0
+
+    def writable(self) -> bool:
+        return True
+
+    def write(self, b) -> int:  # type: ignore[override]
+        data = bytes(b)
+        try:
+            self._queue.put(TaggedChunk(self._stream, data), timeout=5.0)
+        except queue.Full:
+            self.drop_count += 1
+            if self.drop_count == 1:
+                logger.warning(
+                    "TaggingQueueWriter: output queue full, dropping chunks"
+                )
+        return len(data)
+```
+
+After the consumer loop in `_execute_turn_body`, if either writer
+`drop_count > 0`, emit a posthog event:
+
+```python
+total_drops = stdout_writer.drop_count + stderr_writer.drop_count
+if total_drops > 0:
+    with posthog.new_context():
+        posthog.identify_context(str(session.user_id))
+        posthog.capture(
+            "session.output_chunks_dropped",
+            properties={
+                "session_id": str(session.id),
+                "turn_number": turn.turn_number,
+                "runtime": session.runtime,
+                "dropped_count": total_drops,
+            },
+        )
+```
+
+Requires plumbing `stdout_writer` and `stderr_writer` as local
+variables (they're currently inline in `_run_command`).
+
+#### 3. `cmd_thread.is_alive()` check after join
+
+**File**: `src/agent_on_demand/session_service/tasks.py:388`
+
+Replace:
+
+```python
+cmd_thread.join(timeout=5.0)
+```
+
+with:
+
+```python
+cmd_thread.join(timeout=5.0)
+if cmd_thread.is_alive():
+    logger.error(
+        "session %s turn %s: command thread still alive after join",
+        session.id,
+        turn.turn_number,
+    )
+    with posthog.new_context():
+        posthog.identify_context(str(session.user_id))
+        posthog.capture(
+            "session.cmd_thread_leaked",
+            properties={
+                "session_id": str(session.id),
+                "turn_number": turn.turn_number,
+                "runtime": session.runtime,
+            },
+        )
+```
+
+No forceful termination — Python can't kill a thread. The leak is
+reported; the turn proceeds to mark itself `failed` or `completed` per
+the existing `result_holder` state.
+
+#### 4. SSE write timeout / idle client detection
+
+**File**: `src/agent_on_demand/stream.py` (modify around lines 20-57)
+
+Add an **idle timeout**: if no new chunks arrive and the session is still
+`running`, keep polling up to `STREAM_IDLE_LIMIT=600` seconds. After
+that, break and emit a terminal "stale" event. This bounds the maximum
+time a slow client can hold a worker.
+
+Note: detecting actual client disconnect in a Gunicorn sync/gthread view
+is *not* reliably possible in Django — the generator only knows when it
+writes and the socket errors. Gunicorn's internal write machinery will
+raise an exception on a dead socket, which will propagate out of the
+`yield` and unwind `event_generator`. We don't need to catch it; we need
+to ensure we don't stay in `time.sleep` forever.
+
+Replace the body of `stream_session_from_db`:
+
+```python
+STREAM_IDLE_LIMIT = 600  # seconds of no new chunks before giving up
+
+def stream_session_from_db(session_id: str) -> Generator[str, None, None]:
+    last_id = 0
+    last_turn_id = None
+    last_heartbeat = time.time()
+    last_chunk_time = time.time()
+
+    while True:
+        chunks = list(
+            AgentSessionLog.objects.filter(session_id=session_id, id__gt=last_id)
+            .order_by("id")
+            .values("id", "stream", "data", "turn_id", "turn__turn_number")[:100]
+        )
+
+        if chunks:
+            last_chunk_time = time.time()
+
+        for chunk in chunks:
+            last_id = chunk["id"]
+            turn_id = chunk["turn_id"]
+            if turn_id is not None and turn_id != last_turn_id:
+                yield _format("turn_start", chunk["id"], {"turn": chunk["turn__turn_number"]})
+                last_turn_id = turn_id
+            yield _format("output", chunk["id"], {
+                "stream": chunk["stream"],
+                "data": chunk["data"],
+                "turn": chunk["turn__turn_number"],
+            })
+
+        session = AgentSession.objects.get(pk=session_id)
+        if session.status in ("completed", "failed", "terminated") and not chunks:
+            if session.status == "terminated":
+                yield _format("terminated", last_id, {"message": "Session terminated"})
+            elif session.status == "failed" and session.exit_code is None:
+                yield _format("error", last_id, {"message": "Session failed"})
+            else:
+                yield _format("exit", last_id, {"code": session.exit_code})
+            break
+
+        if time.time() - last_chunk_time > STREAM_IDLE_LIMIT:
+            yield _format("stale", last_id, {
+                "message": f"No output for {STREAM_IDLE_LIMIT}s"
+            })
+            break
+
+        now = time.time()
+        if now - last_heartbeat >= 15:
+            last_heartbeat = now
+            yield ""
+
+        time.sleep(0.5)
+
+
+def _format(event_type: str, log_id: int, payload: dict) -> str:
+    return json.dumps({"type": event_type, "id": log_id, **payload})
+```
+
+Note: we embed the log ID inside the JSON payload as `"id": <int>` in
+addition to the SSE `id:` field (emitted by the view wrapper). This makes
+parsing robust whether the client uses `EventSource` (reads SSE `id:`) or
+parses `data:` JSON lines.
+
+The signature of the generator also needs a new `since` parameter —
+see change #5.
+
+#### 5. `Last-Event-ID` + `?since=<id>` parsing
+
+**File**: `src/agent_on_demand/views/sessions.py:298-320`
+
+Modify `stream_session`:
+
+```python
+@require_GET
+@require_api_key
+def stream_session(request, session_id):
+    try:
+        session = AgentSession.objects.get(pk=session_id, user=request.user)
+    except (AgentSession.DoesNotExist, ValueError):
+        return JsonResponse({"detail": "Session not found"}, status=404)
+
+    raw = request.META.get("HTTP_LAST_EVENT_ID") or request.GET.get("since", "0")
+    try:
+        since = max(0, int(raw))
+    except ValueError:
+        return JsonResponse({"detail": "since must be an integer"}, status=400)
+
+    def event_generator():
+        yield f"data: {json.dumps({'type': 'start', 'runtime': session.runtime, 'session_id': str(session.id)})}\n\n"
+
+        for event in stream_session_from_db(str(session.id), since=since):
+            if event == "":
+                yield ": heartbeat\n\n"
+            else:
+                payload = json.loads(event)
+                log_id = payload.get("id")
+                if log_id:
+                    yield f"id: {log_id}\n"
+                yield f"data: {event}\n\n"
+
+    response = StreamingHttpResponse(event_generator(), content_type="text/event-stream")
+    response["Cache-Control"] = "no-cache"
+    response["X-Accel-Buffering"] = "no"
+    return response
+```
+
+Validation is lenient: any int ≥ 0 is accepted. If the referenced log
+row was deleted by retention (PR 3), the query silently starts from the
+next surviving row (already-correct behavior because the query is
+`id__gt=since`, not an equality match).
+
+And update `stream_session_from_db` signature:
+
+```python
+def stream_session_from_db(
+    session_id: str, since: int = 0
+) -> Generator[str, None, None]:
+    last_id = since
+    ...
+```
+
+#### 6. Documentation updates
+
+**File**: `site/docs/api/streaming.md`
+
+- Add `turn_start` row to the event-types table.
+- Add "Resuming a stream" section covering `Last-Event-ID` header and
+  `?since=<id>` query param, with a note that stale cursors silently
+  resume from the next surviving event.
+- Update the example stream to show `id:` lines.
+- Update the Python client example to track and pass `last_event_id`.
+
+**File**: `docs/openapi.yaml:347-360`
+
+Add `since` query parameter and update the description to list
+`turn_start` in the event enumeration.
+
+**File**: `.claude/skills/agent-on-demand-api.md:177-188`
+
+Add `turn_start` to the event list.
+
+#### 7. Tests
+
+**New file**: `tests/test_stream.py`
+
+Follows patterns from `test_api.py:329` (consume via
+`b"".join(resp.streaming_content).decode()`).
+
+- `test_stream_replays_from_since_cursor`: seed 10 log rows, call with
+  `since=5`, assert only 5 events emitted and first `id:` is 6.
+- `test_stream_rejects_non_integer_since`: 400.
+- `test_stream_lenient_on_stale_cursor`: seed logs 100-200, call with
+  `since=50` (below range), assert all 100 events appear (no 400, no
+  replay-from-zero).
+- `test_stream_emits_id_field`: assert wire format includes `id: N\n`
+  before `data:` for output events.
+- `test_stream_emits_turn_start`: assert `turn_start` event emitted on
+  turn boundary with correct `id:`.
+- `test_stream_idle_timeout`: patch `time.time` + `time.sleep`, simulate
+  a `running` session with no new chunks → `stale` terminal event after
+  10 min.
+
+**File**: `tests/test_tasks.py` (add cases)
+
+- `test_bulk_create_retries_on_transient_failure`: mock `bulk_create`
+  to raise twice then succeed; assert 3 calls, all chunks written, no
+  posthog exhaustion event.
+- `test_bulk_create_exhausts_retries_and_raises`: mock `bulk_create` to
+  always raise; assert 3 calls, turn marks `failed`, posthog
+  `session.log_write_retry_exhausted` emitted.
+- `test_queue_full_drops_chunk_and_counts`: monkeypatch `output_q` to
+  `Queue(maxsize=1)`, force put-timeout, assert `drop_count > 0` and
+  posthog event emitted.
+- `test_cmd_thread_leak_detected`: stub `cmd_thread.is_alive` to return
+  True; assert posthog `session.cmd_thread_leaked` emitted.
+
+**File**: `tests/e2e/test_sessions.py` (add case, mark `@slow`)
+
+- `test_sse_reconnect_via_last_event_id`: start session, consume stream
+  partway, capture last `id:`, reconnect with `Last-Event-ID` header,
+  assert no duplicate events.
+
+### Success Criteria
+
+#### Automated:
+- [ ] `make lint` passes.
+- [ ] `make test` passes (unit + integration).
+- [ ] `make test-e2e-fast` passes.
+- [ ] `make test-e2e` passes (includes `@slow` reconnect test).
+
+#### Manual:
+- [ ] `curl -N $BASE/sessions/$SID/stream` against an active session,
+      then Ctrl+C — worker returns within 30 s (verify via Render logs /
+      honeycomb span end-time).
+- [ ] `curl -N "$BASE/sessions/$SID/stream?since=50"` resumes mid-stream,
+      no events with `id ≤ 50` appear.
+- [ ] Provoke a queue-full scenario by slowing DB (e.g., `pg_sleep` in a
+      long transaction on the web connection path) and driving a noisy
+      agent → posthog `session.output_chunks_dropped` event appears,
+      agent does not hang beyond 5 s per write.
+
+### Rollback
+
+Revert commit + push. Clients using `Last-Event-ID` will see full replay
+on their next reconnect (no data loss). No DB state changes.
+
+---
+
+## PR 3: Operational hygiene (retention + watchdog)
+
+### Overview
+Two new periodic tasks registered on the existing Procrastinate worker
+plus a migration to make the watchdog query fast.
+
+### Dependencies
+Requires PR 1 deployed (so the worker process is running and can pick up
+periodic task registrations).
+
+### Changes Required
+
+#### 1. New module: `session_service/maintenance.py`
+
+**File**: `src/agent_on_demand/session_service/maintenance.py` (new)
+
+```python
+"""Periodic maintenance tasks.
+
+Two periodic tasks run on the existing Procrastinate worker:
+
+- `purge_old_session_logs` (daily at 02:00 UTC): deletes AgentSession
+  rows in terminal states older than 30 days, which cascades to their
+  AgentSessionLog rows.
+- `mark_stuck_sessions_failed` (every 5 minutes): flips sessions stuck
+  in `running` state for >15 minutes to `failed`. The watchdog uses
+  AgentSession.updated_at, not AgentSessionLog.created_at, because the
+  former is auto_now-updated on every state transition and is
+  index-friendly (see migration 0013).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from django.db import close_old_connections
+from django.utils import timezone
+from procrastinate.contrib.django import app as procrastinate_app
+
+from agent_on_demand.models import AgentSession
+
+logger = logging.getLogger(__name__)
+
+RETENTION_DAYS = 30
+WATCHDOG_IDLE_MINUTES = 15
+PURGE_BATCH_SIZE = 500
+TERMINAL_STATUSES = ("completed", "failed", "terminated")
+
+
+@procrastinate_app.task(
+    queue="maintenance", name="purge_old_session_logs", pass_context=False
+)
+@procrastinate_app.periodic(cron="0 2 * * *", periodic_id="purge_old_session_logs")
+def purge_old_session_logs(timestamp: int) -> None:
+    close_old_connections()
+    try:
+        cutoff = timezone.now() - timedelta(days=RETENTION_DAYS)
+        total = 0
+        while True:
+            ids = list(
+                AgentSession.objects.filter(
+                    status__in=TERMINAL_STATUSES,
+                    updated_at__lt=cutoff,
+                ).values_list("id", flat=True)[:PURGE_BATCH_SIZE]
+            )
+            if not ids:
+                break
+            deleted, _ = AgentSession.objects.filter(id__in=ids).delete()
+            total += deleted
+        logger.info("purge_old_session_logs: deleted %d sessions", total)
+    finally:
+        close_old_connections()
+
+
+@procrastinate_app.task(
+    queue="maintenance", name="mark_stuck_sessions_failed", pass_context=False
+)
+@procrastinate_app.periodic(cron="*/5 * * * *", periodic_id="mark_stuck_sessions_failed")
+def mark_stuck_sessions_failed(timestamp: int) -> None:
+    close_old_connections()
+    try:
+        cutoff = timezone.now() - timedelta(minutes=WATCHDOG_IDLE_MINUTES)
+        updated = AgentSession.objects.filter(
+            status="running", updated_at__lt=cutoff
+        ).update(status="failed", updated_at=timezone.now())
+        if updated:
+            logger.warning(
+                "mark_stuck_sessions_failed: flipped %d sessions to failed",
+                updated,
+            )
+    finally:
+        close_old_connections()
+```
+
+The `timestamp: int` parameter is Procrastinate's periodic contract —
+keep it as a positional argument even though we don't use it.
+
+#### 2. Register maintenance module
+
+**File**: `src/agent_on_demand/apps.py` (modify)
+
+Ensure the module is imported at app-ready time so Procrastinate's
+periodic scheduler sees the decorators. The existing `tasks.py` is
+already imported through Django's app loading; verify and, if
+`maintenance.py` isn't auto-imported, add:
+
+```python
+from django.apps import AppConfig
+
+
+class AgentOnDemandConfig(AppConfig):
+    name = "agent_on_demand"
+    label = "fairy"
+
+    def ready(self) -> None:
+        from agent_on_demand.session_service import (  # noqa: F401
+            maintenance,
+            tasks,
+        )
+```
+
+#### 3. Migration 0013 — `(status, updated_at)` index
+
+**File**: `src/agent_on_demand/migrations/0013_add_maintenance_indexes.py` (new)
+
+```python
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("fairy", "0012_add_runtime_session_id")]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="agentsession",
+            index=models.Index(
+                fields=["status", "updated_at"],
+                name="agentsession_status_upd_idx",
+            ),
+        ),
+    ]
+```
+
+Index name is under Postgres's 63-char limit. No concurrent-index
+option needed — `AgentSession` is small relative to logs.
+
+#### 4. Admin bulk-purge action
+
+**File**: `src/agent_on_demand/admin.py` (modify)
+
+Add an admin action on `AgentSessionAdmin` following the existing
+`terminate_sessions` pattern (`admin.py:218-264`):
+
+```python
+@admin.action(description="Purge selected sessions and their logs")
+def purge_sessions(modeladmin, request, queryset):
+    non_terminal = queryset.exclude(status__in=TERMINAL_STATUSES).count()
+    if non_terminal:
+        messages.warning(
+            request,
+            f"Skipped {non_terminal} non-terminal session(s); "
+            "terminate them first.",
+        )
+    eligible = queryset.filter(status__in=TERMINAL_STATUSES)
+    deleted, _ = eligible.delete()
+    messages.success(request, f"Purged {deleted} session(s) and their logs.")
+```
+
+#### 5. Tests
+
+**New file**: `tests/test_maintenance.py`
+
+Follows the pattern in `test_tasks.py` — call task functions directly.
+No `freezegun` — use `.update(updated_at=...)` to backdate rows.
+
+- `test_purge_old_session_logs_deletes_old_terminal_sessions`
+- `test_purge_old_session_logs_skips_recent_sessions`
+- `test_purge_old_session_logs_skips_running_sessions`
+- `test_purge_old_session_logs_cascades_to_logs`
+- `test_purge_old_session_logs_batches_correctly`: seed > `PURGE_BATCH_SIZE` rows
+- `test_mark_stuck_sessions_failed_flips_stuck_running`
+- `test_mark_stuck_sessions_failed_leaves_recent_running_alone`
+- `test_mark_stuck_sessions_failed_leaves_terminal_alone`
+
+Plus a `close_old_connections` spy assertion on each task (matches
+`test_tasks.py:187` pattern).
+
+### Success Criteria
+
+#### Automated:
+- [ ] `make lint` passes.
+- [ ] `make migrate` applies 0013 cleanly; `make test` passes.
+- [ ] New tests in `test_maintenance.py` all pass.
+
+#### Manual:
+- [ ] On deploy, worker log shows periodic tasks registered at startup
+      (Procrastinate logs this).
+- [ ] After 5 min post-deploy, watchdog log line appears (either "flipped
+      0 sessions" or "flipped N").
+- [ ] Postgres `EXPLAIN` of the watchdog query uses the new index:
+      ```sql
+      EXPLAIN SELECT id FROM fairy_agentsession
+      WHERE status='running' AND updated_at < NOW() - INTERVAL '15 min';
+      ```
+      → expects "Index Scan using agentsession_status_upd_idx".
+- [ ] Seed a test session with backdated `updated_at` in staging (or a
+      throwaway local DB) and confirm the watchdog flips it.
+
+### Rollback
+
+Revert commit + push. Migration 0013 is additive (adds an index); a
+rollback can optionally leave the index in place (harmless) or run the
+reverse migration if we want cleanliness. No destructive schema changes.
+
+### Gate
+
+Wait 48 hours after PR 3 deploys before considering the streaming-scale
+initiative complete. Watch:
+- Posthog `session.log_write_retry_exhausted`, `session.output_chunks_dropped`,
+  `session.cmd_thread_leaked` — should be rare/zero.
+- Worker log for first watchdog flip and first nightly purge.
+- Honeycomb span counts for `session.execute_turn` overlapping up to 4.
+
+---
+
+## Testing Strategy
+
+### Unit (per PR):
+- PR 1: no new tests (config change only); verify nothing breaks.
+- PR 2: new `tests/test_stream.py`; extensions to `tests/test_tasks.py`.
+- PR 3: new `tests/test_maintenance.py`.
+
+### Integration:
+- All PRs run against the Django test client + SQLite (per
+  `tests/conftest.py`). Thread-isolation behavior of `close_old_connections`
+  is spied, not integration-tested (SQLite has different connection
+  semantics than Postgres; the `test-researcher` note was explicit about this).
+
+### E2E:
+- PR 2: one new `@slow` e2e test for SSE reconnect via `Last-Event-ID`.
+- PR 1 and PR 3 don't need e2e coverage — PR 1 is infra, PR 3's effects
+  are observable only over time windows.
+
+### Manual:
+- After each PR, run the verification steps listed under "Success
+  Criteria → Manual".
+
+## Performance Considerations
+
+- **PR 1** moves max concurrent SSE streams from 3 → 24. Connection pool
+  grows from ~4 → up to ~29 persistent connections. `standard-1gb`
+  Postgres (97 max_connections) provides headroom.
+- **PR 2** adds at most 3 extra DB round-trips per turn on bulk_create
+  retry (steady-state: zero; failure mode: 3). The 500 ms SSE poll loop
+  is unchanged.
+- **PR 3** adds two periodic tasks:
+  - Retention: daily at 02:00 UTC; batched ORM delete with `PURGE_BATCH_SIZE=500`
+    per batch. Even purging 10k sessions fits in ~20 batches.
+  - Watchdog: every 5 min; single indexed UPDATE — cost is negligible.
+
+## References
+
+- Research: `thoughts/research/2026-04-19-streaming-high-volume-readiness.md`
+- Prior streaming research: `thoughts/research/2026-04-19-threading-in-web-server.md`
+- Prior threading decision: `thoughts/plans/2026-04-19-threading-architecture-decision.md`
+- Procrastinate migration: `thoughts/plans/2026-04-19-procrastinate-worker.md`
+- Admin bulk-action pattern: `src/agent_on_demand/admin.py:218-264`
+- Existing task pattern: `src/agent_on_demand/session_service/tasks.py:104,264`
+- Posthog event pattern: `src/agent_on_demand/session_service/tasks.py:252-261,420-432`
+- Tracer pattern: `src/agent_on_demand/session_service/tasks.py:155-162,305-316`
+- SSE test pattern: `tests/test_api.py:329,580`

--- a/thoughts/research/2026-04-19-streaming-high-volume-readiness.md
+++ b/thoughts/research/2026-04-19-streaming-high-volume-readiness.md
@@ -1,0 +1,206 @@
+---
+date: 2026-04-19T11:10:00-07:00
+researcher: Claude Code (team-research skill)
+git_commit: fc7d41b0641dff82e404647b195be02c761ff4be
+branch: main
+repository: ravi-hq/agent-on-demand
+topic: "Is our streaming implementation up to snuff for high-volume load?"
+tags: [research, team-research, streaming, sse, scale, gunicorn, procrastinate, postgres]
+status: complete
+method: agent-team
+team_size: 5
+tracks: [sse-endpoint, producer-path, database, client-ux, thoughts-history]
+last_updated: 2026-04-19
+last_updated_by: Claude Code
+---
+
+# Research: Is our streaming implementation up to snuff for high-volume load?
+
+**Date**: 2026-04-19
+**Researcher**: Claude Code (team-research)
+**Git Commit**: [`fc7d41b`](https://github.com/ravi-hq/agent-on-demand/commit/fc7d41b0641dff82e404647b195be02c761ff4be)
+**Branch**: `main`
+**Repository**: ravi-hq/agent-on-demand
+**Method**: Agent team (5 specialist researchers)
+
+## Research Question
+
+Is our streaming implementation up to snuff? When we get into a high volume
+situation, is it going to bite us?
+
+## Summary
+
+**Yes, it will bite — and the ceiling is lower than it looks.** The biggest
+single problem is structural: the SSE endpoint pins one sync Gunicorn worker
+per connected client for the entire session duration, and we only run three
+workers. That's a hard **3 concurrent SSE clients** cap before *all* HTTP —
+including `POST /sessions`, `/health`, and any non-streaming endpoint — is
+blocked. This problem was identified and named in prior research
+(`2026-04-19-threading-in-web-server.md`), the specific fix was chosen
+(`--worker-class=gthread --threads=N`), but **the fix never shipped** —
+`render.yaml` still uses sync workers.
+
+Beyond that, three compounding failure modes show up at volume:
+
+1. **Storage runway is short.** `AgentSessionLog` has no retention logic.
+   At ~100 sessions/day × ~1 MB of logs each, the `basic-256mb` Postgres
+   plan fills in ~2 days.
+2. **The producer can stall the agent.** `output_q` is a bounded blocking
+   queue; if the DB writer falls behind, the Sprite SDK's stdout thread
+   blocks, which can time out the running agent.
+3. **Procrastinate worker concurrency is defaulted to 1.** The recently
+   shipped worker process runs turns one at a time unless configured
+   otherwise; multi-tenant load will serialize.
+
+The good news: indexes are correct, there are no obvious auth/isolation
+bugs, and the DB tailing pattern itself is appropriate for our model (we
+own the logs because Sprites can't replay them). The architecture is
+sound; it's under-provisioned and under-configured for volume.
+
+Below, **the top 6 risks** by severity, then full findings by track.
+
+### Top 6 risks (ordered by blast radius)
+
+| # | Risk | Severity | Fix effort | Status |
+|---|------|----------|-----------|--------|
+| 1 | **3-client SSE saturation ceiling** — 3 sync workers × 1 pin per stream ties up the whole web service at 3 concurrent streams | Critical | Low (config change) | Known, unfixed |
+| 2 | **No log retention** — `AgentSessionLog` grows unbounded; 256 MB Postgres fills fast | High | Medium (cleanup job + policy) | Not discussed |
+| 3 | **Producer queue stall can time out the agent** — full `output_q` blocks the SDK stdout thread | High | Medium (switch to `put(block=False)` + drop policy or larger queue) | Not discussed |
+| 4 | **Procrastinate worker runs 1 turn at a time** — no `--concurrency` flag set | High | Low (config change) | Not discussed |
+| 5 | **Slow-client DoS** — a client that stops reading holds a worker indefinitely; `--timeout 700` doesn't fire during `time.sleep(0.5)` between chunks | High | Medium (watchdog + idle kill) | Not discussed |
+| 6 | **Worker crash leaves session `running` forever** — SSE stream never terminates, holding a worker | Medium | Medium (watchdog / heartbeat timeout) | Follow-up noted |
+
+## Research Tracks
+
+### Track 1: SSE endpoint & request lifecycle
+**Researcher**: `sse-researcher`
+**Scope**: `stream.py`, `views/sessions.py::stream_session`, `render.yaml`, `settings.py`
+
+1. **3-worker hard ceiling (structural)** — `render.yaml:21` sets `--workers 3` sync. Each active SSE connection pins one worker for the life of the session (can be minutes to 10 min given `--timeout 700`). At 3 concurrent streams the whole web service is saturated. Severity: **high**. Evidence: `render.yaml:18-25` startCommand.
+2. **Slow-client DoS via timer skew** — `views/sessions.py:317` wraps the generator; Gunicorn's `--timeout 700` watches between requests, but the 500 ms `time.sleep()` cycles in `stream.py:57` repeatedly refresh the liveness signal. A client that stops reading causes the write to TCP to block — the worker stays pinned. Severity: **high**. Evidence: `stream.py:57`.
+3. **DB query rate per client** — 2 queries per 500 ms per client (log tail + `AgentSession.objects.get`), plus a JOIN to `session_turns` via `turn__turn_number` on every poll (`stream.py:24`). At N clients: 4N queries/sec, baseline, regardless of whether any new log rows exist. Severity: **medium**. Evidence: `stream.py:22,24,42`.
+4. **Connection lifecycle during long streams** — `settings.py:73` sets `conn_max_age=600`. The SSE generator never calls `close_old_connections()` in-loop; connection cleanup waits for the request to end, which may never happen for a stuck stream. Severity: **medium**. Evidence: `settings.py:73` + `stream.py:20-57`.
+5. **Heartbeat works through the proxy** — `X-Accel-Buffering: no` is set (`views/sessions.py:319`); 15 s heartbeat is frequent enough to keep Render's edge alive. But heartbeats are SSE comments (`": heartbeat\n\n"`) — invisible to `EventSource.onmessage`, not useful as a client-side liveness signal unless the client explicitly parses them. Severity: **low**. Evidence: `views/sessions.py:312-319`.
+6. **Memory is bounded per loop iteration** — `[:100]` cap on the query means no unbounded accumulation. No memory concern. Severity: **low**. Evidence: `stream.py:22-25`.
+
+### Track 2: Log producer path (worker → DB)
+**Researcher**: `producer-researcher`
+**Scope**: `session_service/tasks.py`, worker config
+
+1. **Bounded blocking queue can stall the agent** — `output_q: queue.Queue(maxsize=4096)` in `tasks.py:325`. `TaggingQueueWriter.write` calls `queue.put(...)` with no timeout/`block=False`. If the DB consumer falls behind (e.g., bulk_create latency spike, transient DB slowness), the SDK's stdout thread blocks, which stalls `sprite.command().run()`. Under sustained high-volume output, this risks tripping the turn `timeout` and marking the session `failed`. Severity: **high**. Evidence: `tasks.py:84-87, 325`.
+2. **Write cadence is tight** — `FLUSH_SIZE=20` plus a 1-second idle flush (`tasks.py:57, 370-373`). A noisy session can trigger 50+ `bulk_create` calls/sec; each is a network round-trip. Severity: **medium**. Evidence: `tasks.py:57, 376-385`.
+3. **Arbitrary byte-fragment chunks** — `TaggingQueueWriter` doesn't line-buffer. The SDK may emit byte fragments (mid-line, mid-UTF8). Each fragment is one `AgentSessionLog` row. Storage amplification scales with fragment count, not byte count. Severity: **medium**. Evidence: `tasks.py:70-87`.
+4. **Daemon thread isolation guarded by convention, not enforcement** — `tasks.py:335-336` has a `NOTE:` comment warning against DB writes inside the inner thread. The thread never touches the DB today, but future edits could silently break the `close_old_connections()` contract. Severity: **low**. Evidence: `tasks.py:335-336`.
+5. **`bulk_create` has no try/except** — a single DB write failure crashes out of `_flush_buffer`, propagates up, loses up to `FLUSH_SIZE` chunks, and fails the turn. Explicit no-retry policy (module docstring). For a transient DB blip, that's a permanent turn failure. Severity: **high**. Evidence: `tasks.py:329-332`.
+6. **`cmd_thread.join(timeout=5.0)` has no `is_alive()` follow-up** — if the command thread is still running after 5 s (e.g., blocked on a full queue), we proceed to the next turn. The daemon thread keeps writing into a queue nobody drains; chunks are lost; cleanup never happens. Severity: **medium**. Evidence: `tasks.py:388`.
+7. **Procrastinate worker runs one task at a time** — `render.yaml:57` uses `uv run python manage.py procrastinate worker` with no `--concurrency` flag. Default is 1. Multi-tenant load will serialize turns in a single FIFO queue. Severity: **high**. Evidence: `render.yaml:56-57`.
+
+### Track 3: Database shape & query cost
+**Researcher**: `db-researcher`
+**Scope**: `models/sessions.py`, migrations, `render.yaml`
+
+1. **Indexes are correct** — `(session_id, id)` composite index in migration 0002 covers the hot SSE query fully (range scan, no heap fallback). `(turn_id, id)` from migration 0011 covers per-turn queries. Severity: **low** (good news). Evidence: `src/agent_on_demand/migrations/0002_agentsession_alter_userruntimekey_runtime_and_more.py`, `models/sessions.py:128`.
+2. **No log retention — unbounded growth** — `AgentSessionLog` has zero purge logic. Only deletion path is CASCADE from `DELETE /sessions/{id}`. At ~100 sessions/day × ~1 MB logs each, the `basic-256mb` plan fills in ~2 days. Severity: **high**. Evidence: no management commands, cron jobs, or admin actions; confirmed by exhaustive grep.
+3. **Per-row storage amplification ~3-4×** — ~70 bytes of fixed overhead per row (PK, FK, UUID, timestamp, heap tuple header) + 2 B-tree index entries. For 50-byte chunks that's roughly 3-4× raw byte storage. Severity: **medium**. Evidence: `models/sessions.py:112-134`.
+4. **No lock contention** — append-only table, INSERT + SELECT don't conflict in Postgres. Autovacuum has little to do. Severity: **low**. Evidence: `tasks.py:331`, `stream.py:22`.
+5. **AgentSession.status churn is negligible** — 2-4 writes per turn; `update_fields=` limits dirty footprint; single heap page served from buffer cache. Severity: **low**. Evidence: `tasks.py:359-362`, `stream.py:42`.
+6. **Connection pool math is tight** — `conn_max_age=600` persistent connections per worker; 3 web workers + 1 worker process. `basic-256mb` Postgres allows ~25 max connections. Each SSE stream holds a connection for the full session duration. Adding workers to fix #1 directly pressures the connection limit. Severity: **medium**. Evidence: `settings.py:73`, `render.yaml:21`, `stream.py:20-57`.
+7. **No archive/purge story** — no management commands, no scheduled tasks, no admin bulk-delete for logs. `DELETE /sessions/{id}` is the only user-facing deletion, and it only works on non-running sessions. Severity: **high**. Evidence: exhaustive grep for delete/purge/truncate/retention.
+
+### Track 4: Client UX & reconnect semantics
+**Researcher**: `ux-researcher`
+**Scope**: `site/docs/api/streaming.md`, `docs/openapi.yaml`, `session_detail` UI, e2e tests
+
+1. **`turn_start` event undocumented** — server emits it (`stream.py:31`), docs only list: `start`, `output`, `exit`, `error`, `terminated`. Doc-following clients silently drop it. Severity: **medium**.
+2. **No reconnect cursor** — every reconnect replays from `id=0` (`stream.py:16`). No `Last-Event-ID`, no `?since=`, no SSE `id:` field. Docs literally tell clients "count events and skip duplicates" (`streaming.md:106`). O(N) replay cost per reconnect; bad at volume. Severity: **medium**.
+3. **Deterministic 500 ms latency on terminal event** — `stream_session_from_db` checks session status *after* draining chunks (`stream.py:42`). If the final chunk writes between check and exit, the terminal event waits for the next poll. Not a lost-event bug, but a predictable 500 ms tail latency. Severity: **low**.
+4. **Heartbeat is documented but not framed as a liveness signal** — `streaming.md:37-39` mentions heartbeats; doesn't tell clients to treat >15 s silence as a health warning. Severity: **low**.
+5. **Browser `EventSource` can't authenticate** — `@require_api_key` wants a Bearer header; `EventSource` can't send custom headers. Clients must use `fetch` + `ReadableStream`. Not documented. The in-repo UI sidesteps this entirely by rendering logs server-side (`ui/views.py:179-190`, `session_detail.html`) — so there's no in-repo reference SSE client. Severity: **medium**.
+6. **Tenant isolation is fine** — `user=request.user` filter in `views/sessions.py:304`; `@require_GET` + `@require_api_key`; no SSRF/CSRF surface. Severity: **low** (no issue).
+7. **Failure paths are ungraceful** — DB drop mid-stream, deleted FK, or crashed worker all cause the stream to either hang (worker crash → session stuck `running` → poll forever) or abrupt-close without a terminal SSE event. No watchdog, no stale-session cleanup. Severity: **high**.
+
+### Track 5: Prior context from `thoughts/`
+**Researcher**: `history-researcher`
+**Scope**: all `thoughts/` files relevant to streaming / threading / worker
+
+**Decisions already made — don't re-litigate:**
+- **DB tailing is the intentional streaming architecture** (`2026-04-16-session-based-execution.md`). Sprites can't replay server-side, so we own log storage. Don't propose pub/sub or WebSockets as a replacement.
+- **500 ms poll interval, 15 s heartbeat, `FLUSH_SIZE=20` batching** — all deliberate tradeoffs.
+- **`failed` is now terminal** (PR #48, `2026-04-19-threading-bug-fixes.md`). Don't propose making it resumable.
+- **The inner daemon thread in the worker task stays** — explicitly deferred optimization per the procrastinate-worker plan. Don't flag its existence as a new finding.
+- **ASGI was explicitly rejected** — "the real problems aren't caused by sync-ness" (`2026-04-19-threading-in-web-server.md`, `2026-04-19-threading-architecture-decision.md`).
+- **Celery/RQ/Dramatiq were explicitly rejected** — Redis adds cost for no advantage once Postgres is provisioned.
+
+**Known open items from prior work:**
+- **SSE saturation fix (`--worker-class=gthread --threads=N`) was identified but never shipped.** Confirmed against current `render.yaml` — still `--workers 3` sync. **This is the single highest-leverage open item.**
+- **Procrastinate concurrency tuning** was flagged as unknown.
+- **Retry policy** for turn failures was deferred.
+- **`/health/worker` endpoint** was proposed as a follow-up, not yet shipped.
+- **Log retention policy** — no cleanup mechanism exists.
+- **Muddy Zone 3** — `write_prompt` orphans turn rows; still open.
+
+**Gaps prior work didn't cover:**
+- No scale benchmarks or capacity targets. The "3 concurrent SSE clients" number is structural math, not measured.
+- No analysis of DB load at scale with concurrent sessions writing to `AgentSessionLog`.
+- No analysis of the cost of polling × multiple viewers per session.
+
+## Cross-Track Discoveries
+
+- **#1 (SSE saturation) compounds with #2 (producer stall) and #4 (worker concurrency=1).** A single noisy session can stall the producer, whose blocked queue can time out the turn. Meanwhile the web side can only serve 3 stream viewers at once. A handful of customers monitoring their own sessions exhausts the service before any real "volume" is reached.
+- **Fixing #1 requires watching #6 (connection pool).** Switching to gthread workers with e.g. `--threads 16` + 3 workers = up to 48 concurrent SSE clients, each holding a DB connection. `basic-256mb` Postgres caps ~25 connections. The fix for saturation directly pressures the DB connection ceiling.
+- **Reconnect cost (Track 4 #2) × DB write rate (Track 2 #2) = scan explosion.** Every reconnect replays the full session from id=0; a long session with a flaky client generates expensive full-range scans on every resume. Indexes cover it (Track 3 #1), but the work still has to happen.
+- **No terminal event on worker crash (Track 4 #7) = permanent worker pin (Track 1 #2).** A crashed worker leaves a session stuck `running`; the SSE stream polls forever; the Gunicorn worker serving that stream never returns. This is a self-inflicted slow-burn outage mechanism.
+
+## Code References
+
+| File | Tracks | Key findings | Link |
+|------|--------|--------------|------|
+| `render.yaml:18-25` | 1, 2, 3 | 3 sync workers, no gthread, no Procrastinate `--concurrency` | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/fc7d41b/render.yaml#L18-L25) |
+| `render.yaml:56-57` | 2 | Procrastinate worker start command, no concurrency flag | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/fc7d41b/render.yaml#L56-L57) |
+| `src/agent_on_demand/stream.py:20-57` | 1, 3, 4 | Poll loop, query shape, termination condition, heartbeat | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/fc7d41b/src/agent_on_demand/stream.py#L20-L57) |
+| `src/agent_on_demand/views/sessions.py:296-320` | 1, 4 | SSE view, auth, headers | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/fc7d41b/src/agent_on_demand/views/sessions.py#L296-L320) |
+| `src/agent_on_demand/session_service/tasks.py:321-388` | 2 | `_execute_turn_body`, queue bound, flush cadence, thread join | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/fc7d41b/src/agent_on_demand/session_service/tasks.py#L321-L388) |
+| `src/agent_on_demand/session_service/tasks.py:70-87` | 2 | `TaggingQueueWriter.write` — blocking put, no backpressure | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/fc7d41b/src/agent_on_demand/session_service/tasks.py#L70-L87) |
+| `src/agent_on_demand/models/sessions.py:112-134` | 3 | `AgentSessionLog` schema + indexes | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/fc7d41b/src/agent_on_demand/models/sessions.py#L112-L134) |
+| `src/config/settings.py:73` | 1, 3 | `conn_max_age=600` | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/fc7d41b/src/config/settings.py#L73) |
+| `site/docs/api/streaming.md` | 4 | Public contract — missing `turn_start`, no reconnect cursor | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/fc7d41b/site/docs/api/streaming.md) |
+
+## Architecture Insights
+
+- **The pattern is correct; the provisioning isn't.** DB-tailed SSE is a good fit for Fairy's model (Sprites can't replay, and multiple viewers of the same session are supported naturally). The issues are deployment config (workers, concurrency, retention) not architectural.
+- **The worst problems are all "we haven't configured this yet" problems**, not "we built it wrong." That's a positive signal — the fixes are mostly small and reversible.
+- **Every producer/consumer boundary has a shock absorber except one.** `bulk_create` batches writes, `time.sleep(0.5)` paces reads, 100-row `LIMIT` caps memory — but `output_q.put()` is unconditionally blocking. That's the one place producer-side backpressure leaks back into the agent, which is where volume pain will first be felt.
+- **The retry policy (none) is deliberate.** Don't introduce retries for turn execution; the design expects failures to be surfaced to the caller. But that raises the bar for `bulk_create` to not be the thing that fails the turn on a DB blip.
+
+## Historical Context
+
+- `thoughts/research/2026-04-19-threading-in-web-server.md` — prior team research that identified SSE saturation and the gthread fix. Fix did not ship.
+- `thoughts/plans/2026-04-19-procrastinate-worker.md` — recently landed; moved execution out of the web process. Left SSE endpoint unchanged and left the inner daemon thread in place.
+- `thoughts/plans/2026-04-19-threading-architecture-decision.md` — rejected ASGI and Redis-backed queues.
+- `thoughts/research/2026-04-16-session-based-execution.md` — the original decision to own log storage because Sprites can't replay.
+
+## Related Research
+
+- `thoughts/research/2026-04-19-threading-in-web-server.md`
+- `thoughts/research/2026-04-18-session-backend-abstraction.md`
+- `thoughts/research/2026-04-18-sprites-script-setup.md`
+
+## Open Questions
+
+1. **What's our actual target volume?** Sessions/day, concurrent viewers per session, concurrent sessions running. No capacity target exists in any doc.
+2. **Per-session log size distribution?** We assume ~1 MB average. Is that real? (Informs retention math.)
+3. **Is `basic-256mb` Postgres the right plan going forward?** Any fix for #1 (SSE saturation) directly pressures the connection limit.
+4. **Retention policy**: delete logs after N days? Keep metadata but purge `data` field? Move to object storage?
+5. **Should the web process still serve SSE at all?** Long-lived connections on a request/response server will always have friction. Consider a dedicated stream process later.
+
+## Recommended Next Steps (not part of this research, but implied)
+
+In priority order:
+
+1. **Ship `--worker-class=gthread --threads=N`** (config-only; already specified in prior research).
+2. **Add Procrastinate `--concurrency=N` to the worker command.**
+3. **Add a retention/cleanup job for `AgentSessionLog`** + bump Postgres plan.
+4. **Swap `queue.put()` for `put(timeout=X)` with a drop-or-error policy** in `TaggingQueueWriter`.
+5. **Wrap `bulk_create` in a try/except with bounded retry** (not turn-retry — row-retry).
+6. **Add watchdog for stuck-`running` sessions** → terminal event + mark failed.
+7. **Add reconnect cursor (`Last-Event-ID` support)** + document `turn_start`.


### PR DESCRIPTION
## Summary

Follow-up to #60 (config/capacity). Makes the streaming stack resilient to transient DB failures, slow consumers, leaked threads, and reconnects — plus documents `turn_start` and adds a `Last-Event-ID` resume cursor.

**Depends on #60.** Do not merge until #60 has soaked in prod for 24h.

### Producer robustness (`session_service/tasks.py`)
- `bulk_create` retries (3 attempts, 0.1/0.3/1.0s backoff) with `close_old_connections` between tries; posthog event on exhaustion.
- `TaggingQueueWriter.put(timeout=5.0)` with drop counter + posthog event — a slow DB can no longer stall the SDK's stdout thread indefinitely.
- `cmd_thread.is_alive()` after `join(timeout=5.0)` emits a posthog event if the daemon thread leaks.

### Consumer robustness (`stream.py`, `views/sessions.py`)
- 10-minute idle timeout: running sessions that emit no chunks for 600s emit a `stale` terminal event and close the stream. Prevents slow/stalled clients from pinning a worker.
- Every non-`start` event now carries `"id": <log_id>` in the JSON payload AND an SSE `id:` line — enables standard EventSource `Last-Event-ID` resume.
- View accepts `Last-Event-ID` header or `?since=<id>` query param (header wins). Validation is lenient: integers ≥ 0 accepted; non-integer returns 400; stale cursors (e.g., logs deleted by retention in PR 3) silently resume from the next surviving row.

### Docs
- `site/docs/api/streaming.md`, `docs/openapi.yaml`, `.claude/skills/agent-on-demand-api.md` all updated to cover `turn_start`, `stale`, the `id` payload field, and the resume mechanism.

### Tests
- New `tests/test_stream.py` (10 tests) covering cursor behavior, stale-cursor leniency, 400 on non-int, idle timeout, header vs query param precedence.
- `tests/test_tasks.py` +5 tests for retry, drop counting, drop posthog, and thread-leak detection. New autouse fixture mocks `close_old_connections` so retry tests don't kill the pytest-django test DB connection.
- `tests/test_api.py` updated for new event shape.
- `tests/e2e/test_sessions.py` adds one `@slow` reconnect test.

## Motivation

Research: `thoughts/research/2026-04-19-streaming-high-volume-readiness.md`
Plan: `thoughts/plans/2026-04-19-streaming-high-volume-readiness.md`

## Test plan

- [x] `uv run ruff check .` clean
- [x] New streaming + task tests pass: `uv run pytest tests/test_stream.py tests/test_tasks.py -v` → 28/28 pass
- [ ] `curl -N $BASE/sessions/$SID/stream` against an active session, then Ctrl+C → worker returns within ~30s
- [ ] `curl -N "$BASE/sessions/$SID/stream?since=50"` resumes, no events with id ≤ 50
- [ ] Running session that emits no chunks for 10 min → SSE closes with `stale` event (manual or stage-induced)

## Known caveats

- **Pre-existing format issue**: `ruff format --check` flags `tests/test_observability.py` on main. Not touched here to keep PR scope tight. Fix in a drive-by.
- **Local pytest without Postgres**: 5 tests in `test_api.py` fail locally with `OperationalError: the connection is closed`. Verified these fail identically on main (pre-existing env issue, not a regression).

## Follow-ups

PR 3 (operational hygiene): `AgentSessionLog` retention job + stuck-session watchdog + migration 0013. Ships after this one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)