### PR TITLE
Send unhandled exceptions to PostHog error tracking

### DIFF
--- a/src/agent_on_demand/apps.py
+++ b/src/agent_on_demand/apps.py
@@ -26,6 +26,14 @@ class AgentOnDemandConfig(AppConfig):
         posthog.api_key = api_key or "disabled"
         posthog.host = os.environ.get("POSTHOG_HOST", DEFAULT_POSTHOG_HOST)
         posthog.disabled = not api_key
+        # Install sys.excepthook + threading.excepthook so unhandled exceptions
+        # outside a request/task context (management commands, signal handlers,
+        # startup) still land in PostHog error tracking. The hook is wired when
+        # the default client is constructed; posthog.setup() forces that here
+        # instead of deferring to the first capture() call.
+        posthog.enable_exception_autocapture = bool(api_key)
+        if api_key:
+            posthog.setup()
         # Render SIGTERMs both the web and worker processes on deploy. Gunicorn
         # and Procrastinate each catch SIGTERM, drain, and exit cleanly — atexit
         # runs on that clean exit and flushes PostHog's async buffer so events

--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -127,13 +127,17 @@ def provision_session_task(
     """
     close_old_connections()
     try:
-        _provision_session_inner(
-            session_id=session_id,
-            turn_id=turn_id,
-            prompt=prompt,
-            mode=mode,
-            timeout=timeout,
-        )
+        with posthog.new_context(capture_exceptions=True):
+            posthog.tag("task", "provision_session")
+            posthog.tag("session_id", session_id)
+            posthog.tag("turn_id", turn_id)
+            _provision_session_inner(
+                session_id=session_id,
+                turn_id=turn_id,
+                prompt=prompt,
+                mode=mode,
+                timeout=timeout,
+            )
     finally:
         close_old_connections()
 
@@ -283,13 +287,17 @@ def execute_turn(
     """
     close_old_connections()
     try:
-        _execute_turn_inner(
-            session_id=session_id,
-            turn_id=turn_id,
-            prompt=prompt,
-            mode=mode,
-            timeout=timeout,
-        )
+        with posthog.new_context(capture_exceptions=True):
+            posthog.tag("task", "execute_turn")
+            posthog.tag("session_id", session_id)
+            posthog.tag("turn_id", turn_id)
+            _execute_turn_inner(
+                session_id=session_id,
+                turn_id=turn_id,
+                prompt=prompt,
+                mode=mode,
+                timeout=timeout,
+            )
     finally:
         close_old_connections()
 
@@ -500,16 +508,20 @@ def destroy_session_task(*, user_id: int, sprite_name: str) -> None:
     """
     close_old_connections()
     try:
-        User = get_user_model()
-        try:
-            user = User.objects.get(pk=user_id)
-        except User.DoesNotExist:
-            logger.warning(
-                "destroy_session_task: user %s gone, skipping Sprite %s",
-                user_id,
-                sprite_name,
-            )
-            return
-        destroy_session(user, sprite_name)
+        with posthog.new_context(capture_exceptions=True):
+            posthog.tag("task", "destroy_session")
+            posthog.tag("user_id", user_id)
+            posthog.tag("sprite_name", sprite_name)
+            User = get_user_model()
+            try:
+                user = User.objects.get(pk=user_id)
+            except User.DoesNotExist:
+                logger.warning(
+                    "destroy_session_task: user %s gone, skipping Sprite %s",
+                    user_id,
+                    sprite_name,
+                )
+                return
+            destroy_session(user, sprite_name)
     finally:
         close_old_connections()


### PR DESCRIPTION
## Summary

- PostHog is our error reporting system, but only HTTP exceptions were reaching it — the worker was a silent hole.
- `PosthogContextMiddleware` already auto-captures HTTP exceptions. Procrastinate, however, catches task exceptions in its worker loop (`procrastinate/worker.py:269`) so they never hit `sys.excepthook`.
- Two changes close the gap:
  1. Wrap each task body (`provision_session_task`, `execute_turn`, `destroy_session_task`) in `posthog.new_context(capture_exceptions=True)` with `task`/`session_id`/`turn_id`/`sprite_name` tags so exceptions are captured *with context* and then re-raised for Procrastinate to mark the job failed.
  2. Set `posthog.enable_exception_autocapture = True` in `apps.py:ready()` and force `posthog.setup()` so `sys.excepthook` + `threading.excepthook` are wired at startup — catches anything outside a request/task context (management commands, signal handlers, startup code).

No-ops cleanly when `POSTHOG_API_KEY` is unset: autocapture is gated on `bool(api_key)` and `setup()` is skipped.

## Test plan

- [ ] `make lint` passes.
- [ ] `make test` — task tests (`tests/test_tasks.py`) still pass; other failures are pre-existing on `main`.
- [ ] Smoke in staging: raise an exception inside `execute_turn` (e.g. by poisoning a session) and confirm it shows up in PostHog error tracking with `task=execute_turn`, `session_id`, `turn_id` tags.
- [ ] Smoke in staging: trigger a management command that crashes and confirm `sys.excepthook` path captures it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)