### PR TITLE
Session log retention + stuck-session watchdog

### DIFF
--- a/src/agent_on_demand/admin.py
+++ b/src/agent_on_demand/admin.py
@@ -210,7 +210,7 @@ class AgentSessionAdmin(admin.ModelAdmin):
         "updated_at",
     )
     inlines = [AgentSessionLogInline]
-    actions = ["terminate_sessions"]
+    actions = ["terminate_sessions", "purge_sessions"]
 
     def has_add_permission(self, request):
         return False
@@ -261,6 +261,18 @@ class AgentSessionAdmin(admin.ModelAdmin):
             messages.warning(request, msg)
         else:
             messages.success(request, msg)
+
+    @admin.action(description="Purge selected sessions and their logs (terminal only)")
+    def purge_sessions(self, request, queryset):
+        terminal = ("completed", "failed", "terminated")
+        skipped = queryset.exclude(status__in=terminal).count()
+        if skipped:
+            messages.warning(
+                request,
+                f"Skipped {skipped} non-terminal session(s); terminate them first.",
+            )
+        deleted, _ = queryset.filter(status__in=terminal).delete()
+        messages.success(request, f"Purged {deleted} session(s) and their logs.")
 
 
 @admin.register(AgentSessionLog)

--- a/src/agent_on_demand/apps.py
+++ b/src/agent_on_demand/apps.py
@@ -14,6 +14,7 @@ class AgentOnDemandConfig(AppConfig):
 
     def ready(self):
         import agent_on_demand.signals  # noqa: F401 — register signal handlers
+        from agent_on_demand.session_service import maintenance  # noqa: F401 — register periodic tasks
 
         from agent_on_demand.observability import init_otel
 

--- a/src/agent_on_demand/migrations/0013_add_maintenance_indexes.py
+++ b/src/agent_on_demand/migrations/0013_add_maintenance_indexes.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("fairy", "0012_add_runtime_session_id"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="agentsession",
+            index=models.Index(
+                fields=["status", "updated_at"],
+                name="agentsession_status_upd_idx",
+            ),
+        ),
+    ]

--- a/src/agent_on_demand/models/sessions.py
+++ b/src/agent_on_demand/models/sessions.py
@@ -40,6 +40,9 @@ class AgentSession(models.Model):
 
     class Meta:
         db_table = "agent_sessions"
+        indexes = [
+            models.Index(fields=["status", "updated_at"], name="agentsession_status_upd_idx"),
+        ]
 
     def __str__(self):
         return f"{self.runtime} — {self.status} ({self.id})"

--- a/src/agent_on_demand/session_service/maintenance.py
+++ b/src/agent_on_demand/session_service/maintenance.py
@@ -1,0 +1,71 @@
+"""Periodic maintenance tasks.
+
+Two tasks run on the existing Procrastinate worker:
+
+- `purge_old_session_logs` (daily at 02:00 UTC): deletes AgentSession rows in
+  terminal states older than 30 days, which cascades to their AgentSessionLog
+  rows.
+- `mark_stuck_sessions_failed` (every 5 minutes): flips sessions stuck in
+  `running` for >15 minutes to `failed`. Uses AgentSession.updated_at
+  (auto_now on every state transition) rather than AgentSessionLog.created_at
+  because only the former is index-friendly at this scale (see migration 0013).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from django.db import close_old_connections
+from django.utils import timezone
+from procrastinate.contrib.django import app as procrastinate_app
+
+from agent_on_demand.models import AgentSession
+
+logger = logging.getLogger(__name__)
+
+RETENTION_DAYS = 30
+WATCHDOG_IDLE_MINUTES = 15
+PURGE_BATCH_SIZE = 500
+TERMINAL_STATUSES = ("completed", "failed", "terminated")
+
+
+@procrastinate_app.periodic(cron="0 2 * * *", periodic_id="purge_old_session_logs")
+@procrastinate_app.task(queue="maintenance", name="purge_old_session_logs", pass_context=False)
+def purge_old_session_logs(timestamp: int) -> None:
+    close_old_connections()
+    try:
+        cutoff = timezone.now() - timedelta(days=RETENTION_DAYS)
+        total = 0
+        while True:
+            ids = list(
+                AgentSession.objects.filter(
+                    status__in=TERMINAL_STATUSES,
+                    updated_at__lt=cutoff,
+                ).values_list("id", flat=True)[:PURGE_BATCH_SIZE]
+            )
+            if not ids:
+                break
+            deleted, _ = AgentSession.objects.filter(id__in=ids).delete()
+            total += deleted
+        logger.info("purge_old_session_logs: deleted %d sessions", total)
+    finally:
+        close_old_connections()
+
+
+@procrastinate_app.periodic(cron="*/5 * * * *", periodic_id="mark_stuck_sessions_failed")
+@procrastinate_app.task(queue="maintenance", name="mark_stuck_sessions_failed", pass_context=False)
+def mark_stuck_sessions_failed(timestamp: int) -> None:
+    close_old_connections()
+    try:
+        cutoff = timezone.now() - timedelta(minutes=WATCHDOG_IDLE_MINUTES)
+        updated = AgentSession.objects.filter(status="running", updated_at__lt=cutoff).update(
+            status="failed", updated_at=timezone.now()
+        )
+        if updated:
+            logger.warning(
+                "mark_stuck_sessions_failed: flipped %d session(s) to failed",
+                updated,
+            )
+    finally:
+        close_old_connections()

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,0 +1,146 @@
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth.models import User
+from django.utils import timezone
+
+from agent_on_demand.models import AgentSession, AgentSessionLog
+from agent_on_demand.session_service.maintenance import (
+    mark_stuck_sessions_failed,
+    purge_old_session_logs,
+)
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="mt", password="pw")
+
+
+def _backdate(session: AgentSession, *, hours=0, days=0, minutes=0) -> None:
+    ts = timezone.now() - timedelta(hours=hours, days=days, minutes=minutes)
+    AgentSession.objects.filter(pk=session.pk).update(updated_at=ts)
+
+
+# --- purge_old_session_logs ---
+
+
+@pytest.mark.django_db
+def test_purge_deletes_old_terminal_sessions(user, mocker):
+    mocker.patch("agent_on_demand.session_service.maintenance.close_old_connections")
+    old = AgentSession.objects.create(user=user, runtime="claude", prompt="", status="completed")
+    _backdate(old, days=31)
+
+    purge_old_session_logs(0)
+
+    assert not AgentSession.objects.filter(pk=old.pk).exists()
+
+
+@pytest.mark.django_db
+def test_purge_skips_recent_terminal_sessions(user, mocker):
+    mocker.patch("agent_on_demand.session_service.maintenance.close_old_connections")
+    recent = AgentSession.objects.create(user=user, runtime="claude", prompt="", status="completed")
+    _backdate(recent, days=5)
+
+    purge_old_session_logs(0)
+
+    assert AgentSession.objects.filter(pk=recent.pk).exists()
+
+
+@pytest.mark.django_db
+def test_purge_skips_running_sessions(user, mocker):
+    mocker.patch("agent_on_demand.session_service.maintenance.close_old_connections")
+    old_running = AgentSession.objects.create(
+        user=user, runtime="claude", prompt="", status="running"
+    )
+    _backdate(old_running, days=31)
+
+    purge_old_session_logs(0)
+
+    assert AgentSession.objects.filter(pk=old_running.pk).exists()
+
+
+@pytest.mark.django_db
+def test_purge_cascades_to_logs(user, mocker):
+    mocker.patch("agent_on_demand.session_service.maintenance.close_old_connections")
+    old = AgentSession.objects.create(user=user, runtime="claude", prompt="", status="completed")
+    AgentSessionLog.objects.create(session=old, stream="stdout", data="hello\n")
+    AgentSessionLog.objects.create(session=old, stream="stdout", data="world\n")
+    _backdate(old, days=31)
+
+    purge_old_session_logs(0)
+
+    assert AgentSessionLog.objects.filter(session_id=old.pk).count() == 0
+
+
+@pytest.mark.django_db
+def test_purge_batches_correctly(user, mocker):
+    mocker.patch("agent_on_demand.session_service.maintenance.close_old_connections")
+    mocker.patch("agent_on_demand.session_service.maintenance.PURGE_BATCH_SIZE", 3)
+    for _ in range(7):
+        s = AgentSession.objects.create(
+            user=user, runtime="claude", prompt="", status="completed"
+        )
+        _backdate(s, days=31)
+
+    assert AgentSession.objects.count() == 7
+    purge_old_session_logs(0)
+    assert AgentSession.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_purge_closes_db_connections(user, mocker):
+    spy = mocker.patch("agent_on_demand.session_service.maintenance.close_old_connections")
+
+    purge_old_session_logs(0)
+
+    assert spy.call_count == 2  # entry + finally
+
+
+# --- mark_stuck_sessions_failed ---
+
+
+@pytest.mark.django_db
+def test_watchdog_flips_stuck_running(user, mocker):
+    mocker.patch("agent_on_demand.session_service.maintenance.close_old_connections")
+    stuck = AgentSession.objects.create(user=user, runtime="claude", prompt="", status="running")
+    _backdate(stuck, minutes=20)
+
+    mark_stuck_sessions_failed(0)
+
+    stuck.refresh_from_db()
+    assert stuck.status == "failed"
+
+
+@pytest.mark.django_db
+def test_watchdog_leaves_recent_running_alone(user, mocker):
+    mocker.patch("agent_on_demand.session_service.maintenance.close_old_connections")
+    fresh = AgentSession.objects.create(user=user, runtime="claude", prompt="", status="running")
+    _backdate(fresh, minutes=5)
+
+    mark_stuck_sessions_failed(0)
+
+    fresh.refresh_from_db()
+    assert fresh.status == "running"
+
+
+@pytest.mark.django_db
+def test_watchdog_leaves_terminal_sessions_alone(user, mocker):
+    mocker.patch("agent_on_demand.session_service.maintenance.close_old_connections")
+    completed = AgentSession.objects.create(
+        user=user, runtime="claude", prompt="", status="completed"
+    )
+    _backdate(completed, minutes=20)
+
+    mark_stuck_sessions_failed(0)
+
+    completed.refresh_from_db()
+    assert completed.status == "completed"
+
+
+@pytest.mark.django_db
+def test_watchdog_closes_db_connections(user, mocker):
+    spy = mocker.patch("agent_on_demand.session_service.maintenance.close_old_connections")
+
+    mark_stuck_sessions_failed(0)
+
+    assert spy.call_count == 2


### PR DESCRIPTION
## Summary

Third and final PR in the streaming scalability series. Adds the operational hygiene missing today.

**Does not depend on #61** — touches disjoint files and can ship in parallel. **Does depend on #60** for the capacity headroom, though the tasks themselves would run fine on the current plan.

### New periodic tasks (`session_service/maintenance.py`)
- `purge_old_session_logs` — daily at 02:00 UTC. Batched ORM delete of `AgentSession` rows in terminal states (`completed`/`failed`/`terminated`) older than 30 days. Cascades to their `AgentSessionLog` rows.
- `mark_stuck_sessions_failed` — every 5 minutes. Flips sessions stuck in `running` for >15 minutes to `failed`. Uses `AgentSession.updated_at` (auto_now) since `AgentSessionLog.created_at` isn't indexed.

Both run on the existing Procrastinate worker via `@app.periodic(cron=...)`. No new service needed.

### Migration 0013
Composite index on `AgentSession(status, updated_at)` so the watchdog query is an index range scan.

### Admin
New bulk-purge action on `AgentSessionAdmin` (mirrors the existing `terminate_sessions` pattern).

### Registration
`apps.py::ready()` imports `session_service.maintenance` so the `@periodic` decorators register when Django starts.

### Tests
New `tests/test_maintenance.py` (10 tests): retention deletes old terminal sessions, skips recent and running sessions, cascades to logs, batches correctly, closes DB connections; watchdog flips stuck running sessions, leaves recent ones and terminal ones alone.

## Motivation

Research: `thoughts/research/2026-04-19-streaming-high-volume-readiness.md` — finding #2 (storage runway ~2 days on old plan, no retention logic at all) and #6 (worker-crash-stuck-`running` = SSE worker pin forever).

Plan: `thoughts/plans/2026-04-19-streaming-high-volume-readiness.md`.

## Test plan

- [x] `uv run pytest tests/test_maintenance.py -v` → 10/10 pass
- [x] `uv run python manage.py makemigrations --check` → no drift
- [x] `uv run ruff check .` → clean
- [ ] After deploy, worker log shows periodic tasks registered at startup
- [ ] Within 5 min post-deploy, watchdog log line appears (either "flipped 0" or "flipped N")
- [ ] `EXPLAIN SELECT id FROM fairy_agentsession WHERE status='running' AND updated_at < NOW() - INTERVAL '15 min'` uses `agentsession_status_upd_idx`

## Rollback

Revert commit + push. Migration 0013 is additive (index only); a rollback can leave the index in place or run the reverse migration. No destructive schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)