### PR TITLE
Add aod-sdk PyPI + TestPyPI release workflows

### DIFF
--- a/.github/workflows/sdk-release-test.yml
+++ b/.github/workflows/sdk-release-test.yml
@@ -1,0 +1,48 @@
+name: Publish aod-sdk to TestPyPI
+
+# Manual dry-run against test.pypi.org. Run this before cutting a real
+# release to validate the build + trusted-publisher config end-to-end.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref (branch, tag, or SHA) to build from'
+        default: main
+        required: true
+
+jobs:
+  publish-testpypi:
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/aod-sdk
+    permissions:
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        working-directory: clients/python
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - run: uv sync --all-extras
+      - run: uv run pytest -q
+      - run: uv build
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: clients/python/dist/
+          # TestPyPI can't overwrite versions. skip-existing lets you re-run
+          # the dry-run without bumping the pyproject version every time.
+          skip-existing: true

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -1,0 +1,49 @@
+name: Publish aod-sdk to PyPI
+
+# Fires when a GitHub Release is published with a tag like `aod-sdk-v0.1.0`.
+# The server ships from the same repo, so we scope by tag prefix.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    if: startsWith(github.event.release.tag_name, 'aod-sdk-v')
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/aod-sdk
+    permissions:
+      id-token: write   # OIDC for PyPI Trusted Publishing
+      contents: read
+    defaults:
+      run:
+        working-directory: clients/python
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Verify tag matches pyproject.toml version
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          tag_version="${tag#aod-sdk-v}"
+          pkg_version=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::Tag version ($tag_version) does not match pyproject.toml version ($pkg_version)"
+            exit 1
+          fi
+
+      - run: uv sync --all-extras
+      - run: uv run pytest -q
+      - run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: clients/python/dist/

--- a/clients/python/LICENSE
+++ b/clients/python/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Ravi, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -136,3 +136,55 @@ pytest
 ruff check
 mypy
 ```
+
+## Releases (maintainers)
+
+Published to PyPI via GitHub Actions using [Trusted
+Publishing](https://docs.pypi.org/trusted-publishers/) — no API tokens to
+manage. Two workflows live in `.github/workflows/`:
+
+- `sdk-release.yml` — fires on GitHub Release creation with tag
+  `aod-sdk-v<version>`, publishes to [pypi.org/p/aod-sdk](https://pypi.org/p/aod-sdk).
+- `sdk-release-test.yml` — manual `workflow_dispatch`, publishes to
+  [test.pypi.org/p/aod-sdk](https://test.pypi.org/p/aod-sdk) for dry-run
+  validation.
+
+### One-time setup
+
+1. **Reserve the name on PyPI (and TestPyPI)**. On both
+   [pypi.org](https://pypi.org/manage/account/publishing/) and
+   [test.pypi.org](https://test.pypi.org/manage/account/publishing/), add a
+   *pending* trusted publisher:
+
+   | Field | Value |
+   | ----- | ----- |
+   | Project name | `aod-sdk` |
+   | Owner | `ravi-hq` |
+   | Repository | `agent-on-demand` |
+   | Workflow | `sdk-release.yml` (PyPI) / `sdk-release-test.yml` (TestPyPI) |
+   | Environment | `pypi` / `testpypi` |
+
+2. **(Recommended) Create protected GitHub environments**. In
+   *Settings → Environments*, create `pypi` with required reviewers, and
+   `testpypi` with no protections.
+
+### Cutting a release
+
+1. Bump the version in **both** `clients/python/pyproject.toml` and
+   `clients/python/src/aod/__init__.py` (the workflow verifies the
+   pyproject value matches the tag). PR + merge to `main`.
+2. (Recommended) Run `sdk-release-test.yml` against `main` and
+   `pip install -i https://test.pypi.org/simple/ aod-sdk==<version>` in a
+   throwaway venv to confirm the wheel installs and imports cleanly.
+3. Tag and create a GitHub Release:
+
+   ```bash
+   gh release create aod-sdk-v0.2.0 \
+     --title "aod-sdk v0.2.0" \
+     --notes "..." \
+     --target main
+   ```
+
+   `sdk-release.yml` fires on `published`, verifies the tag matches
+   `pyproject.toml`, runs the tests, builds sdist + wheel, and uploads to
+   PyPI.

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 description = "Python SDK for the Agent on Demand API"
 requires-python = ">=3.11"
 license = "Apache-2.0"
-license-files = ["../../LICENSE"]
+license-files = ["LICENSE"]
 readme = "README.md"
 authors = [{ name = "Ravi" }]
 dependencies = [
@@ -30,8 +30,8 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/ravi-hq/fairy"
-Source = "https://github.com/ravi-hq/fairy/tree/main/clients/python"
+Homepage = "https://github.com/ravi-hq/agent-on-demand"
+Source = "https://github.com/ravi-hq/agent-on-demand/tree/main/clients/python"
 
 [tool.ruff]
 target-version = "py311"


### PR DESCRIPTION
## Summary

Wires up automated publishing for `aod-sdk` via GitHub Actions + PyPI
[Trusted Publishing](https://docs.pypi.org/trusted-publishers/) — no API
tokens stored in the repo.

- **`sdk-release.yml`** — fires on GitHub Release creation with tag
  `aod-sdk-v*`, verifies the tag matches `pyproject.toml`, runs tests,
  builds sdist + wheel, uploads to [pypi.org/p/aod-sdk](https://pypi.org/p/aod-sdk)
  (environment `pypi`).
- **`sdk-release-test.yml`** — manual `workflow_dispatch` against a chosen
  ref, uploads to [test.pypi.org/p/aod-sdk](https://test.pypi.org/p/aod-sdk)
  (environment `testpypi`). `skip-existing: true` so dry-run re-runs
  don't fail on duplicate versions.

Tag prefix is `aod-sdk-v*` (not plain `v*`) because the server and SDK
ship from the same repo.

## Incidental fixes found while validating the build

- `pyproject.toml` had `license-files = ["../../LICENSE"]`, which produced a
  `aod_sdk-0.1.0/../../LICENSE` entry in the sdist (path traversal, would
  trip strict extractors). Copied the LICENSE into `clients/python/` and
  pointed `license-files` at the local path. Verified the wheel now lists
  `License-File: LICENSE` in METADATA with no `..` components.
- `pyproject.toml` referenced `ravi-hq/fairy` in `Project-URL` fields; the
  real repo is `ravi-hq/agent-on-demand`.

## Required manual setup before the first release

Documented in detail in `clients/python/README.md` under "Releases":

1. On PyPI + TestPyPI, add a *pending* trusted publisher for `aod-sdk` with
   owner `ravi-hq`, repo `agent-on-demand`, workflow `sdk-release.yml` /
   `sdk-release-test.yml`, environment `pypi` / `testpypi`.
2. (Recommended) Create GitHub environments `pypi` (with required
   reviewers) and `testpypi` (no protections) under Settings → Environments.

Both workflows will fail until step 1 is done — that's by design.

## Test plan

- [x] `uv build` produces clean sdist + wheel; `License-File: LICENSE` in METADATA; no path-traversal entries.
- [x] `uv run pytest` → 59 passed.
- [ ] After merge + pending-publisher setup: trigger `sdk-release-test.yml` against main, `pip install -i https://test.pypi.org/simple/ aod-sdk==0.1.0 --extra-index-url https://pypi.org/simple/` in a throwaway venv, verify `from aod import Client` works.
- [ ] Cut real release: `gh release create aod-sdk-v0.1.0 --title "aod-sdk v0.1.0" --target main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)