### PR TITLE
Port patterns/*.md to aod-sdk

### DIFF
--- a/site/docs/patterns/batch-automation.md
+++ b/site/docs/patterns/batch-automation.md
@@ -4,86 +4,81 @@ You need to run the same agent task against many inputs at once — processing a
 list of files, generating content for a dataset, or applying automated fixes
 across multiple repositories.
 
+Python examples use the official [`aod-sdk`](../sdks/python.md) package
+(`pip install aod-sdk`).
+
 ## Shape of the solution
 
-Call `POST /sessions` for each item in your batch, run them concurrently with
-a semaphore to stay within your Sprites quota and API rate limits, poll or
-stream each session, then clean up when done.
+Call `client.sessions.create(...)` for each item in your batch, run them
+concurrently with a semaphore to stay within your Sprites quota and API rate
+limits, poll or stream each session, then clean up when done.
 
 Because each session runs in its own isolated Sprite, Agent on Demand handles parallelism
 naturally — the main challenge is staying within the concurrency limits of
-both Sprites and the underlying model runtime.
+both Sprites and the underlying model runtime. `AsyncClient` is the natural fit
+here: one client, many concurrent tasks.
 
 ## Example
 
 ```python
 import asyncio
-import httpx
-
 import os
 
-AOD_URL = os.environ["AOD_URL"]
-AOD_TOKEN = os.environ["AOD_TOKEN"]
+from aod import AodError, AsyncClient, ConflictError
+
 AGENT_ID = os.environ["AOD_AGENT_ID"]
 MAX_CONCURRENT = 5   # tune to your Sprites quota
 
-async def run_session(client: httpx.AsyncClient, prompt: str) -> str:
-    headers = {"Authorization": f"Bearer {AOD_TOKEN}"}
-
-    # Create session
-    r = await client.post(
-        f"{AOD_URL}/sessions",
-        json={"agent_id": AGENT_ID, "prompt": prompt, "timeout": 300},
-        headers=headers,
+async def run_session(client: AsyncClient, prompt: str) -> str:
+    ack = await client.sessions.create(
+        agent_id=AGENT_ID, prompt=prompt, timeout=300
     )
-    r.raise_for_status()
-    session_id = r.json()["id"]
+    session_id = str(ack.id)
 
     # Poll until terminal
     for _ in range(120):
         await asyncio.sleep(3)
-        status_r = await client.get(
-            f"{AOD_URL}/sessions/{session_id}", headers=headers
-        )
-        status_r.raise_for_status()
-        status = status_r.json()["status"]
-        if status in ("completed", "failed", "terminated"):
+        session = await client.sessions.get(session_id)
+        if session.status in ("completed", "failed", "terminated"):
             break
 
     # Collect output via SSE stream
-    output_lines = []
-    async with client.stream(
-        "GET",
-        f"{AOD_URL}/sessions/{session_id}/stream",
-        headers={**headers, "Accept": "text/event-stream"},
-        timeout=None,
-    ) as stream_r:
-        async for line in stream_r.aiter_lines():
-            if line.startswith("data: "):
-                output_lines.append(line[6:])
+    output_parts: list[str] = []
+    async with client.sessions.stream(session_id) as events:
+        async for event in events:
+            if event.type == "output" and event.extra.get("stream") == "stdout":
+                output_parts.append(event.extra.get("data", ""))
+            elif event.type in ("exit", "error", "terminated", "stale"):
+                break
 
     # Clean up session and Sprite
-    await client.request(
-        "DELETE",
-        f"{AOD_URL}/sessions/{session_id}/delete",
-        headers=headers,
-    )
+    try:
+        await client.sessions.delete(session_id)
+    except ConflictError:
+        pass  # already running/deleted — safe no-op
 
-    return "\n".join(output_lines)
+    return "".join(output_parts)
 
-async def batch(prompts: list[str]) -> list[str]:
+async def batch(prompts: list[str]) -> list[str | BaseException]:
     sem = asyncio.Semaphore(MAX_CONCURRENT)
-    async with httpx.AsyncClient(timeout=30) as client:
-        async def bounded(prompt):
+    async with AsyncClient() as client:  # reads AOD_API_URL + AOD_API_TOKEN
+        async def bounded(prompt: str) -> str:
             async with sem:
                 return await run_session(client, prompt)
-        return await asyncio.gather(*[bounded(p) for p in prompts])
+
+        return await asyncio.gather(
+            *[bounded(p) for p in prompts],
+            return_exceptions=True,   # one failure shouldn't cancel the batch
+        )
 
 if __name__ == "__main__":
     items = ["Summarise file A", "Summarise file B", "Summarise file C"]
     results = asyncio.run(batch(items))
     for prompt, result in zip(items, results):
-        print(f"--- {prompt} ---\n{result}\n")
+        if isinstance(result, BaseException):
+            print(f"--- {prompt} --- FAILED: {result!r}\n")
+        else:
+            print(f"--- {prompt} ---\n{result}\n")
 ```
 
 ## Handling stuck sessions
@@ -93,22 +88,20 @@ the underlying model times out. Add a hard deadline in your polling loop and
 terminate sessions that exceed it:
 
 ```python
-# Terminate a stuck session
-await client.post(
-    f"{AOD_URL}/sessions/{session_id}/terminate",
-    headers=headers,
-)
-```
+from aod import ConflictError
 
-`POST /sessions/{id}/terminate` returns `409` if the session is already
-terminated — treat that as a safe no-op.
+try:
+    await client.sessions.terminate(session_id)
+except ConflictError:
+    pass  # already terminated — safe no-op
+```
 
 ## Trade-offs
 
 | | |
 |---|---|
-| **Semaphore** | Controls in-flight sessions; set `MAX_CONCURRENT` based on your Sprites plan and model rate limits. |
-| **Polling vs streaming** | Polling (`GET /sessions/{id}`) is simpler for batch; streaming is better when you want incremental output. |
-| **Cleanup** | Always call `DELETE /sessions/{id}/delete` after processing — terminated Sprites still count against your quota until deleted. |
-| **Error handling** | `asyncio.gather` with `return_exceptions=True` prevents one failure from cancelling the whole batch. |
+| **Semaphore** | Controls in-flight sessions; set `MAX_CONCURRENT` based on your Sprites plan and model rate limits. The server also enforces a per-user cap — overshoot raises `RateLimitError` (`.limit`, `.active`). |
+| **Polling vs streaming** | `client.sessions.get(id).status` is simpler for batch; streaming is better when you want incremental output. |
+| **Cleanup** | Always call `client.sessions.delete(id)` after processing — terminated Sprites still count against your quota until the session row is gone. |
+| **Error handling** | `asyncio.gather(..., return_exceptions=True)` prevents one failure from cancelling the whole batch. Errors come back as `AodError` subclasses. |
 | **Cost** | Each session creates and runs a Sprite — budget per-item before launching large batches. |

--- a/site/docs/patterns/chat-bot.md
+++ b/site/docs/patterns/chat-bot.md
@@ -3,68 +3,44 @@
 You want users to converse with an AI agent through Slack, Discord, or an
 internal chat tool — with each message in a thread continuing the same session.
 
+Python examples use the official [`aod-sdk`](../sdks/python.md) package
+(`pip install aod-sdk`).
+
 ## Shape of the solution
 
 Map **one chat thread → one Agent on Demand session**. On the first message in a thread,
-call `POST /sessions` to create a session and store the returned `id` alongside
-the thread ID in your bot's storage. On every subsequent message in that thread,
-call `POST /sessions/{id}/prompt` — Agent on Demand resumes the same Sprite, so the agent
-has full context of the prior conversation.
+call `client.sessions.create(...)` and store the returned `id` alongside the
+thread ID in your bot's storage. On every subsequent message in that thread,
+call `client.sessions.prompt(session_id, ...)` — Agent on Demand resumes the
+same Sprite, so the agent has full context of the prior conversation.
 
 Stream the agent's response back to the thread via
-`GET /sessions/{id}/stream`.
+`client.sessions.stream(session_id)`.
 
 ## Example (Slack)
 
 ```python
-import httpx
+import os
+from aod import Client, ConflictError
 from slack_bolt import App
 
-import os
-
 app = App(token=os.environ["SLACK_BOT_TOKEN"])
-AOD_URL = os.environ["AOD_URL"]
-AOD_TOKEN = os.environ["AOD_TOKEN"]
 AGENT_ID = os.environ["AOD_AGENT_ID"]
+client = Client()  # reads AOD_API_URL + AOD_API_TOKEN
 
 # Simple in-memory store; use Redis/DB in production
 thread_sessions: dict[str, str] = {}
 
-def api_headers():
-    return {"Authorization": f"Bearer {AOD_TOKEN}"}
-
-def create_session(prompt: str) -> str:
-    r = httpx.post(
-        f"{AOD_URL}/sessions",
-        json={"agent_id": AGENT_ID, "prompt": prompt},
-        headers=api_headers(),
-        timeout=30,
-    )
-    r.raise_for_status()
-    return r.json()["id"]
-
-def send_prompt(session_id: str, prompt: str) -> str:
-    r = httpx.post(
-        f"{AOD_URL}/sessions/{session_id}/prompt",
-        json={"prompt": prompt},
-        headers=api_headers(),
-        timeout=30,
-    )
-    r.raise_for_status()
-    return r.json()["id"]
-
-def collect_output(session_id: str) -> str:
-    lines = []
-    with httpx.stream(
-        "GET",
-        f"{AOD_URL}/sessions/{session_id}/stream",
-        headers={**api_headers(), "Accept": "text/event-stream"},
-        timeout=None,
-    ) as r:
-        for line in r.iter_lines():
-            if line.startswith("data: "):
-                lines.append(line[6:])
-    return "\n".join(lines)
+def run_turn(session_id: str) -> str:
+    """Collect all output for one turn into a single reply string."""
+    parts: list[str] = []
+    with client.sessions.stream(session_id) as events:
+        for event in events:
+            if event.type == "output" and event.extra.get("stream") == "stdout":
+                parts.append(event.extra.get("data", ""))
+            elif event.type in ("exit", "error", "terminated", "stale"):
+                break
+    return "".join(parts)
 
 @app.event("app_mention")
 def handle_mention(event, say):
@@ -72,13 +48,19 @@ def handle_mention(event, say):
     prompt = event["text"]
 
     if thread_ts not in thread_sessions:
-        session_id = create_session(prompt)
-        thread_sessions[thread_ts] = session_id
+        ack = client.sessions.create(agent_id=AGENT_ID, prompt=prompt)
+        thread_sessions[thread_ts] = str(ack.id)
     else:
         session_id = thread_sessions[thread_ts]
-        send_prompt(session_id, prompt)
+        try:
+            client.sessions.prompt(session_id, prompt=prompt)
+        except ConflictError:
+            # 409: session is already running (user typed quickly).
+            # Queue this message or tell the user to wait.
+            say(text="Still working on the previous message…", thread_ts=thread_ts)
+            return
 
-    output = collect_output(session_id)
+    output = run_turn(thread_sessions[thread_ts])
     say(text=output, thread_ts=thread_ts)
 ```
 
@@ -87,7 +69,7 @@ def handle_mention(event, say):
 | | |
 |---|---|
 | **Stateful threads** | Agent on Demand holds the session state; your bot only stores the `session_id` mapping. |
-| **Multi-turn** | `POST /sessions/{id}/prompt` re-enters the Sprite — the agent sees previous output. |
-| **Session lifetime** | Sprites are long-lived within a session; terminate (`POST /sessions/{id}/terminate`) when the thread is archived or idle. |
-| **Concurrency** | `POST /sessions/{id}/prompt` returns `409` if the session is already running — queue incoming messages per thread if users type quickly. |
+| **Multi-turn** | `client.sessions.prompt(id, prompt=...)` re-enters the Sprite — the agent sees previous output. |
+| **Session lifetime** | Sprites are long-lived within a session; call `client.sessions.terminate(id)` when the thread is archived or idle. |
+| **Concurrency** | `prompt()` raises `ConflictError` (HTTP 409) if the session is already running — queue incoming messages per thread if users type quickly. |
 | **Storage** | In production, persist the `thread_ts → session_id` map in Redis or a database so it survives bot restarts. |

--- a/site/docs/patterns/ci-bot.md
+++ b/site/docs/patterns/ci-bot.md
@@ -14,6 +14,10 @@ CI runs are short-lived and stateless, so prefer single-shot sessions over
 multi-turn. You don't need to call `POST /sessions/{id}/prompt` or manage
 session continuations.
 
+Teams that already use Python in CI can run the same flow through
+[`aod-sdk`](../sdks/python.md) — see the [CLI Wrapper](cli-wrapper.md) pattern
+for an SDK-based equivalent.
+
 ## Example (GitHub Actions)
 
 ```yaml

--- a/site/docs/patterns/cli-wrapper.md
+++ b/site/docs/patterns/cli-wrapper.md
@@ -3,15 +3,18 @@
 Your team needs a one-liner that kicks off an AI coding task without opening a
 browser or writing HTTP boilerplate.
 
+Python examples use the official [`aod-sdk`](../sdks/python.md) package
+(`pip install aod-sdk`).
+
 ## Shape of the solution
 
-Wrap Agent on Demand in a thin CLI that creates a session via `POST /sessions`, then opens
-the SSE stream at `GET /sessions/{id}/stream` and prints each event to the
+Wrap Agent on Demand in a thin CLI that creates a session via `client.sessions.create(...)`, then opens
+the SSE stream with `client.sessions.stream(session_id)` and prints each event to the
 terminal. The user gets a familiar `mytool code "<prompt>"` interface backed by
 a real agent session.
 
 Because Agent on Demand tracks session state, the CLI can also support follow-up prompts
-(`POST /sessions/{id}/prompt`) — but the simplest starting point is
+via `client.sessions.prompt(session_id, ...)` — but the simplest starting point is
 single-shot: create → stream → exit.
 
 ## Example
@@ -19,65 +22,58 @@ single-shot: create → stream → exit.
 ```python
 #!/usr/bin/env python3
 """mytool code <prompt> — run an Agent on Demand session and stream output."""
-import sys
-import httpx
-
 import os
+import sys
 
-AOD_URL = os.environ["AOD_URL"]        # e.g. https://aod.example
-AOD_TOKEN = os.environ["AOD_TOKEN"]    # aod_...
+from aod import Client
+
 AGENT_ID = os.environ["AOD_AGENT_ID"]  # your team's shared agent
 
-def main():
+def main() -> int:
     if len(sys.argv) < 2:
         print("usage: mytool code '<prompt>'", file=sys.stderr)
-        sys.exit(1)
+        return 1
 
     prompt = " ".join(sys.argv[1:])
-    headers = {"Authorization": f"Bearer {AOD_TOKEN}"}
 
-    # 1. Create session
-    resp = httpx.post(
-        f"{AOD_URL}/sessions",
-        json={"agent_id": AGENT_ID, "prompt": prompt},
-        headers=headers,
-        timeout=30,
-    )
-    resp.raise_for_status()
-    session = resp.json()
-    session_id = session["id"]
-    print(f"# session {session_id}", flush=True)
+    with Client() as client:  # reads AOD_API_URL + AOD_API_TOKEN
+        ack = client.sessions.create(agent_id=AGENT_ID, prompt=prompt)
+        print(f"# session {ack.id}", file=sys.stderr)
 
-    # 2. Stream output
-    with httpx.stream(
-        "GET",
-        f"{AOD_URL}/sessions/{session_id}/stream",
-        headers={**headers, "Accept": "text/event-stream"},
-        timeout=None,
-    ) as r:
-        r.raise_for_status()
-        for line in r.iter_lines():
-            if line.startswith("data: "):
-                payload = line[6:]
-                print(payload, flush=True)
+        with client.sessions.stream(ack.id) as events:
+            for event in events:
+                if event.type == "output":
+                    print(event.extra["data"], end="", flush=True)
+                elif event.type == "exit":
+                    return int(event.extra.get("code") or 0)
+                elif event.type in ("error", "terminated", "stale"):
+                    print(f"\n[{event.type}]", file=sys.stderr)
+                    return 1
+        return 1
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())
 ```
 
 Install it as a script entry point in your team's internal package, or just
 `chmod +x` and drop it on `$PATH`.
+
+A more complete reference — with a spinner, Claude stream-json formatting, and
+GitHub repo cloning — lives at
+[`examples/cli/`](https://github.com/ravi-hq/agent-on-demand/tree/main/examples/cli)
+in the repo.
 
 ## Trade-offs
 
 | | |
 |---|---|
 | **Simple** | No persistent state needed client-side — Agent on Demand holds the session. |
-| **Streamable** | SSE is plain text; the terminal gets output as it arrives. |
-| **Re-entrant** | Save `session_id` and call `POST /sessions/{id}/prompt` to continue. |
+| **Streamable** | `client.sessions.stream()` yields typed events as they arrive. |
+| **Re-entrant** | Save `session_id` and call `client.sessions.prompt(id, prompt=...)` to continue. |
 | **Long prompts** | For large diffs or file contents, pipe via stdin and pass as the prompt string. |
-| **Auth** | Store the token in `~/.config/mytool/token` or an env var — never hardcode it. |
+| **Auth** | Set `AOD_API_TOKEN` (or `~/.config/mytool/token`) — never hardcode it in source. |
 
-For teams that need richer output formatting (spinners, syntax highlighting),
-feed the SSE events through [Rich](https://github.com/Textualize/rich) before
+For richer output formatting, feed events through
+[`aod.pretty.claude.ClaudeFormatter`](../sdks/python.md#pretty-printing-claude-output)
+(for Claude runtimes) or [Rich](https://github.com/Textualize/rich) before
 printing.

--- a/site/docs/patterns/dashboard.md
+++ b/site/docs/patterns/dashboard.md
@@ -4,6 +4,9 @@ You want an internal web UI where multiple users can kick off and monitor Agent 
 sessions without each managing their own API token or knowing about the Agent on Demand
 API.
 
+Python examples use the official [`aod-sdk`](../sdks/python.md) package
+(`pip install aod-sdk`).
+
 ## Shape of the solution
 
 Your dashboard acts as an authenticated proxy between your users and Agent on Demand. Each
@@ -29,25 +32,16 @@ If you need per-user audit trails in Agent on Demand, create one Agent on Demand
 ## Listing sessions
 
 ```python
-import httpx
+from aod import Client, Session
 
-import os
+client = Client()  # reads AOD_API_URL + AOD_API_TOKEN
 
-AOD_URL = os.environ["AOD_URL"]
-AOD_TOKEN = os.environ["AOD_TOKEN"]
-
-def list_sessions() -> list[dict]:
-    r = httpx.get(
-        f"{AOD_URL}/sessions",
-        headers={"Authorization": f"Bearer {AOD_TOKEN}"},
-        timeout=10,
-    )
-    r.raise_for_status()
-    return r.json()["data"]   # list of session objects, ordered by created_at desc
+def list_sessions() -> list[Session]:
+    return client.sessions.list()  # newest first
 ```
 
-Each session object includes `id`, `status`, `runtime`, `created_at`,
-`updated_at`, and `resources`.
+Each `Session` is a typed pydantic model with `id`, `status`, `runtime`,
+`created_at`, `updated_at`, `resources`, `turn_count`, and `current_turn`.
 
 ## Streaming to the browser
 
@@ -56,26 +50,28 @@ Each session object includes `id`, `status`, `runtime`, `created_at`,
 browser with `Content-Type: text/event-stream`. The browser's `EventSource`
 connects to your route, not to Agent on Demand directly.
 
-**Option B — WebSocket relay:** Your backend opens the SSE stream from Agent on Demand,
-collects events, and pushes them to the browser over a WebSocket. Use this when
-your infrastructure doesn't support long-lived HTTP responses (e.g. behind an
-API gateway with a 30-second timeout).
+**Option B — WebSocket relay:** Your backend opens the SSE stream from Agent on Demand
+via `client.sessions.stream(id)` or `AsyncClient.sessions.stream(id)`, collects
+typed `StreamEvent` objects, and pushes them to the browser over a WebSocket.
+Use this when your infrastructure doesn't support long-lived HTTP responses
+(e.g. behind an API gateway with a 30-second timeout).
 
 ## Design notes
 
 - **Session ownership:** All sessions created with the same Agent on Demand token are
-  visible to `GET /sessions`. If you share one token across users, prefix
-  session prompts or use the `metadata` field on agents to tag sessions by
+  visible to `client.sessions.list()`. If you share one token across users, prefix
+  session prompts or use the agent's `metadata` field to tag sessions by
   user.
-- **Creating sessions:** `POST /sessions` requires `agent_id` — create one
-  named agent per task type (e.g. "code-review", "doc-gen") and let the
-  dashboard UI pick the right one.
+- **Creating sessions:** `client.sessions.create(agent_id=..., prompt=...)`
+  requires `agent_id` — create one named agent per task type (e.g.
+  "code-review", "doc-gen") and let the dashboard UI pick the right one.
 - **Termination:** Provide a "Stop" button that calls
-  `POST /sessions/{id}/terminate`. Agent on Demand returns a `409` if the session is
-  already terminated — handle it gracefully.
+  `client.sessions.terminate(session_id)`. Already-terminated sessions raise
+  `ConflictError` (HTTP 409) — handle it gracefully.
 - **Cleanup:** Implement a retention policy: call
-  `DELETE /sessions/{id}/delete` on sessions older than your threshold.
-  Sessions cannot be deleted while `status == "running"`.
+  `client.sessions.delete(session_id)` on sessions older than your threshold.
+  Sessions cannot be deleted while `status == "running"` — attempting to
+  raises `ConflictError`.
 
 ## Trade-offs
 
@@ -84,4 +80,4 @@ API gateway with a 30-second timeout).
 | **Token isolation** | A single service token simplifies ops but loses per-user audit trails in Agent on Demand. |
 | **SSE proxy** | Straightforward, but requires long-lived connections — check your load balancer timeout settings. |
 | **WebSocket relay** | More complex but works anywhere; lets you add server-side filtering or enrichment. |
-| **Session listing** | `GET /sessions` returns all sessions for the token, newest first — add client-side filtering for large result sets. |
+| **Session listing** | `client.sessions.list()` returns all sessions for the token, newest first — add client-side filtering for large result sets. |


### PR DESCRIPTION
Follow-up to #90. Applies the SDK-first treatment to the \`patterns/*.md\` pages.

**Depends on #90** (based on \`docs/add-python-sdk-references\` for link integrity). Rebase onto main after #90 merges.

## Per-page changes

Existing Python examples built on raw \`httpx\`; four of them are now rewritten on \`aod-sdk\`. \`ci-bot.md\` is intentionally left as bash + curl — see below.

| Page | Change |
|------|--------|
| \`cli-wrapper.md\` | Thin SDK-based CLI; points at \`examples/cli/\` for the full-featured version. |
| \`chat-bot.md\` | Slack bot on \`Client\`; \`ConflictError\` for the 409 concurrent-typing case. |
| \`dashboard.md\` | \`client.sessions.list()\` returns typed \`Session\`; notes use SDK method names. |
| \`batch-automation.md\` | Rewritten on \`AsyncClient\` — proper showcase for concurrent sessions, typed errors, \`asyncio.gather(return_exceptions=True)\`. |
| \`ci-bot.md\` | **Left as bash + curl.** GitHub Actions is a bash-native context; forcing Python (setup-python + pip install + heredoc) adds ceremony without clarity. Added a one-line pointer to the CLI Wrapper pattern for teams that want the SDK flow in Python CI. |

Each updated page gets a one-line "Python examples use \`aod-sdk\`" note linking to \`sdks/python.md\`.

## Verification

\`mkdocs build --strict\` — clean, no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)