### PR TITLE
Add runnable examples for batch / chat-bot / dashboard patterns

### DIFF
--- a/examples/batch-automation/README.md
+++ b/examples/batch-automation/README.md
@@ -1,0 +1,69 @@
+# batch-automation
+
+Run one agent prompt per line against Agent on Demand, concurrently. Reads
+prompts from a file or stdin, creates a session per prompt (capped by a
+semaphore), streams each one's output, and prints results to stdout as
+`--- <prompt> ---\n<output>` blocks.
+
+Built on [`aod-sdk`](../../clients/python/)'s async client. See the
+[Batch Automation pattern](../../site/docs/patterns/batch-automation.md) for the
+full write-up.
+
+## Install
+
+```bash
+pip install aod-sdk
+```
+
+Python 3.11+ required.
+
+## Configure
+
+| Variable | Required | Default | What it does |
+|---|---|---|---|
+| `AOD_API_URL` | yes | — | Deployment URL, e.g. `https://aod.example` |
+| `AOD_API_TOKEN` | yes | — | Bearer token (`aod_...`) |
+| `AOD_AGENT_ID` | yes | — | Agent to run each prompt against |
+| `AOD_MAX_CONCURRENT` | no | `5` | Cap on in-flight sessions |
+| `AOD_TIMEOUT` | no | `300` | Per-session timeout (seconds) |
+| `AOD_POLL_INTERVAL` | no | `3` | Seconds between status polls |
+| `AOD_POLL_ATTEMPTS` | no | `120` | Max polls before giving up |
+
+## Run
+
+```bash
+# From a file
+./batch.py prompts.sample.txt
+
+# From stdin
+./batch.py < prompts.sample.txt
+printf 'task a\ntask b\n' | ./batch.py
+```
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| `0` | All prompts succeeded |
+| `1` | No prompts to run (empty input) |
+| `2` | At least one prompt failed — failed blocks are labeled `FAILED: <repr>` |
+
+## What to look at
+
+- `batch.py:run_one` — per-session flow: create → poll → stream stdout → delete.
+- `batch.py:batch` — concurrency loop with `asyncio.Semaphore` and
+  `asyncio.gather(return_exceptions=True)` so one failure doesn't cancel the batch.
+- `batch.py:_drain_stdout` — the SDK's `StreamEvent` iterator makes SSE
+  reading a four-line loop.
+
+## Production notes
+
+This is an example — simple on purpose. For real pipelines:
+
+- Replace stdin with a queue (SQS, Redis Streams, etc.) so work survives
+  restarts.
+- Persist results instead of printing them — one row per (prompt, output).
+- Wrap the inner retry loop around `RateLimitError` (HTTP 429); the server
+  returns `.limit` and `.active` so you can back off precisely.
+- Tune `AOD_MAX_CONCURRENT` to your Sprites quota and the underlying model's
+  rate limit — whichever is tighter.

--- a/examples/batch-automation/batch.py
+++ b/examples/batch-automation/batch.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""batch.py — run one agent prompt per line against Agent on Demand, concurrently.
+
+Reads prompts from a file (one per line) or stdin, creates a session per prompt
+capped at AOD_MAX_CONCURRENT, collects each session's stdout via SSE, deletes
+the session, and prints the results to stdout as `--- <prompt> ---\\n<output>`.
+
+Usage:
+    ./batch.py prompts.txt
+    ./batch.py < prompts.txt
+    printf 'summarize file a\\nsummarize file b\\n' | ./batch.py
+
+Required env vars:
+    AOD_API_URL, AOD_API_TOKEN    (read by aod.AsyncClient())
+    AOD_AGENT_ID                   agent to run each prompt against
+Optional:
+    AOD_MAX_CONCURRENT   default 5 — cap in-flight sessions
+    AOD_TIMEOUT          default 300 — per-session timeout (seconds)
+    AOD_POLL_INTERVAL    default 3 — seconds between status polls
+    AOD_POLL_ATTEMPTS    default 120 — max polls before giving up
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from aod import AodError, AsyncClient, ConflictError
+
+AGENT_ID = os.environ["AOD_AGENT_ID"]
+MAX_CONCURRENT = int(os.environ.get("AOD_MAX_CONCURRENT", "5"))
+TIMEOUT = int(os.environ.get("AOD_TIMEOUT", "300"))
+POLL_INTERVAL = float(os.environ.get("AOD_POLL_INTERVAL", "3"))
+POLL_ATTEMPTS = int(os.environ.get("AOD_POLL_ATTEMPTS", "120"))
+
+_TERMINAL = {"completed", "failed", "terminated"}
+
+
+async def _wait_terminal(client: AsyncClient, session_id: str) -> str:
+    """Poll until the session reaches a terminal status or attempts run out."""
+    for _ in range(POLL_ATTEMPTS):
+        await asyncio.sleep(POLL_INTERVAL)
+        session = await client.sessions.get(session_id)
+        if session.status in _TERMINAL:
+            return session.status
+    # Caller treats "unknown" as non-fatal and still tries to drain the stream.
+    return "unknown"
+
+
+async def _drain_stdout(client: AsyncClient, session_id: str) -> str:
+    parts: list[str] = []
+    async with client.sessions.stream(session_id) as events:
+        async for event in events:
+            if event.type == "output" and event.extra.get("stream") == "stdout":
+                parts.append(event.extra.get("data", ""))
+            elif event.type in ("exit", "error", "terminated", "stale"):
+                break
+    return "".join(parts)
+
+
+async def run_one(client: AsyncClient, prompt: str) -> str:
+    ack = await client.sessions.create(agent_id=AGENT_ID, prompt=prompt, timeout=TIMEOUT)
+    session_id = str(ack.id)
+    try:
+        await _wait_terminal(client, session_id)
+        return await _drain_stdout(client, session_id)
+    finally:
+        try:
+            await client.sessions.delete(session_id)
+        except (ConflictError, AodError):
+            # Already running/deleted, or transient — examples shouldn't
+            # block cleanup on best-effort teardown.
+            pass
+
+
+async def batch(prompts: list[str]) -> list[str | BaseException]:
+    sem = asyncio.Semaphore(MAX_CONCURRENT)
+    async with AsyncClient() as client:
+
+        async def bounded(prompt: str) -> str:
+            async with sem:
+                return await run_one(client, prompt)
+
+        return await asyncio.gather(
+            *(bounded(p) for p in prompts),
+            return_exceptions=True,
+        )
+
+
+def _read_prompts(argv: list[str]) -> list[str]:
+    if len(argv) > 1:
+        text = Path(argv[1]).read_text()
+    else:
+        text = sys.stdin.read()
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def main() -> int:
+    prompts = _read_prompts(sys.argv)
+    if not prompts:
+        print("no prompts to run (pass a file or pipe via stdin)", file=sys.stderr)
+        return 1
+    print(f"# running {len(prompts)} prompts, max {MAX_CONCURRENT} concurrent", file=sys.stderr)
+
+    results = asyncio.run(batch(prompts))
+
+    failures = 0
+    for prompt, result in zip(prompts, results):
+        print(f"--- {prompt} ---")
+        if isinstance(result, BaseException):
+            failures += 1
+            print(f"FAILED: {result!r}")
+        else:
+            print(result)
+        print()
+
+    if failures:
+        print(f"# {failures}/{len(prompts)} prompts failed", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/batch-automation/prompts.sample.txt
+++ b/examples/batch-automation/prompts.sample.txt
@@ -1,0 +1,3 @@
+Summarise the README in /workspace in two sentences.
+List the top-level files in /workspace and describe what each one does in one line.
+What programming language and framework does this project use? Answer in one line.

--- a/examples/chat-bot/README.md
+++ b/examples/chat-bot/README.md
@@ -1,0 +1,82 @@
+# chat-bot
+
+A Slack bot that maps **one thread → one Agent on Demand session**. The first
+message in a thread creates a session; every subsequent message resumes it
+(same Sprite, same filesystem, same agent memory).
+
+Built on [`aod-sdk`](../../clients/python/) and
+[`slack-bolt`](https://slack.dev/bolt-python/concepts). See the
+[Chat Bot pattern](../../site/docs/patterns/chat-bot.md) for the full write-up.
+
+## Install
+
+```bash
+pip install aod-sdk slack-bolt
+```
+
+Python 3.11+ required.
+
+## Slack app setup
+
+You need a Slack app in **socket mode** so the bot doesn't need a public URL.
+
+1. Create an app at <https://api.slack.com/apps>.
+2. **Socket Mode** → enable. Generate an app-level token with scope
+   `connections:write` — this is your `SLACK_APP_TOKEN` (`xapp-...`).
+3. **OAuth & Permissions** → add bot scopes: `app_mentions:read`,
+   `chat:write`. Install to your workspace; copy the Bot User OAuth Token —
+   this is your `SLACK_BOT_TOKEN` (`xoxb-...`).
+4. **Event Subscriptions** → enable events and subscribe to `app_mention`.
+5. Invite the bot to the channel(s) where you want it: `/invite @your-bot`.
+
+## Configure
+
+| Variable | Required | What it does |
+|---|---|---|
+| `SLACK_BOT_TOKEN` | yes | `xoxb-...` — bot's OAuth token |
+| `SLACK_APP_TOKEN` | yes | `xapp-...` — app-level token for socket mode |
+| `AOD_API_URL` | yes | Deployment URL |
+| `AOD_API_TOKEN` | yes | `aod_...` |
+| `AOD_AGENT_ID` | yes | Agent used for every thread |
+
+## Run
+
+```bash
+./bot.py
+# 2026-04-22 ... INFO connecting to Slack in socket mode…
+```
+
+Then in Slack:
+
+```
+@your-bot hello, what's in /workspace?
+# Bot replies in-thread. Continue the conversation with follow-up mentions
+# in the same thread — those resume the same session.
+```
+
+## What to look at
+
+- `bot.py:on_mention` — the whole lifecycle: first message creates a session
+  via `client.sessions.create(...)`, subsequent messages resume via
+  `client.sessions.prompt(...)`.
+- `bot.py:_drain_stdout` — `client.sessions.stream(session_id)` is a context
+  manager yielding typed `StreamEvent`s. The bot collects stdout until a
+  terminal event and posts the result back to the thread.
+- `ConflictError` handling — if a user fires off a second message before the
+  first one finishes, `prompt()` raises `ConflictError` (HTTP 409). The bot
+  posts a short "still working" reply; a production implementation would
+  enqueue messages per thread.
+
+## Production notes
+
+- **Storage.** `thread_sessions` is an in-memory dict; it disappears on
+  restart. Persist to Redis, Postgres, or SQLite so threads survive deploys.
+- **Long replies.** Slack's `chat.postMessage` caps a block at ~3000
+  characters. For longer agent output, chunk the reply or post a snippet.
+- **Session lifetime.** Sprites aren't free. Call
+  `client.sessions.terminate(id)` when a thread goes idle (cron the bot or
+  track last-activity per thread).
+- **Streaming to Slack.** Slack doesn't support true streaming; this bot
+  waits for the terminal event and posts once. For a "typing…" UX, use
+  [`chat.update`](https://api.slack.com/methods/chat.update) to edit the
+  message as new `output` events arrive.

--- a/examples/chat-bot/bot.py
+++ b/examples/chat-bot/bot.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""bot.py — a Slack bot that runs Agent on Demand sessions per thread.
+
+One thread → one session. The first message in a thread creates a session;
+every subsequent message in the thread resumes it via
+`client.sessions.prompt(id, prompt=...)`, so the agent keeps full context
+across turns.
+
+Run with Slack's socket mode so the bot doesn't need a public URL.
+
+Required env vars:
+    SLACK_BOT_TOKEN    xoxb-... (from your Slack app's OAuth page)
+    SLACK_APP_TOKEN    xapp-... (from the App-Level Tokens section, needs
+                       `connections:write` scope for socket mode)
+    AOD_API_URL        Deployment URL
+    AOD_API_TOKEN      aod_... token
+    AOD_AGENT_ID       Agent that handles messages in every thread
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from aod import AodError, Client, ConflictError
+from slack_bolt import App
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("chat-bot")
+
+AGENT_ID = os.environ["AOD_AGENT_ID"]
+
+app = App(token=os.environ["SLACK_BOT_TOKEN"])
+client = Client()  # reads AOD_API_URL + AOD_API_TOKEN
+
+# Simple in-memory store; use Redis/DB in production so restarts don't drop state.
+thread_sessions: dict[str, str] = {}
+
+
+def _drain_stdout(session_id: str) -> str:
+    """Block until the session reaches a terminal event, returning stdout joined."""
+    parts: list[str] = []
+    with client.sessions.stream(session_id) as events:
+        for event in events:
+            if event.type == "output" and event.extra.get("stream") == "stdout":
+                parts.append(event.extra.get("data", ""))
+            elif event.type in ("exit", "error", "terminated", "stale"):
+                break
+    text = "".join(parts).strip()
+    return text or "_(no output)_"
+
+
+@app.event("app_mention")
+def on_mention(event: dict, say) -> None:
+    thread_ts = event.get("thread_ts") or event["ts"]
+    # Strip the @bot mention from the prompt — Slack includes it verbatim.
+    prompt = event["text"].split(">", 1)[-1].strip() or "(no prompt)"
+
+    try:
+        if thread_ts not in thread_sessions:
+            ack = client.sessions.create(agent_id=AGENT_ID, prompt=prompt)
+            thread_sessions[thread_ts] = str(ack.id)
+            log.info("new session %s for thread %s", ack.id, thread_ts)
+        else:
+            session_id = thread_sessions[thread_ts]
+            try:
+                client.sessions.prompt(session_id, prompt=prompt)
+                log.info("resumed session %s for thread %s", session_id, thread_ts)
+            except ConflictError:
+                # 409: session is running (user typed during a reply).
+                # Simple strategy: tell the user; robust strategy: enqueue.
+                say(text="Still working on the previous message…", thread_ts=thread_ts)
+                return
+
+        reply = _drain_stdout(thread_sessions[thread_ts])
+    except AodError as e:
+        log.exception("aod error")
+        say(text=f":warning: agent error: {e}", thread_ts=thread_ts)
+        return
+
+    say(text=reply, thread_ts=thread_ts)
+
+
+if __name__ == "__main__":
+    handler = SocketModeHandler(app, os.environ["SLACK_APP_TOKEN"])
+    log.info("connecting to Slack in socket mode…")
+    handler.start()

--- a/examples/dashboard/README.md
+++ b/examples/dashboard/README.md
@@ -1,0 +1,90 @@
+# dashboard
+
+A tiny internal dashboard that lets multiple users start and watch Agent on
+Demand sessions through a browser, without each user holding an AoD token.
+
+```
+┌─────────┐   HTTP   ┌──────────┐   aod-sdk    ┌──────────────────┐
+│ Browser │ ────────▶│ FastAPI  │ ────────────▶│ Agent on Demand  │
+│         │◀──SSE────│ (this)   │◀──SSE────────│                  │
+└─────────┘          └──────────┘              └──────────────────┘
+```
+
+The dashboard uses a **single service token** for all outbound calls. Your
+own auth layer (VPN, SSO proxy, reverse-proxy header auth, etc.) goes in
+front. See the [Internal Dashboard pattern](../../site/docs/patterns/dashboard.md)
+for the full write-up.
+
+## Install
+
+```bash
+pip install aod-sdk fastapi "uvicorn[standard]"
+```
+
+Python 3.11+ required.
+
+## Configure
+
+| Variable | Required | Default | What it does |
+|---|---|---|---|
+| `AOD_API_URL` | yes | — | Deployment URL |
+| `AOD_API_TOKEN` | yes | — | Service token (`aod_...`) used for all outbound calls |
+| `AOD_AGENT_ID` | yes | — | Shared agent — every dashboard user runs this one |
+| `PORT` | no | `8000` | uvicorn bind port |
+
+## Run
+
+```bash
+./app.py
+# INFO: Uvicorn running on http://0.0.0.0:8000
+```
+
+Open <http://localhost:8000>. Type a prompt, hit **Start**, and the output
+streams live into the log panel via a server-proxied `EventSource`.
+
+## Routes
+
+| Method | Path | Does |
+|---|---|---|
+| `GET`  | `/` | Dashboard HTML |
+| `POST` | `/api/sessions` | Create a session `{prompt}` → `{id, status}` |
+| `GET`  | `/api/sessions` | List sessions for the service token |
+| `POST` | `/api/sessions/{id}/terminate` | Stop a running session |
+| `GET`  | `/api/sessions/{id}/stream` | SSE proxy |
+
+## What to look at
+
+- `app.py:lifespan` — one `AsyncClient` for the process lifetime (reused
+  across requests). The client reads `AOD_API_URL` and `AOD_API_TOKEN`
+  from the environment.
+- `app.py:stream` — the SSE proxy. `client.sessions.stream(...)` is an
+  async context manager yielding typed `StreamEvent`s; we re-emit each
+  payload as a `data:` line so the browser's `EventSource` sees a
+  dashboard-native stream (the upstream AoD token never touches the
+  browser).
+- `app.py:terminate_session` — `ConflictError` (HTTP 409) from a
+  double-stop is treated as idempotent success, which matches the UX
+  expectation of the "Stop" button.
+- `templates/index.html` — standalone HTML; no build step, no JS
+  dependencies. The JS is one `EventSource` per active session, polling
+  `/api/sessions` every 5s for the session list.
+
+## Production notes
+
+- **Auth.** This example skips the authentication layer. In a real deploy:
+  (a) put it behind your SSO/VPN, or (b) add your own cookie/JWT middleware
+  that populates `request.state.user` before any `/api/*` route.
+- **Per-user audit.** A single service token means AoD sees all sessions
+  as "dashboard." If you need per-user attribution in AoD, create one
+  `aod_` token per user via `APIKey.create_key` and store the mapping in
+  your own DB, then pick the right client per request.
+- **Multiple agents.** Hardcoded to `AOD_AGENT_ID` for brevity. To let
+  users pick an agent, add `GET /api/agents` returning
+  `client.agents.list()`, and include `agent_id` in the start-session body.
+- **Session cleanup.** AoD keeps session rows forever. Run a cron job
+  that calls `client.sessions.delete(id)` on sessions older than your
+  retention threshold (sessions cannot be deleted while
+  `status == "running"`).
+- **Load balancer timeouts.** SSE needs long-lived connections. If your
+  LB defaults to 30s, either bump it or switch to the WebSocket relay
+  variant (documented in the pattern page).

--- a/examples/dashboard/app.py
+++ b/examples/dashboard/app.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""app.py — an internal dashboard that lets multiple users start and watch
+Agent on Demand sessions through a web UI, without each user holding an
+AoD token of their own.
+
+Shape:
+    Browser  ──HTTP─▶  FastAPI  ──aod-sdk──▶  Agent on Demand
+             ◀──SSE──             ◀──SSE────
+
+The dashboard uses a single service token (env `AOD_API_TOKEN`) for all
+outbound calls. Your own auth layer would sit in front — this example
+assumes the deployment is already behind a VPN, SSO proxy, or similar.
+
+Routes:
+    GET  /                          — dashboard HTML
+    POST /api/sessions              — start a session {prompt}
+    GET  /api/sessions              — list recent sessions (JSON)
+    POST /api/sessions/{id}/terminate
+    GET  /api/sessions/{id}/stream  — SSE proxy (re-streams /sessions/{id}/stream)
+
+Required env vars:
+    AOD_API_URL, AOD_API_TOKEN   (read by aod.AsyncClient)
+    AOD_AGENT_ID                  agent every dashboard user shares
+Optional:
+    PORT            default 8000 — uvicorn bind port
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from aod import AsyncClient, ConflictError, NotFoundError
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse, StreamingResponse
+from pydantic import BaseModel
+
+AGENT_ID = os.environ["AOD_AGENT_ID"]
+PORT = int(os.environ.get("PORT", "8000"))
+
+INDEX_HTML = Path(__file__).parent / "templates" / "index.html"
+
+
+@asynccontextmanager
+async def lifespan(app_: FastAPI) -> AsyncIterator[None]:
+    """Keep one AsyncClient for the app's lifetime instead of per-request."""
+    async with AsyncClient() as client:
+        app_.state.aod = client
+        yield
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+class StartSession(BaseModel):
+    prompt: str
+
+
+def _client(request: Request) -> AsyncClient:
+    return request.app.state.aod
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index() -> HTMLResponse:
+    return HTMLResponse(INDEX_HTML.read_text())
+
+
+@app.get("/api/sessions")
+async def list_sessions(request: Request) -> dict:
+    sessions = await _client(request).sessions.list()
+    return {
+        "data": [
+            {
+                "id": str(s.id),
+                "status": s.status,
+                "runtime": s.runtime,
+                "created_at": s.created_at.isoformat(),
+                "turn_count": s.turn_count,
+            }
+            for s in sessions
+        ]
+    }
+
+
+@app.post("/api/sessions", status_code=202)
+async def start_session(req: StartSession, request: Request) -> dict:
+    ack = await _client(request).sessions.create(agent_id=AGENT_ID, prompt=req.prompt)
+    return {"id": str(ack.id), "status": ack.status}
+
+
+@app.post("/api/sessions/{session_id}/terminate")
+async def terminate_session(session_id: str, request: Request) -> dict:
+    try:
+        ack = await _client(request).sessions.terminate(session_id)
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail="Session not found") from None
+    except ConflictError:
+        # Already terminal — idempotent success for the UI.
+        return {"id": session_id, "status": "terminated"}
+    return {"id": str(ack.id), "status": ack.status}
+
+
+@app.get("/api/sessions/{session_id}/stream")
+async def stream(session_id: str, request: Request) -> StreamingResponse:
+    """Proxy the upstream SSE stream straight through to the browser.
+
+    The browser's `EventSource` connects here, not to AoD directly — so the
+    AoD token never leaves the server.
+    """
+    client = _client(request)
+
+    async def generator() -> AsyncIterator[bytes]:
+        try:
+            async with client.sessions.stream(session_id) as events:
+                async for event in events:
+                    payload = {"type": event.type, "id": event.id, **event.extra}
+                    yield f"data: {json.dumps(payload)}\n\n".encode()
+        except NotFoundError:
+            yield b'data: {"type":"error","message":"session not found"}\n\n'
+
+    return StreamingResponse(
+        generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",  # disables Nginx response buffering
+        },
+    )
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("app:app", host="0.0.0.0", port=PORT, reload=False)

--- a/examples/dashboard/templates/index.html
+++ b/examples/dashboard/templates/index.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Agent on Demand — Dashboard</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+  body { max-width: 960px; margin: 2rem auto; padding: 0 1rem; line-height: 1.4; }
+  h1 { font-size: 1.3rem; margin-bottom: 0; }
+  .sub { color: #888; font-size: 0.9rem; margin-top: 0.2rem; }
+  form { display: flex; gap: 0.5rem; margin: 1rem 0; }
+  input, button { font: inherit; padding: 0.5rem 0.75rem; }
+  input { flex: 1; }
+  button { cursor: pointer; }
+  section { margin-top: 1.5rem; }
+  table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+  th, td { text-align: left; padding: 0.4rem 0.5rem; border-bottom: 1px solid rgba(128,128,128,0.2); }
+  th { font-weight: 600; color: #888; }
+  .pill { display: inline-block; padding: 0.1rem 0.5rem; border-radius: 0.5rem; font-size: 0.75rem; }
+  .pill-running  { background: #ffeb3b; color: #000; }
+  .pill-pending  { background: #90caf9; color: #000; }
+  .pill-completed{ background: #a5d6a7; color: #000; }
+  .pill-failed   { background: #ef9a9a; color: #000; }
+  .pill-terminated { background: #cfcfcf; color: #000; }
+  #log {
+    background: rgba(128,128,128,0.08);
+    padding: 1rem;
+    border-radius: 0.5rem;
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 0.85rem;
+    white-space: pre-wrap;
+    min-height: 10rem;
+    max-height: 28rem;
+    overflow-y: auto;
+  }
+  button.link { background: none; border: none; padding: 0; color: #2196f3; cursor: pointer; }
+</style>
+</head>
+<body>
+<h1>Agent on Demand — Dashboard</h1>
+<p class="sub">Single agent, one prompt per session. SSE is proxied through this server.</p>
+
+<form id="new-session">
+  <input id="prompt" placeholder="Prompt for the agent…" required autofocus />
+  <button type="submit">Start</button>
+</form>
+
+<section>
+  <table>
+    <thead>
+      <tr><th>status</th><th>id</th><th>runtime</th><th>turns</th><th>created</th><th></th></tr>
+    </thead>
+    <tbody id="sessions"></tbody>
+  </table>
+</section>
+
+<section>
+  <h2 style="font-size: 1rem; margin-bottom: 0.3rem;">Output <span id="active" class="sub"></span></h2>
+  <div id="log">Select a session above to stream its output here.</div>
+</section>
+
+<script>
+const $ = (id) => document.getElementById(id);
+const sessionsEl = $("sessions");
+const logEl = $("log");
+const activeEl = $("active");
+
+async function refreshSessions() {
+  const r = await fetch("/api/sessions");
+  const { data } = await r.json();
+  sessionsEl.innerHTML = data.map((s) => `
+    <tr>
+      <td><span class="pill pill-${s.status}">${s.status}</span></td>
+      <td><button class="link" onclick="streamSession('${s.id}')">${s.id.slice(0, 8)}…</button></td>
+      <td>${s.runtime ?? "—"}</td>
+      <td>${s.turn_count ?? 0}</td>
+      <td>${new Date(s.created_at).toLocaleTimeString()}</td>
+      <td>${s.status === "running" || s.status === "pending"
+            ? `<button onclick="terminate('${s.id}')">stop</button>`
+            : ""}</td>
+    </tr>`).join("");
+}
+
+let currentStream = null;
+
+function streamSession(id) {
+  if (currentStream) currentStream.close();
+  logEl.textContent = "";
+  activeEl.textContent = `· streaming ${id.slice(0, 8)}…`;
+  const es = new EventSource(`/api/sessions/${id}/stream`);
+  currentStream = es;
+  es.onmessage = (e) => {
+    const ev = JSON.parse(e.data);
+    if (ev.type === "output") {
+      logEl.textContent += ev.data ?? "";
+      logEl.scrollTop = logEl.scrollHeight;
+    } else if (ev.type === "stage") {
+      logEl.textContent += `\n[stage] ${ev.stage} ${ev.state}\n`;
+    } else if (["exit", "error", "terminated", "stale"].includes(ev.type)) {
+      logEl.textContent += `\n[${ev.type}]${ev.message ? " " + ev.message : ""}\n`;
+      es.close();
+      refreshSessions();
+    }
+  };
+  es.onerror = () => { es.close(); activeEl.textContent = "· stream disconnected"; };
+}
+
+async function terminate(id) {
+  await fetch(`/api/sessions/${id}/terminate`, { method: "POST" });
+  refreshSessions();
+}
+
+$("new-session").addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const prompt = $("prompt").value;
+  $("prompt").value = "";
+  const r = await fetch("/api/sessions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ prompt }),
+  });
+  const { id } = await r.json();
+  await refreshSessions();
+  streamSession(id);
+});
+
+refreshSessions();
+setInterval(refreshSessions, 5000);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Companion to the patterns docs: three full, runnable example implementations.

Skipped:
- **cli-wrapper** — \`examples/cli/\` already covers it.
- **ci-bot** — intentionally bash-native; lives in \`site/docs/patterns/ci-bot.md\` only.

## What lands

| Folder | Entry point | Extra deps | Notes |
|---|---|---|---|
| \`examples/batch-automation/\` | \`batch.py\` | none beyond \`aod-sdk\` | Reads prompts from stdin or a file; \`AsyncClient\` + \`asyncio.Semaphore\`; per-prompt create → poll → stream → delete; exit 2 if any prompt fails. Includes \`prompts.sample.txt\`. |
| \`examples/chat-bot/\` | \`bot.py\` | \`slack-bolt\` | Slack socket-mode; thread → session map (in-memory); \`ConflictError\` → friendly "still working" reply. README walks through Slack-app setup. |
| \`examples/dashboard/\` | \`app.py\` | \`fastapi\`, \`uvicorn[standard]\` | FastAPI + standalone \`templates/index.html\` with \`EventSource\`. Single service token; SSE proxy re-streams typed \`StreamEvent\`s as \`data:\` lines so the browser never sees the AoD token. |

Each folder follows the shape of \`examples/cli/\`: one entry point, a README with install/configure/run, no shared scaffolding.

## Verification

All three py_compile cleanly:

\`\`\`bash
for f in examples/batch-automation/batch.py examples/chat-bot/bot.py examples/dashboard/app.py; do
  python -m py_compile \"\$f\"
done
\`\`\`

Heavy-dep imports (\`slack-bolt\`, \`fastapi\`) aren't in the SDK venv; both files only call well-trodden \`aod-sdk\` APIs that the SDK's test suite covers, so bugs there would surface at runtime in a real Slack/browser rather than at import.

## Follow-up

The three pattern docs pages will get \"A complete example is at \`examples/<pattern>/\`\" links once **this PR** and **#91** both land — separate PR to avoid a doc/code rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)