### PR TITLE
Add Python SDK references + tabbed curl/Python examples to docs

### DIFF
--- a/site/docs/api/authentication.md
+++ b/site/docs/api/authentication.md
@@ -33,13 +33,35 @@ Agent on Demand does not return 403. Resources that exist but don't belong to th
 
 ## Example
 
-```bash
-# Missing header → 401
-curl http://localhost:8777/agents
-# {"detail":"Missing or invalid Authorization header"}
+=== "curl"
 
-# Valid token
-curl http://localhost:8777/agents \
-  -H "Authorization: Bearer aod_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-# {"data":[...]}
-```
+    ```bash
+    # Missing header → 401
+    curl http://localhost:8777/agents
+    # {"detail":"Missing or invalid Authorization header"}
+
+    # Valid token
+    curl http://localhost:8777/agents \
+      -H "Authorization: Bearer aod_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    # {"data":[...]}
+    ```
+
+=== "Python"
+
+    With [`aod-sdk`](../sdks/python.md), the token is set at `Client` construction (or via `AOD_API_TOKEN`); 401 responses surface as `AuthError`:
+
+    ```python
+    from aod import AuthError, Client
+
+    client = Client(
+        base_url="http://localhost:8777",
+        token="aod_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    )
+    try:
+        agents = client.agents.list()
+    except AuthError as e:
+        print(e.status_code, e.detail)
+        # 401 'Invalid API key'
+    ```
+
+    `AuthError` is a subclass of `AodHTTPError` — `.status_code`, `.detail`, `.method`, `.url` are all available.

--- a/site/docs/api/quickstart.md
+++ b/site/docs/api/quickstart.md
@@ -2,31 +2,59 @@
 
 This page walks through the minimum-viable flow: create an agent, start a session, and stream its output. All you need is a running Agent on Demand deployment and an API token.
 
+Python examples use the official [`aod-sdk`](../sdks/python.md) package (`pip install aod-sdk`). `Client()` reads `AOD_API_URL` and `AOD_API_TOKEN` from the environment when no explicit arguments are passed.
+
 ## Prerequisites
 
 - **Local**: run `make dev` — the server starts on `http://localhost:8777`.
 - **Remote**: set `BASE` to your deployment URL.
 - A valid API token (created server-side via `APIKey.create_key`).
 
-```bash
-BASE=http://localhost:8777
-TOKEN=aod_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-```
+=== "curl"
+
+    ```bash
+    BASE=http://localhost:8777
+    TOKEN=aod_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    ```
+
+=== "Python"
+
+    ```bash
+    export AOD_API_URL=http://localhost:8777
+    export AOD_API_TOKEN=aod_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    pip install aod-sdk
+    ```
 
 ## Step 1 — Create an agent
 
 An agent is a reusable template. The minimum required fields are `name`, `model`, and `runtime`.
 
-```bash
-curl -X POST "$BASE/agents" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "hello",
-    "model": "claude-sonnet-4-6",
-    "runtime": "claude"
-  }'
-```
+=== "curl"
+
+    ```bash
+    curl -X POST "$BASE/agents" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "name": "hello",
+        "model": "claude-sonnet-4-6",
+        "runtime": "claude"
+      }'
+    ```
+
+=== "Python"
+
+    ```python
+    from aod import Client
+
+    client = Client()  # reads AOD_API_URL + AOD_API_TOKEN
+    agent = client.agents.create(
+        name="hello",
+        model="claude-sonnet-4-6",
+        runtime="claude",
+    )
+    print(agent.id)
+    ```
 
 Response (`201 Created`):
 
@@ -56,16 +84,29 @@ Save the `id` — you'll need it to create a session.
 
 A session runs the agent with a prompt inside a Sprite. Execution is asynchronous; the response comes back immediately with `status: "pending"`.
 
-```bash
-curl -X POST "$BASE/sessions" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "{
-    \"agent_id\": \"<agent-uuid>\",
-    \"prompt\": \"Print the current date.\",
-    \"timeout\": 120
-  }"
-```
+=== "curl"
+
+    ```bash
+    curl -X POST "$BASE/sessions" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Type: application/json" \
+      -d "{
+        \"agent_id\": \"<agent-uuid>\",
+        \"prompt\": \"Print the current date.\",
+        \"timeout\": 120
+      }"
+    ```
+
+=== "Python"
+
+    ```python
+    ack = client.sessions.create(
+        agent_id=agent.id,
+        prompt="Print the current date.",
+        timeout=120,
+    )
+    print(ack.id, ack.status)  # <session-uuid> pending
+    ```
 
 Response (`202 Accepted`):
 
@@ -81,51 +122,92 @@ Response (`202 Accepted`):
 
 ## Step 3 — Stream output
 
-Connect to the SSE stream to receive agent output in real time. The `-N` flag disables curl's output buffering.
+Connect to the SSE stream to receive agent output in real time.
 
-```bash
-curl -N -H "Authorization: Bearer $TOKEN" "$BASE/sessions/<session-uuid>/stream"
-```
+=== "curl"
 
-You'll see a sequence of `data:` lines:
+    The `-N` flag disables curl's output buffering.
 
-```
-data: {"type":"start","runtime":"claude","session_id":"<session-uuid>"}
+    ```bash
+    curl -N -H "Authorization: Bearer $TOKEN" "$BASE/sessions/<session-uuid>/stream"
+    ```
 
-data: {"type":"output","stream":"stdout","data":"Thu Apr 17 14:00:00 UTC 2026\n"}
+    You'll see a sequence of `data:` lines:
 
-data: {"type":"exit","code":0}
-```
+    ```
+    data: {"type":"start","runtime":"claude","session_id":"<session-uuid>"}
+
+    data: {"type":"output","stream":"stdout","data":"Thu Apr 17 14:00:00 UTC 2026\n"}
+
+    data: {"type":"exit","code":0}
+    ```
+
+=== "Python"
+
+    `client.sessions.stream(session_id)` is a context manager yielding typed `StreamEvent` objects.
+
+    ```python
+    with client.sessions.stream(ack.id) as events:
+        for event in events:
+            if event.type == "output":
+                print(event.extra["data"], end="")
+            elif event.type == "exit":
+                print(f"\n[exit {event.extra['code']}]")
+    ```
 
 The stream closes after the terminal event (`exit`, `error`, or `terminated`). Reconnecting replays all output from the beginning — useful if your connection drops.
 
 ## Full scripted example
 
-```bash
-BASE=http://localhost:8777
-TOKEN=aod_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-AUTH="Authorization: Bearer $TOKEN"
-JSON="Content-Type: application/json"
+=== "curl"
 
-# Create agent
-AGENT_ID=$(curl -s -X POST "$BASE/agents" -H "$AUTH" -H "$JSON" \
-  -d '{"name":"demo","model":"claude-sonnet-4-6","runtime":"claude"}' \
-  | jq -r .id)
+    ```bash
+    BASE=http://localhost:8777
+    TOKEN=aod_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    AUTH="Authorization: Bearer $TOKEN"
+    JSON="Content-Type: application/json"
 
-# Create session
-SESS_ID=$(curl -s -X POST "$BASE/sessions" -H "$AUTH" -H "$JSON" \
-  -d "{\"agent_id\":\"$AGENT_ID\",\"prompt\":\"Say hello.\",\"timeout\":120}" \
-  | jq -r .id)
+    # Create agent
+    AGENT_ID=$(curl -s -X POST "$BASE/agents" -H "$AUTH" -H "$JSON" \
+      -d '{"name":"demo","model":"claude-sonnet-4-6","runtime":"claude"}' \
+      | jq -r .id)
 
-# Stream output
-curl -N -H "$AUTH" "$BASE/sessions/$SESS_ID/stream"
+    # Create session
+    SESS_ID=$(curl -s -X POST "$BASE/sessions" -H "$AUTH" -H "$JSON" \
+      -d "{\"agent_id\":\"$AGENT_ID\",\"prompt\":\"Say hello.\",\"timeout\":120}" \
+      | jq -r .id)
 
-# Clean up
-curl -s -X POST -H "$AUTH" "$BASE/agents/$AGENT_ID/archive"
-```
+    # Stream output
+    curl -N -H "$AUTH" "$BASE/sessions/$SESS_ID/stream"
+
+    # Clean up
+    curl -s -X POST -H "$AUTH" "$BASE/agents/$AGENT_ID/archive"
+    ```
+
+=== "Python"
+
+    ```python
+    from aod import Client
+
+    with Client() as client:
+        agent = client.agents.create(
+            name="demo", model="claude-sonnet-4-6", runtime="claude"
+        )
+        ack = client.sessions.create(
+            agent_id=agent.id, prompt="Say hello.", timeout=120
+        )
+        with client.sessions.stream(ack.id) as events:
+            for event in events:
+                if event.type == "output":
+                    print(event.extra["data"], end="")
+                elif event.type == "exit":
+                    break
+        client.agents.archive(agent.id)
+    ```
 
 ## What's next
 
 - [Core Concepts](concepts.md) — understand agents, environments, sessions, and versioning.
 - [API Reference](reference.md) — browse all endpoints interactively.
+- [Python SDK](../sdks/python.md) — full surface, typed errors, async client, SSE helpers.
 - [Streaming](streaming.md) — full SSE event reference and reconnect guidance.

--- a/site/docs/api/streaming.md
+++ b/site/docs/api/streaming.md
@@ -107,37 +107,74 @@ If the `id` is not a non-negative integer, the server returns `400`.
 
 ## Client examples
 
-### curl
+=== "curl"
 
-```bash
-curl -N \
-  -H "Authorization: Bearer $TOKEN" \
-  "$BASE/sessions/<session-uuid>/stream"
-```
+    The `-N` flag disables output buffering.
 
-The `-N` flag disables output buffering.
+    ```bash
+    curl -N \
+      -H "Authorization: Bearer $TOKEN" \
+      "$BASE/sessions/<session-uuid>/stream"
+    ```
 
-### Python
+    To resume after a disconnect, pass the last `id` you received:
 
-```python
-import json
-import requests
+    ```bash
+    curl -N \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Last-Event-ID: 42" \
+      "$BASE/sessions/<session-uuid>/stream"
+    ```
 
-last_event_id = 0
-while True:
-    headers = {"Authorization": f"Bearer {token}"}
-    if last_event_id:
-        headers["Last-Event-ID"] = str(last_event_id)
-    with requests.get(url, headers=headers, stream=True) as r:
-        for line in r.iter_lines(decode_unicode=True):
-            if not line or line.startswith(":"):
-                continue  # blank line between events, or heartbeat
-            if line.startswith("id: "):
-                last_event_id = int(line[4:])
-            elif line.startswith("data: "):
-                event = json.loads(line[6:])
-                # handle event...
-                if event["type"] in ("exit", "error", "terminated", "stale"):
-                    return
-    # loop reconnects with Last-Event-ID preserved
-```
+=== "Python (aod-sdk)"
+
+    The [`aod-sdk`](../sdks/python.md) package handles SSE parsing, heartbeats, and `Last-Event-ID` resume for you. Events are typed `StreamEvent` objects; everything beyond `type` and `id` lands in `event.extra`.
+
+    ```python
+    from aod import Client
+
+    with Client() as client:
+        with client.sessions.stream(session_id) as events:
+            for event in events:
+                if event.type == "output":
+                    print(event.extra["data"], end="")
+                elif event.type == "stage":
+                    print(f"[{event.extra['stage']} {event.extra['state']}]")
+                elif event.type in ("exit", "error", "terminated", "stale"):
+                    print(f"\n[{event.type}]")
+                    break
+    ```
+
+    Pass `since=<id>` to resume after a previously-seen event:
+
+    ```python
+    with client.sessions.stream(session_id, since=42) as events:
+        ...
+    ```
+
+=== "Python (raw)"
+
+    If you'd rather not add `aod-sdk` as a dependency, here's a minimal reconnect-aware loop on top of `requests`:
+
+    ```python
+    import json
+    import requests
+
+    last_event_id = 0
+    while True:
+        headers = {"Authorization": f"Bearer {token}"}
+        if last_event_id:
+            headers["Last-Event-ID"] = str(last_event_id)
+        with requests.get(url, headers=headers, stream=True) as r:
+            for line in r.iter_lines(decode_unicode=True):
+                if not line or line.startswith(":"):
+                    continue  # blank line between events, or heartbeat
+                if line.startswith("id: "):
+                    last_event_id = int(line[4:])
+                elif line.startswith("data: "):
+                    event = json.loads(line[6:])
+                    # handle event...
+                    if event["type"] in ("exit", "error", "terminated", "stale"):
+                        return
+        # loop reconnects with Last-Event-ID preserved
+    ```

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -12,34 +12,62 @@ Local dev runs on `http://localhost:8777` (`make dev`). Every request except `GE
 
 Three calls to go from zero to a running agent:
 
-```bash
-BASE=http://localhost:8777
-TOKEN=aod_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+=== "curl"
 
-# 1. Create an agent.
-AGENT_ID=$(curl -s -X POST "$BASE/agents" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"name":"hello","model":"claude-sonnet-4-6","runtime":"claude"}' | jq -r .id)
+    ```bash
+    BASE=http://localhost:8777
+    TOKEN=aod_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-# 2. Start a session.
-SESS_ID=$(curl -s -X POST "$BASE/sessions" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "{\"agent_id\":\"$AGENT_ID\",\"prompt\":\"Say hello.\",\"timeout\":120}" | jq -r .id)
+    # 1. Create an agent.
+    AGENT_ID=$(curl -s -X POST "$BASE/agents" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"name":"hello","model":"claude-sonnet-4-6","runtime":"claude"}' | jq -r .id)
 
-# 3. Stream output.
-curl -N -H "Authorization: Bearer $TOKEN" "$BASE/sessions/$SESS_ID/stream"
-```
+    # 2. Start a session.
+    SESS_ID=$(curl -s -X POST "$BASE/sessions" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Type: application/json" \
+      -d "{\"agent_id\":\"$AGENT_ID\",\"prompt\":\"Say hello.\",\"timeout\":120}" | jq -r .id)
+
+    # 3. Stream output.
+    curl -N -H "Authorization: Bearer $TOKEN" "$BASE/sessions/$SESS_ID/stream"
+    ```
+
+=== "Python"
+
+    ```bash
+    pip install aod-sdk
+    ```
+
+    ```python
+    from aod import Client
+
+    # Client() reads AOD_API_URL and AOD_API_TOKEN from the environment.
+    with Client(base_url="http://localhost:8777", token="aod_...") as client:
+        agent = client.agents.create(
+            name="hello", model="claude-sonnet-4-6", runtime="claude"
+        )
+        ack = client.sessions.create(
+            agent_id=agent.id, prompt="Say hello.", timeout=120
+        )
+        with client.sessions.stream(ack.id) as events:
+            for event in events:
+                if event.type == "output":
+                    print(event.extra["data"], end="")
+    ```
+
+    See the [Python SDK](sdks/python.md) page for the full surface.
 
 ## Explore the docs
 
 | Section | What you'll find |
 |---------|-----------------|
-| [Quickstart](api/quickstart.md) | Full minimum-viable flow with curl commands |
+| [Quickstart](api/quickstart.md) | Full minimum-viable flow with curl + Python SDK |
 | [Core Concepts](api/concepts.md) | Resources, versioning, state machines, metadata semantics |
 | [Overview](api/product.md) | What problems Agent on Demand solves |
 | [API Reference](api/reference.md) | Interactive Stoplight Elements explorer |
+| [Python SDK](sdks/python.md) | `aod-sdk` — typed sync + async client on PyPI |
 | [Authentication](api/authentication.md) | Bearer tokens, 401 shapes |
 | [Streaming](api/streaming.md) | SSE event types, reconnect, replay |
 | [Errors](api/errors.md) | Every status code and when it fires |

--- a/site/docs/sdks/python.md
+++ b/site/docs/sdks/python.md
@@ -1,0 +1,134 @@
+# Python SDK
+
+The official Python client for Agent on Demand. Covers every endpoint in the [API reference](../api/reference.md) with typed pydantic models, sync and async clients, and a typed SSE event stream.
+
+- **Package**: [`aod-sdk` on PyPI](https://pypi.org/p/aod-sdk)
+- **Source**: [`clients/python/`](https://github.com/ravi-hq/agent-on-demand/tree/main/clients/python)
+- **Supports**: Python 3.11+
+
+## Install
+
+```bash
+pip install aod-sdk
+```
+
+## Quickstart
+
+```python
+from aod import Client
+
+with Client(token="aod_...") as client:
+    agent = client.agents.create(
+        name="demo",
+        model="claude-sonnet-4-6",
+        runtime="claude",
+    )
+    ack = client.sessions.create(agent_id=agent.id, prompt="Say hello.")
+    with client.sessions.stream(ack.id) as events:
+        for event in events:
+            if event.type == "output":
+                print(event.extra["data"], end="")
+```
+
+`Client()` reads `AOD_API_URL` and `AOD_API_TOKEN` from the environment when no explicit arguments are passed.
+
+## Feature summary
+
+| Capability | Where it lives |
+|------------|----------------|
+| Sync + async clients | `aod.Client`, `aod.AsyncClient` |
+| Typed resources | `client.agents`, `client.environments`, `client.sessions` |
+| Typed models | `Agent`, `Environment`, `Session`, `SessionAck`, `SessionTurn`, `StreamEvent`, … |
+| Typed error hierarchy | `AodError` → `NotFoundError`, `ConflictError`, `ValidationError`, `RateLimitError`, `AuthError`, `ServerError` |
+| SSE stream (context manager, typed events) | `client.sessions.stream(session_id, since=None)` |
+| Claude `stream-json` pretty-printer | `aod.pretty.claude.ClaudeFormatter` (optional, runtime-scoped) |
+
+## Errors
+
+Non-2xx responses raise a typed subclass of `AodHTTPError` — all share `.status_code`, `.detail`, `.method`, `.url`:
+
+```python
+from aod import Client, ConflictError
+
+client = Client(token="aod_...")
+try:
+    client.agents.update(agent_id, version=1, name="renamed")
+except ConflictError as e:
+    # 409: stale version or archived row
+    print(e.status_code, e.detail)
+```
+
+Mapping matches the [Errors reference](../api/errors.md):
+
+| Status | Exception | When |
+| ------ | --------- | ---- |
+| 401/403 | `AuthError` | Missing or invalid token |
+| 404 | `NotFoundError` | Resource missing (or not owned by caller) |
+| 409 | `ConflictError` | Archived row, terminal session, or stale `version` |
+| 422 | `ValidationError` | Server-side pydantic validation failure |
+| 429 | `RateLimitError` | Per-user concurrent session limit (`.limit`, `.active`) |
+| 5xx | `ServerError` | |
+
+## Streaming
+
+`client.sessions.stream(session_id)` is a context manager that yields typed `StreamEvent` objects. See the [Streaming reference](../api/streaming.md) for the full event schema.
+
+```python
+with client.sessions.stream(session_id) as events:
+    for event in events:
+        match event.type:
+            case "stage":
+                print(f"[stage] {event.extra['stage']} {event.extra['state']}")
+            case "output":
+                print(event.extra["data"], end="")
+            case "exit":
+                print(f"\n[exit {event.extra['code']}]")
+            case "error" | "terminated" | "stale":
+                print(f"\n[{event.type}] {event.extra.get('message', '')}")
+```
+
+Pass `since=<id>` to resume after a previously-seen event.
+
+### Pretty-printing Claude output
+
+For Claude-runtime sessions, `aod.pretty.claude.ClaudeFormatter` parses the `stream-json` lines into human-readable summaries:
+
+```python
+from aod import Client
+from aod.pretty.claude import ClaudeFormatter
+
+fmt = ClaudeFormatter()
+with client.sessions.stream(session_id) as events:
+    for event in events:
+        for line in fmt.consume(event):  # filters to output/stdout
+            print(line)
+    for line in fmt.flush():              # drain any buffered partial
+        print(line)
+```
+
+Other runtimes emit plain text — no formatter needed.
+
+## Async
+
+Every method has an async counterpart on `AsyncClient`:
+
+```python
+import asyncio
+from aod import AsyncClient
+
+async def main():
+    async with AsyncClient(token="aod_...") as client:
+        agents = await client.agents.list()
+        for agent in agents:
+            print(agent.name)
+
+asyncio.run(main())
+```
+
+SSE streams use `async with client.sessions.stream(...)` and `async for event in events`.
+
+## See also
+
+- [`clients/python/README.md`](https://github.com/ravi-hq/agent-on-demand/tree/main/clients/python#readme) — full API surface, optimistic-concurrency semantics, release notes for maintainers.
+- [Example CLI](https://github.com/ravi-hq/agent-on-demand/tree/main/examples/cli) — a production-ready CLI wrapper built on the SDK.
+- [Quickstart](../api/quickstart.md), [Streaming](../api/streaming.md), [Authentication](../api/authentication.md) — Python examples are tabbed alongside curl.

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -39,6 +39,8 @@ nav:
     - Streaming: api/streaming.md
     - Errors: api/errors.md
     - Pagination: api/pagination.md
+  - SDKs:
+    - Python: sdks/python.md
   - Patterns:
     - CLI Wrapper: patterns/cli-wrapper.md
     - Chat Bot: patterns/chat-bot.md


### PR DESCRIPTION
First of two PRs adding SDK coverage to the docs site. This one covers the reference/getting-started pages; a follow-up will do the patterns/* pages.

## What's new

- **New page** `site/docs/sdks/python.md` — install, quickstart, feature summary, typed-error mapping, streaming (with ClaudeFormatter), async. Nav entry "SDKs → Python" between Reference and Patterns.
- **index.md** — tabbed curl + Python quickstart; Python SDK row added to the "Explore the docs" table so the SDK is findable from the landing page.
- **api/quickstart.md** — every curl block now has a Python SDK tab beside it (prereqs, create agent, create session, stream, full scripted example).
- **api/streaming.md** — replaced the raw-requests Python example with three tabs: curl, Python (aod-sdk), Python (raw). The SDK tab is recommended; raw stays for dep-free consumers.
- **api/authentication.md** — Python tab showing \`AuthError\` handling beside the curl 401 example.

## Intentional skips (to keep scope tight)

- \`errors.md\`, \`pagination.md\`, \`concepts.md\`, \`product.md\` — HTTP-level reference; Python tabs don't add value.
- \`patterns/*\` — long pages with their own examples; worth a dedicated follow-up PR.

## Verification

- \`mkdocs build --strict\` — clean, no warnings.
- Tab rendering spot-checked in built HTML: streaming has 3 tabs, index has 2, quickstart has 5 tabbed blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)