### PR TITLE
Raise default session cap to 100

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -109,5 +109,7 @@ SPRITE_NAME_PREFIX = os.environ.get("SPRITE_NAME_PREFIX", "aod")
 DEFAULT_TIMEOUT = int(os.environ.get("DEFAULT_TIMEOUT", "600"))
 
 # Per-user cap on concurrent (pending + running) sessions. Users can be granted
-# a higher (or lower) limit via UserQuota.max_concurrent_sessions.
-DEFAULT_MAX_CONCURRENT_SESSIONS = int(os.environ.get("DEFAULT_MAX_CONCURRENT_SESSIONS", "10"))
+# a higher (or lower) limit via UserQuota.max_concurrent_sessions. Sprites cost
+# is borne by the user (own token), so this cap protects our worker queue from
+# a single user saturating it, not our spend.
+DEFAULT_MAX_CONCURRENT_SESSIONS = int(os.environ.get("DEFAULT_MAX_CONCURRENT_SESSIONS", "100"))


### PR DESCRIPTION
## Summary
- Raises `DEFAULT_MAX_CONCURRENT_SESSIONS` from 10 to 100
- Users bring their own Sprites token, so the cap protects our worker queue from a single user saturating it — not our spend
- Per-user `UserQuota` overrides still work for tightening specific users if needed

## Test plan
- [x] Existing quota tests still pass (they set the default explicitly)
- [ ] On launch day, watch worker queue depth to confirm 100 is sane under real load

🤖 Generated with [Claude Code](https://claude.com/claude-code)