### PR TITLE
Restore OTel traces under ASGI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "opentelemetry-api>=1.29",
     "opentelemetry-sdk>=1.29",
     "opentelemetry-exporter-otlp-proto-http>=1.29",
+    "opentelemetry-instrumentation-asgi>=0.50b0",
     "opentelemetry-instrumentation-django>=0.50b0",
     "opentelemetry-instrumentation-psycopg>=0.50b0",
     "opentelemetry-instrumentation-requests>=0.50b0",

--- a/src/config/asgi.py
+++ b/src/config/asgi.py
@@ -4,4 +4,8 @@ from django.core.asgi import get_asgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
-application = get_asgi_application()
+_django_app = get_asgi_application()
+
+from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware  # noqa: E402
+
+application = OpenTelemetryMiddleware(_django_app)

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,7 @@ dependencies = [
     { name = "django-cors-headers" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-asgi" },
     { name = "opentelemetry-instrumentation-django" },
     { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-instrumentation-psycopg" },
@@ -64,6 +65,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
     { name = "opentelemetry-api", specifier = ">=1.29" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.29" },
+    { name = "opentelemetry-instrumentation-asgi", specifier = ">=0.50b0" },
     { name = "opentelemetry-instrumentation-django", specifier = ">=0.50b0" },
     { name = "opentelemetry-instrumentation-logging", specifier = ">=0.50b0" },
     { name = "opentelemetry-instrumentation-psycopg", specifier = ">=0.50b0" },
@@ -1292,6 +1294,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f9/fd/b8e90bb340957f059084376f94cff336b0e871a42feba7d3f7342365e987/opentelemetry_instrumentation-0.62b0.tar.gz", hash = "sha256:aa1b0b9ab2e1722c2a8a5384fb016fc28d30bba51826676c8036074790d2861e", size = 34042, upload-time = "2026-04-09T14:40:22.843Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/b6/3356d2e335e3c449c5183e9b023f30f04f1b7073a6583c68745ea2e704b1/opentelemetry_instrumentation-0.62b0-py3-none-any.whl", hash = "sha256:30d4e76486eae64fb095264a70c2c809c4bed17b73373e53091470661f7d477c", size = 34158, upload-time = "2026-04-09T14:39:21.428Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/38/999bf777774878971c2716de4b7a03cd57a7decb4af25090e703b79fa0e5/opentelemetry_instrumentation_asgi-0.62b0.tar.gz", hash = "sha256:93cde8c62e5918a3c1ff9ba020518127300e5e0816b7e8b14baf46a26ba619fc", size = 26779, upload-time = "2026-04-09T14:40:26.566Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/cf/29df82f5870178143bdb5c9a7be044b9f78c71e1c5dcf995242e86d80158/opentelemetry_instrumentation_asgi-0.62b0-py3-none-any.whl", hash = "sha256:89b62a6f996b260b162f515c25e6d78e39286e4cbe2f935899e51b32f31027e2", size = 17011, upload-time = "2026-04-09T14:39:27.305Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `opentelemetry-instrumentation-django` only instruments Django's WSGI handler. Under uvicorn every request goes through `ASGIHandler.__call__`, which the Django instrumentor never touches — server spans stopped being emitted after #64 merged.
- Fix: wrap the ASGI application in `OpenTelemetryMiddleware` from `opentelemetry-instrumentation-asgi` so each request gets a root span again.

Once this lands, the psycopg and requests child spans that are still being emitted will have a parent to nest under, and Honeycomb will start seeing `aod-web` traces again.

## Changes
- `pyproject.toml`: add `opentelemetry-instrumentation-asgi>=0.50b0` alongside the other OTel instrumentation packages
- `src/config/asgi.py`: `application = OpenTelemetryMiddleware(get_asgi_application())`

The existing `DjangoInstrumentor()` call in `observability.py` is left alone — under ASGI it's a no-op on the request path but still hooks DB middleware cheaply, and keeping it means if we ever point another runner at `config.wsgi` (e.g. `manage.py runserver`) traces still flow.

## Test plan
- [x] `make test` — 232 passed
- [x] `make lint` — clean
- [ ] Reviewer: confirm Honeycomb receives traces for `aod-web` again within a few minutes of deploy
- [ ] Reviewer: spot-check that request spans carry `http.route`, `http.method`, `http.status_code` attributes as before
- [ ] Reviewer: psycopg + requests spans nest under the ASGI root span

🤖 Generated with [Claude Code](https://claude.com/claude-code)