### PR TITLE
Break clone_repos into sub-stages to diagnose slow provisioning

### DIFF
--- a/src/agent_on_demand/session_service/provisioning.py
+++ b/src/agent_on_demand/session_service/provisioning.py
@@ -269,28 +269,33 @@ def _clone_repos(sprite: Sprite, repos: list[RepoSpec], session_id: str | None) 
     with stage_timer(session_id, STAGE_CLONE_REPOS):
         try:
             if cred_lines:
-                fs = sprite.filesystem()
-                (fs / cred_path.lstrip("/")).write_text("\n".join(cred_lines) + "\n")
-                sprite.command("chmod", "600", cred_path).run()
-                sprite.command(
-                    "git",
-                    "config",
-                    "--global",
-                    "credential.helper",
-                    f"store --file={cred_path}",
-                ).run()
+                with stage_timer(session_id, f"{STAGE_CLONE_REPOS}.setup"):
+                    fs = sprite.filesystem()
+                    (fs / cred_path.lstrip("/")).write_text("\n".join(cred_lines) + "\n")
+                    sprite.command("chmod", "600", cred_path).run()
+                    sprite.command(
+                        "git",
+                        "config",
+                        "--global",
+                        "credential.helper",
+                        f"store --file={cred_path}",
+                    ).run()
             for repo in repos:
-                sprite.command(
-                    "git", "clone", "--depth=1", "--quiet", repo.url, repo.mount_path
-                ).run()
+                with stage_timer(session_id, f"{STAGE_CLONE_REPOS}.download"):
+                    sprite.command(
+                        "git", "clone", "--depth=1", "--quiet", repo.url, repo.mount_path
+                    ).run()
         except SpriteError as e:
             raise ProvisionError(f"Failed to clone repos: {e}", stage=STAGE_CLONE_REPOS) from e
         finally:
             # Always attempt cleanup, even on clone failure. Cleanup errors are
             # logged but don't shadow the real failure.
             try:
-                sprite.command("rm", "-f", cred_path).run()
-                sprite.command("git", "config", "--global", "--unset", "credential.helper").run()
+                with stage_timer(session_id, f"{STAGE_CLONE_REPOS}.cleanup"):
+                    sprite.command("rm", "-f", cred_path).run()
+                    sprite.command(
+                        "git", "config", "--global", "--unset", "credential.helper"
+                    ).run()
             except SpriteError:
                 logger.warning("Failed to clean git credentials on Sprite", exc_info=True)
 


### PR DESCRIPTION
## Why

Recent sessions show `clone_repos` taking ~30s for a single small repo. The current stage is opaque — we see the total but not whether the time is in git clone itself, in shell setup, or somewhere else. Hard to optimize what you can't measure.

## What

Nest three inner `stage_timer` calls inside the existing `clone_repos` stage_timer in [`provisioning.py:269`](../blob/perf/clone-subrange-events/src/agent_on_demand/session_service/provisioning.py#L269):

| Inner stage | Covers | Sprite round trips |
|---|---|---|
| `clone_repos.setup` | Write `/tmp/.git-credentials`, chmod, `git config credential.helper` | 3 |
| `clone_repos.download` | `git clone --depth=1 --quiet ...` | 1 + actual transfer |
| `clone_repos.cleanup` | `rm -f creds`, `git config --unset credential.helper` | 2 |

The **outer `clone_repos` event is unchanged** — consumers that only watch the coarse name keep working. Inner events are additive.

## Why ship this separately

PR #73 has the CLI side (labels + spinner hookup) but is still the full example-cli surface. Splitting the backend diagnostic out means it can merge/deploy fast and the next prod session run will give us the breakdown.

## Expected outcome

Next session against prod will emit:

```
stage clone_repos started
stage clone_repos.setup started
stage clone_repos.setup done  (duration_ms=...)
stage clone_repos.download started
stage clone_repos.download done  (duration_ms=...)   ← this number is the real question
stage clone_repos.cleanup started
stage clone_repos.cleanup done  (duration_ms=...)
stage clone_repos done  (duration_ms=...)
```

If `download` is ~28s, the next move is in-Sprite investigation (TLS/DNS cold, GitHub-side, bandwidth). If `setup` is unexpectedly large, the 6-command credential-file dance is the culprit and we can batch into one `bash -c`.

## Test plan
- [x] `uv run pytest tests/test_session_service.py` — passes (10/10).
- [x] `uv run ruff check` — clean.
- [ ] Merge → Render auto-deploys → run `./examples/cli/example-cli.py "…"` against `aod.ravi.id` and observe the per-sub-stage durations.
- [ ] Based on the numbers, file a follow-up PR (or close with a note if the breakdown is expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)