### PR TITLE
Drop local-checkout install fallback from example CLI README

### DIFF
--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -7,7 +7,7 @@ version that runs inside a Sprite sandbox against a pinned agent, tool set,
 and repo list.
 
 ```
-$ pip install aod-sdk                                    # or: pip install -e ../../clients/python
+$ pip install aod-sdk
 $ export AOD_API_URL=https://aod.example.com
 $ export AOD_API_TOKEN=aod_xxxxxxxx
 $ ./example-cli.py "what does /workspace/fairy do?"     # new session


### PR DESCRIPTION
aod-sdk 0.1.0 is live on PyPI (https://pypi.org/p/aod-sdk), so the \`pip install -e ../../clients/python\` sidecar in the examples/cli/README.md is noise.

The SDK README's TestPyPI install (line 177) uses \`-i\` legitimately and stays as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)