### PR TITLE
Exclude /health from ASGI OTel spans

### DIFF
--- a/src/config/asgi.py
+++ b/src/config/asgi.py
@@ -8,4 +8,7 @@ _django_app = get_asgi_application()
 
 from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware  # noqa: E402
 
-application = OpenTelemetryMiddleware(_django_app)
+# `/health` is polled every few seconds by Render's health check; excluding it
+# here mirrors the DjangoInstrumentor filter in observability.py so the ASGI
+# middleware doesn't emit a span for every poll.
+application = OpenTelemetryMiddleware(_django_app, excluded_urls="health")


### PR DESCRIPTION
## Summary
- Render polls `/health` every few seconds, generating a span per poll that dominates Honeycomb traffic.
- `DjangoInstrumentor().instrument(excluded_urls="health")` in `observability.py` already filters these, but the ASGI layer wrapping the app in `config/asgi.py` was still emitting its own span (see `library.name: opentelemetry.instrumentation.asgi` on the noisy traces).
- Pass `excluded_urls="health"` to `OpenTelemetryMiddleware` so both layers agree.

## Test plan
- [ ] Deploy and confirm `/health` traces stop appearing in Honeycomb for `service.name: aod-web` under `library.name: opentelemetry.instrumentation.asgi`.
- [ ] Verify non-health requests still produce spans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)