### PR TITLE
Add goose / opencode runtime research + meta-runtime pattern notes

### DIFF
--- a/thoughts/research/2026-04-21-goose-runtime-support.md
+++ b/thoughts/research/2026-04-21-goose-runtime-support.md
@@ -1,0 +1,291 @@
+---
+date: 2026-04-21
+researcher: Claude Code (team-research skill)
+git_commit: 919a4d4fd679effee2099161911a3146aedc6a64
+branch: plans/provision-stage-events
+repository: ravi-hq/agent-on-demand
+topic: "Adding Goose (Block coding agent) as a runtime"
+tags: [research, team-research, runtimes, goose, provisioning]
+status: complete
+method: agent-team
+team_size: 4
+tracks: [runtime-abstraction, provisioning-surface, goose-cli, api-tests-surface]
+last_updated: 2026-04-21
+last_updated_by: Claude Code
+---
+
+# Research: Adding Goose (Block coding agent) as a runtime
+
+**Date**: 2026-04-21
+**Researcher**: Claude Code (team-research)
+**Git Commit**: [`919a4d4`](https://github.com/ravi-hq/agent-on-demand/commit/919a4d4fd679effee2099161911a3146aedc6a64)
+**Branch**: `plans/provision-stage-events`
+**Repository**: ravi-hq/agent-on-demand
+**Method**: Agent team (4 specialist researchers)
+
+## Research Question
+
+What does it take to add support for **Goose** (Block's open-source coding agent, https://github.com/block/goose) as a fourth runtime alongside the existing `claude`, `codex`, `gemini` runtimes?
+
+## Summary
+
+Mechanically, adding Goose is small: one entry in `RUNTIMES`, model entries in `AgentModel`/`MODEL_RUNTIME_MAP`, two short additions in `provisioning.py` (MCP writer + skills root), updates to a handful of tests and docs. The Goose CLI itself is friendly to headless use — `goose run --text "..." --output-format stream-json --mode auto --name <id>`, with `--resume` for continuation — and the install is a single curl script.
+
+**The hard part is architectural, not mechanical.** Goose is provider-agnostic: it pairs `GOOSE_PROVIDER` with `GOOSE_MODEL` and reads the provider's native API key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, …). Our current contract assumes one runtime → one model namespace → one `env_var` → one `UserRuntimeKey` row. Three concrete strain points fall out of that mismatch:
+
+1. **`RuntimeConfig.env_var` is singular**, but Goose needs at least two variables set at launch (provider key + provider/model selection).
+2. **`AgentModel` is a flat enum**, but Goose's identity is `(provider, model)`, so model strings have to encode both — the codex pattern (multiple model strings → one runtime) extends to Goose, just with more entries.
+3. **`tests/test_runtimes.py::test_each_runtime_has_unique_env_var`** asserts uniqueness of `env_var` across runtimes; if Goose-with-Anthropic uses `ANTHROPIC_API_KEY`, that assertion fires immediately — and so does the design question it's enforcing (do we want two different runtimes pulling from the same `UserRuntimeKey`?).
+
+Recommended path: restrict Goose to one provider per `Agent` row (encoded in the model string), reuse the provider's existing `UserRuntimeKey` (or namespace it as e.g. `goose-anthropic`), and decide explicitly whether `RuntimeConfig` grows a second-env-var slot or whether provider-fixed env vars (`GOOSE_PROVIDER`, `GOOSE_MODEL`) get inlined into `cmd` / sourced from a written `~/.config/goose/config.yaml`. The decision should be made before code lands.
+
+## Research Tracks
+
+### Track 1: Runtime abstraction contract
+**Researcher**: runtime-researcher
+**Scope**: `runtimes.py`, `session_service/{specs,tasks,provisioning}.py`, `models/{agents,sessions,auth}.py`
+
+#### Findings
+
+1. **`RuntimeConfig` is a four-field frozen dataclass** — `name`, `cmd`, `continue_cmd`, `env_var`. `cmd` and `continue_cmd` are **shell command strings** (not arg lists), executed via `bash -c` after the wrapper script `set -a; source /tmp/aod-env; set +a; PROMPT=$(cat); export PROMPT; exec <cmd>`. The runtime CLI must read `$PROMPT` from env (typically via `-p "$PROMPT"`) and exit 0 on success, non-zero on failure. ([`src/agent_on_demand/runtimes.py:48-53`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/runtimes.py#L48-L53), [`src/agent_on_demand/session_service/tasks.py:98-109`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/session_service/tasks.py#L98-L109))
+
+2. **`env_var` is singular — exactly one API key per runtime** — `_write_env_file` writes `{spec.runtime.env_var}={api_key}` as the first line of `/tmp/aod-env`, then `AOD_SESSION_ID`, then `Environment.env_vars`. The api_key value is fetched via `UserRuntimeKey.get_key_for(user, runtime)` (one encrypted row per user+runtime). There is **no slot for a second runtime-config-level variable** — anything else has to come through `Environment.env_vars` (user-managed) or by extending `RuntimeConfig` itself. ([`src/agent_on_demand/session_service/provisioning.py:122-139`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/session_service/provisioning.py#L122-L139), [`src/agent_on_demand/models/auth.py:50-81`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/models/auth.py#L50-L81))
+
+3. **`runtime_session_id` is a UUID generated server-side; per-runtime conventions vary** — `views/sessions.py:223` mints the UUID at create-time; `_write_env_file` exposes it as `AOD_SESSION_ID`. claude wires it as `--session-id` on turn 1 and `--resume <uuid>` thereafter; codex ignores it and uses `resume --last`; gemini uses `--resume` with no explicit ID. Goose's `--name <session_id>` plus `--resume` follows the claude pattern most closely. ([`src/agent_on_demand/runtimes.py:61-87`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/runtimes.py#L61-L87), [`src/agent_on_demand/views/sessions.py:223`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/views/sessions.py#L223))
+
+4. **`AgentModel` × `MODEL_RUNTIME_MAP` enforces an N:1 model→runtime mapping** — every `AgentModel` member appears in `MODEL_RUNTIME_MAP`, which resolves to a `RUNTIMES` key. The codex precedent (`gpt-4.1`, `o3`, `o4-mini` → `"codex"`) shows the existing way to handle one runtime CLI fronting multiple models; Goose's provider-agnosticism amplifies this — the model string has to encode both provider and model (e.g. `goose-claude-sonnet-4-6`) for the mapping to retain its current shape. ([`src/agent_on_demand/runtimes.py:5-45`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/runtimes.py#L5-L45))
+
+5. **No DB CHECK constraints — `runtime` choices are application-layer only** — `Agent.runtime` is `CharField(max_length=32, choices=...)`, `AgentSession.runtime` is a bare `CharField(max_length=32)`, `AgentVersion.runtime` likewise. Adding `"goose"` to `RUNTIMES` requires no migration for the session/version tables; the `Agent.runtime` choices update generates a cosmetic `AlterField` migration with no DB effect. ([`src/agent_on_demand/models/agents.py:18-19`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/models/agents.py#L18-L19), [`src/agent_on_demand/models/sessions.py:32`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/models/sessions.py#L32))
+
+6. **SSE stream is byte-for-byte passthrough — no per-runtime parsing** — `stream.py` yields `AgentSessionLog.data` verbatim; `tasks.py` writes whatever `TaggingQueueWriter` captures. claude/gemini's `stream-json`, codex's `--json`, and Goose's `stream-json` are all stored and re-emitted unchanged. The output format choice is a client-side concern, not a server contract. ([`src/agent_on_demand/stream.py:15-74`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/stream.py#L15-L74), [`src/agent_on_demand/session_service/tasks.py:401-419`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/session_service/tasks.py#L401-L419))
+
+### Track 2: Provisioning surface (install + per-runtime config)
+**Researcher**: provisioning-researcher
+**Scope**: `session_service/provisioning.py`, Sprite base image research, `models/environments.py`, `views/agents.py`
+
+#### Findings
+
+1. **All current CLIs are pre-baked into the Sprite image** — `thoughts/research/2026-04-15-sprites-platform-research.md:44-53` documents that every Sprite ships with Claude Code, Codex, and Gemini CLI pre-installed. There is no per-session install step in `provision_session`; `_install_packages` only handles user-specified `Environment.packages`. Goose is *not* in the base image today, so it needs either a new install stage or has to come in via `Environment.packages`/`setup_script`. ([`src/agent_on_demand/session_service/provisioning.py:142-157`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/session_service/provisioning.py#L142-L157))
+
+2. **MCP writer dispatches by runtime name; each format is hand-rolled** — `_write_mcp_config` at [`provisioning.py:227-238`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/session_service/provisioning.py#L227-L238) routes to `_write_mcp_claude` (`~/.claude.json`, JSON, `mcpServers` map), `_write_mcp_codex` (`~/.codex/config.toml`, TOML, special `bearer_token_env_var` handling for `Bearer ${ENV}` headers), or `_write_mcp_gemini` (`~/.gemini/settings.json`, JSON, uses `httpUrl` not `url`, all entries get `"trust": true`). Unknown runtimes silently no-op. Goose needs a new `_write_mcp_goose` branch.
+
+3. **`_SKILLS_ROOTS` is a per-runtime path table; `_write_skills` itself is generic** — Adding Goose to skills *would* require only a new dict entry in `_SKILLS_ROOTS`, but Goose's analogue ("recipes") is **YAML, not Markdown SKILL.md files** (see Track 3 finding 8) and requires explicit `--recipe <path>` at invocation rather than ambient discovery. The team-converged recommendation is to **omit `_SKILLS_ROOTS["goose"]` entirely for v1** — skills silently no-op via the existing `if root is None: return` guard. ([`src/agent_on_demand/session_service/provisioning.py:30-35,305-318`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/session_service/provisioning.py#L30-L35))
+
+4. **One precedent for runtime-specific config files beyond MCP**: `_write_mcp_codex` doubles as Codex's main config writer (it's the `~/.codex/config.toml` file). Goose would follow the same pattern with `~/.config/goose/config.yaml`, holding `GOOSE_PROVIDER`, `GOOSE_MODEL`, telemetry/keyring flags, and the `extensions:` block. ([`src/agent_on_demand/session_service/provisioning.py:258-282`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/session_service/provisioning.py#L258-L282))
+
+5. **Stage ordering: network policy applies before package installs** — `provision_session` runs `_apply_network_policy` → `_write_env_file` → `_install_packages` → `_clone_repos` → `_run_user_setup` → `_write_mcp_config` → `_write_skills`. If `networking_type=="limited"` and Goose needs to be downloaded, `github.com` (where the Goose release lives) must be in the allowed-hosts list, OR a Goose install stage must run before `_apply_network_policy`. ([`src/agent_on_demand/session_service/provisioning.py:65-72`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/session_service/provisioning.py#L65-L72))
+
+6. **API/view layer is runtime-agnostic for MCP and skills** — `_validate_mcp_servers` ([`views/agents.py:80-102`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/views/agents.py#L80-L102)) and skills validation ([`views/agents.py:42-77`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/views/agents.py#L42-L77)) don't branch on runtime. The only runtime touch in views is the membership check `runtime not in RUNTIMES` ([`views/agents.py:238,326`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/views/agents.py#L238) and [`views/sessions.py:204`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/views/sessions.py#L204)).
+
+### Track 3: Goose CLI external research
+**Researcher**: goose-cli-researcher
+**Scope**: Web research against block.github.io/goose, github.com/block/goose
+
+#### Findings
+
+1. **Install (Linux container)** — `sudo apt install -y bzip2 && curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash`. `CONFIGURE=false` skips interactive setup. `.deb` packages also available; no official Docker image. Pin via `releases/download/v1.31.1/download_cli.sh` for reproducible builds. (Source: https://goose-docs.ai/docs/getting-started/installation/)
+
+2. **Headless invocation** — `goose run --text "<prompt>" --output-format stream-json --mode auto --name <session_id>`. Prompt arrives via `--text/-t`, `--instructions/-i <file|->`, or `--system`. There is **no `-p` flag** — the existing `cmd` template style of `... -p "$PROMPT"` would become `... --text "$PROMPT"`. (Source: https://goose-docs.ai/docs/guides/goose-cli-commands/)
+
+3. **Session resume** — Goose persists sessions in a shared local DB; resume in a fresh process via `goose run --text "..." --resume --name <session_id>`. The caller can choose the session name via `--name`, so our existing `runtime_session_id` UUID slots in cleanly. Auto-assigned IDs follow `YYYYMMDD_<COUNT>` if `--name` is omitted. (Source: https://goose-docs.ai/docs/guides/sessions/session-management/)
+
+4. **Provider/model are independent and per-invocation** — `GOOSE_PROVIDER` and `GOOSE_MODEL` (env vars or CLI flags `--provider`/`--model`, or config.yaml entries). 15+ providers: anthropic, openai, google, ollama, openrouter, azure, bedrock, github_copilot, etc. **API keys are provider-standard — no `GOOSE_API_KEY`**. Anthropic backend reads `ANTHROPIC_API_KEY`; OpenAI reads `OPENAI_API_KEY`; etc. (Source: https://goose-docs.ai/docs/guides/config-files/, https://deepwiki.com/block/goose/2.2-provider-configuration)
+
+5. **Config file** — `~/.config/goose/config.yaml` (YAML, UPPERCASE keys mirroring env var names). For containers also set `GOOSE_DISABLE_KEYRING=1` so secrets fall back to `~/.config/goose/secrets.yaml` instead of an unavailable system keyring. (Source: https://goose-docs.ai/docs/guides/config-files/)
+
+6. **MCP = "extensions" under `extensions:` in config.yaml** — stdio entries use `type: stdio`, `cmd`, `args`, `envs`, `env_keys` (keyring lookups), `timeout`, `enabled`. Remote uses `type: streamable_http` with `uri` and `headers`. Built-ins use `type: builtin` with `bundled: true`. **No standalone mcp.json file** — all MCP config is inline in config.yaml, distinct from claude/codex/gemini's separate-file approach. (Source: https://deepwiki.com/block/goose/5.3-extension-types-and-configuration)
+
+7. **Output format** — `--output-format stream-json` emits ndjson events as they occur. `text` and `json` (post-completion) are also options. Schema differs from claude's stream-json (Goose-specific event types); since the server is byte-passthrough this only matters to clients. `-q/--quiet` suppresses non-response output. (Source: https://goose-docs.ai/docs/guides/goose-cli-commands/)
+
+8. **Recipes are the closest analogue to skills, but they're YAML** — Recipes have `version`, `title`, `description`, `instructions`, `parameters`, `extensions`, `sub_recipes`. Triggered with `goose run --recipe <name>`. They are **not free-form Markdown like SKILL.md** — our existing skills payload doesn't drop directly into a recipe. Either translate skill content into a recipe wrapper (instructions = skill body) or accept skills are no-op for Goose. (Source: https://goose-docs.ai/docs/guides/recipes/session-recipes/, https://github.com/block/goose/blob/main/recipe.yaml)
+
+9. **No `--dangerously-*` flag — use `--mode auto`** — Goose's mode system: `auto` (no approvals — equivalent to claude's `--dangerously-skip-permissions`), `approve`, `smart_approve` (default), `chat`. **Prefer `--mode auto` over `GOOSE_MODE=auto`** because of [issue #3386](https://github.com/block/goose/issues/3386) where the env var was ignored for some providers in v1.0.35.
+
+10. **Versioning** — Semver, `stable` tag in install URL tracks latest stable. Latest at time of research: **v1.31.1** (2026-04-20). Active weekly cadence; pin to a specific tag for reproducibility. (Source: https://github.com/block/goose/releases)
+
+#### Drop-in `RuntimeConfig` sketch (per Goose-CLI track)
+
+> Note: the team's own runtime-track and surface-track findings differ on the right shape — see Cross-Track Discoveries below. This is the *Goose-side* sketch; the system-side accommodation is open.
+
+```python
+# src/agent_on_demand/runtimes.py — illustrative, not final
+RUNTIMES["goose"] = RuntimeConfig(
+    name="goose",
+    cmd='goose run --text "$PROMPT" --output-format stream-json --mode auto --name "$AOD_SESSION_ID"',
+    continue_cmd='goose run --text "$PROMPT" --output-format stream-json --mode auto --name "$AOD_SESSION_ID" --resume',
+    env_var="ANTHROPIC_API_KEY",  # if locked to anthropic backend; see strain points
+)
+```
+
+Provider/model selection (`GOOSE_PROVIDER`, `GOOSE_MODEL`) and container hygiene (`GOOSE_DISABLE_KEYRING=1`, `GOOSE_TELEMETRY_ENABLED=false`) need to live somewhere — the cleanest place is a written `~/.config/goose/config.yaml`, which avoids changing `RuntimeConfig` to support multiple env vars.
+
+#### Goose `config.yaml` shape (per Goose-CLI track)
+
+```yaml
+GOOSE_PROVIDER: "anthropic"
+GOOSE_MODEL: "claude-sonnet-4-20250514"
+GOOSE_MODE: "auto"
+GOOSE_TELEMETRY_ENABLED: false
+GOOSE_DISABLE_KEYRING: true   # forces secrets.yaml — no system keyring in container
+
+extensions:
+  developer:
+    type: builtin
+    name: developer
+    bundled: true
+    enabled: true
+    timeout: 300
+  # MCP servers from agent.mcp_servers translated here
+```
+
+### Track 4: API, tests, and downstream surface impact
+**Researcher**: surface-researcher
+**Scope**: views, models, tests (unit + e2e), README/CLAUDE.md, ui/admin
+*(Task description was not preserved post-completion; findings are reproduced from the researcher's two summary messages.)*
+
+#### Findings
+
+1. **Runtime validation is centralized on `RUNTIMES`** — `RUNTIMES` dict at [`runtimes.py:56`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/runtimes.py#L56) is the only source of truth. `views/agents.py:238,326` and `views/sessions.py:204` both check `if req.runtime not in RUNTIMES`. Adding `"goose"` to the dict is the only change needed to pass validation.
+
+2. **`UserRuntimeKey` adapts without code changes** — `RUNTIME_CHOICES` is built dynamically from `RUNTIMES` at [`models/auth.py:51`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/models/auth.py#L51); `makemigrations` will generate a routine `AlterField` migration. The `unique_user_runtime` constraint at `models/auth.py:63` enforces one key per `(user, runtime)` pair — relevant to the Goose-multi-provider question (see Cross-Track Discoveries).
+
+3. **Test fixtures hardcode `"claude"` everywhere** — `tests/conftest.py:37`, `tests/test_api.py:67-84`, `tests/test_agents.py` all hardcode `runtime="claude"`. The fake sprites client (`tests/fakes/sprite.py`) is runtime-agnostic and needs no changes.
+
+4. **`tests/test_runtimes.py` has two assertions that will fire**:
+   - `test_runtimes.py:6` asserts `set(RUNTIMES) == {"claude", "codex", "gemini", "claude-oauth"}` — must add `"goose"`.
+   - `test_runtimes.py:63` `test_each_runtime_has_unique_env_var` — if Goose's `env_var="ANTHROPIC_API_KEY"`, this collides with claude. Either Goose gets a synthetic env_var that the provisioning layer rewrites, or this assertion gets relaxed.
+
+5. **E2E parameterization via `RUNTIME_MODELS` + `E2E_RUNTIMES`** — `tests/e2e/conftest.py:21-26` maps runtime → cheapest model. Adding Goose requires (a) a `RUNTIME_MODELS["goose"] = "..."` entry, (b) a seeded `UserRuntimeKey(runtime="goose")` row in the test deployment, and (c) `E2E_RUNTIMES` updated to include `"goose"`.
+
+6. **README runtime list at lines 66-76, 80-84, 116-117** — three explicit places list the supported runtimes; all need updating.
+
+7. **No UI/admin runtime dropdowns** beyond the choices Django auto-derives from `RUNTIMES`.
+
+#### Goose-specific schema implications (surface-track follow-up)
+
+Surfaced after seeing Track 3's findings; these are the architectural strain points:
+
+- **`AgentModel` enum must encode provider+model for Goose.** Two viable shapes: (A) compound model strings like `"goose/anthropic/claude-sonnet-4-5"` parsed in the provisioning layer, or (B) one `AgentModel` member per provider+model combination (more entries, no parsing). Either way `MODEL_RUNTIME_MAP` and `AgentModel.choices()` extend, and `CreateAgentRequest.validate_model` ([`views/agents.py:116-121`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/views/agents.py#L116-L121)) will reject any Goose model string not in `AgentModel.values()`.
+
+- **`UserRuntimeKey` is one-key-per-(user,runtime).** A single `"goose"` runtime row is ambiguous for a user who wants to use Goose with both Anthropic and OpenAI. Three shapes: (1) restrict each user's Goose to one provider (one key, encoded in the model string), (2) namespace runtime as `goose-anthropic`/`goose-openai`, (3) introduce a `provider` field on `UserRuntimeKey` (schema change). Option (1) is simplest; option (2) gives flexibility without schema change.
+
+- **`test_each_runtime_has_unique_env_var`** at `tests/test_runtimes.py:63` codifies the "one runtime ↔ one env_var" assumption. Whatever Goose strategy is chosen has to explicitly engage with this test.
+
+## Cross-Track Discoveries
+
+Findings that emerged from connections between tracks:
+
+- **The "single env_var" assumption ripples through 4 layers.** Track 1 found `RuntimeConfig.env_var` is singular; Track 3 confirmed Goose needs `GOOSE_PROVIDER` + `GOOSE_MODEL` + provider-native key; Track 2 noted `_write_mcp_codex` already writes a non-MCP config file (the codex pattern of "MCP writer doubles as runtime config writer"); Track 4 identified the test that codifies env_var uniqueness. **The path of least resistance**: write a `~/.config/goose/config.yaml` containing `GOOSE_PROVIDER`, `GOOSE_MODEL`, telemetry/keyring flags, and `extensions:` (combining what would otherwise be `_write_mcp_goose` + `_write_goose_config` into one writer, mirroring codex). Then `RuntimeConfig.env_var` only carries the provider's native API key, no contract change.
+
+- **Goose's "recipes" are YAML — our `SkillSpec.content` is Markdown.** `_write_skills` at `provisioning.py:305-318` writes `SKILL.md` files; that doesn't match Goose. Two options: (a) wrap the SKILL.md content as the `instructions:` field of a recipe YAML and write it under `~/.config/goose/recipes/<name>.yaml`, or (b) declare skills no-op for Goose for v1 and revisit. Option (a) is small but requires teaching `_write_skills` (or a `_write_recipes_goose` sibling) about runtime-specific serialization.
+
+- **Sprite image vs. install stage decision is forced by network policy.** Track 2's finding that `_apply_network_policy` runs before `_install_packages` means that if Goose is installed at provision-time AND the environment uses `networking_type="limited"`, the allowed-hosts list must include `github.com` (release host) and `objects.githubusercontent.com`. The cleanest fix is to bake Goose into the Sprite base image (out-of-band of this repo), eliminating the install stage entirely. Track 3 gives the install command; the question is who owns that change.
+
+- **Session-id semantics align cleanly.** Track 1 noted claude/gemini/codex have three different resume conventions; Track 3 confirmed Goose's `--name <id>` + `--resume` matches claude's pattern. The existing `runtime_session_id` UUID drops in as `--name "$AOD_SESSION_ID"` with no contract changes.
+
+## Code References
+
+| File | Tracks | Findings | Link |
+|------|--------|----------|------|
+| `src/agent_on_demand/runtimes.py:5-87` | 1, 4 | RuntimeConfig shape; AgentModel enum; MODEL_RUNTIME_MAP; RUNTIMES dict | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/runtimes.py#L5-L87) |
+| `src/agent_on_demand/session_service/tasks.py:98-109` | 1 | `build_turn_command` — wrapper script semantics | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/session_service/tasks.py#L98-L109) |
+| `src/agent_on_demand/session_service/provisioning.py:30-35` | 2 | `_SKILLS_ROOTS` — per-runtime skills dir | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/session_service/provisioning.py#L30-L35) |
+| `src/agent_on_demand/session_service/provisioning.py:122-139` | 1, 2 | `_write_env_file` — single-env-var injection | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/session_service/provisioning.py#L122-L139) |
+| `src/agent_on_demand/session_service/provisioning.py:227-302` | 2 | `_write_mcp_config` and per-runtime writers | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/session_service/provisioning.py#L227-L302) |
+| `src/agent_on_demand/models/agents.py:18-19` | 1, 4 | `Agent.model`/`Agent.runtime` field definitions | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/models/agents.py#L18-L19) |
+| `src/agent_on_demand/models/auth.py:50-81` | 1, 4 | `UserRuntimeKey` — one key per (user, runtime) | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/models/auth.py#L50-L81) |
+| `src/agent_on_demand/views/agents.py:80-102,116-121,238,326` | 4 | Runtime validation and model validation in views | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/views/agents.py#L80-L102) |
+| `src/agent_on_demand/views/sessions.py:204,223` | 1, 4 | Runtime guard + UUID generation | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/views/sessions.py#L204) |
+| `src/agent_on_demand/stream.py:15-74` | 1 | SSE replay — runtime-agnostic byte passthrough | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/stream.py#L15-L74) |
+| `tests/test_runtimes.py:6,63` | 4 | Set-equality + unique-env-var assertions to update | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/tests/test_runtimes.py#L6) |
+| `tests/e2e/conftest.py:21-26` | 4 | `RUNTIME_MODELS` + `E2E_RUNTIMES` parameterization | [permalink](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/tests/e2e/conftest.py#L21-L26) |
+
+## Architecture Insights
+
+- **Server is intentionally a dumb pipe between an HTTP request and a CLI on a Sprite.** No output parsing, no per-runtime business logic in views, no per-runtime DB constraints. The runtime contract is held in a single dataclass and a small dispatch table. This makes adding "another CLI" cheap mechanically; it also means the contract has to evolve when a new CLI doesn't match the implicit assumptions baked into the dataclass.
+
+- **The codex precedent is the right model for Goose.** Codex already has multiple `AgentModel` strings → one `RUNTIMES["codex"]`. Goose extends that to many more (provider × model combinations) and adds a richer config file, but it's the same shape.
+
+- **`provisioning.py` is the natural place for runtime-specific knowledge.** Views, tasks, and stream endpoints stay generic; per-runtime quirks live in `_write_mcp_<runtime>` and `_SKILLS_ROOTS`. Goose's `_write_goose_config` would fit alongside.
+
+- **The "stages" abstraction in `provision_session` is well-suited to the planned stage-events work** ([`thoughts/plans/2026-04-21-provision-stage-events.md`](thoughts/plans/2026-04-21-provision-stage-events.md)). A new "install_goose" stage would emit its own event automatically.
+
+## Historical Context
+
+- `thoughts/research/2026-04-15-sprites-platform-research.md` — confirms claude/codex/gemini are baked into the Sprite base image and explains "no install step needed for our target CLIs."
+- `thoughts/research/2026-04-18-session-backend-abstraction.md` — earlier thinking on runtime abstraction.
+- `thoughts/plans/2026-04-21-provision-stage-events.md` — the in-flight stage-events refactor that any new install stage would integrate with.
+
+## Recommended approach (team-converged)
+
+Through cross-track messaging the researchers converged on a concrete design that requires **no `RuntimeConfig` shape change, no schema migration**, and isolates Goose's quirks to two well-defined seams.
+
+1. **One `RUNTIMES["goose"]` entry, model string encodes provider.** Pattern: `goose/anthropic/claude-sonnet-4-20250514`, `goose/openai/gpt-4o`, etc., all mapping to `"goose"` in `MODEL_RUNTIME_MAP`. Same precedent as codex's `gpt-4.1`/`o3`/`o4-mini` → `"codex"`. One `UserRuntimeKey` row per (user, "goose"). The provisioning layer parses the model string at spec-build time to derive provider and model id.
+
+2. **`GOOSE_PROVIDER`/`GOOSE_MODEL` go in a written `~/.config/goose/config.yaml`, not in `RuntimeConfig` or env vars** — exactly mirroring how `_write_mcp_codex` writes `~/.codex/config.toml`. A new `_write_goose_config(sprite, spec, mcp_servers)` writes the YAML with provider/model/mode/telemetry/keyring settings AND the `extensions:` block (MCP servers) in a single pass. This keeps `RuntimeConfig.env_var` singular (no contract change) and avoids two-pass merge problems.
+
+3. **`env_var="ANTHROPIC_API_KEY"` (provider-standard, shared with claude). Relax the uniqueness test, don't invent a synthetic `GOOSE_API_KEY`.** The `claude-oauth` runtime already established the "same provider, different auth surface" precedent (claude → `ANTHROPIC_API_KEY`, claude-oauth → `CLAUDE_CODE_OAUTH_TOKEN`). Goose-with-Anthropic extends this. The `test_each_runtime_has_unique_env_var` invariant guards *accidental* collisions; intentional shared-provider runtimes should be permitted with an explanatory comment. **Note**: this means a user wanting both claude and goose-with-anthropic configures `ANTHROPIC_API_KEY` twice (once per runtime row in `UserRuntimeKey`) — a UX wart worth flagging at product level, but it doesn't block implementation.
+
+4. **`GOOSE_DISABLE_KEYRING`/`GOOSE_TELEMETRY_ENABLED` live in `config.yaml`, not in process env.** Avoids the `RuntimeConfig.static_env` extension that was briefly considered. The CLI also explicitly passes `--mode auto`/`--provider`/`--model` (not relying on env vars alone) because of [block/goose#3386](https://github.com/block/goose/issues/3386).
+
+5. **Install Goose into the Sprite base image (preferred) — fall back to a per-session install stage if not.** If installed at provision time: new `_install_goose_runtime(sprite)` stage runs after `_apply_network_policy`, conditioned on `spec.runtime.name == "goose"`. Limited network policies must allow `github.com` and `objects.githubusercontent.com`. Install command: `apt-get install -y -qq bzip2 && curl -fsSL https://github.com/block/goose/releases/download/<pinned-tag>/download_cli.sh | CONFIGURE=false bash`.
+
+6. **Skills are no-op for Goose v1.** Goose recipes are structurally incompatible with the existing `SkillSpec` (recipes are YAML with `instructions`/`parameters`/`sub_recipes`; SKILL.md is free-form Markdown) and require explicit `--recipe <path>` at invocation time rather than ambient discovery. Omit the `_SKILLS_ROOTS["goose"]` entry; the existing `if root is None: return` guard at [`provisioning.py:308-309`](https://github.com/ravi-hq/agent-on-demand/blob/919a4d4/src/agent_on_demand/session_service/provisioning.py#L308-L309) handles this silently.
+
+7. **MCP server env vars use Goose's `envs:` (plaintext in config.yaml), not `env_keys:` + secrets.yaml.** Matches the threat model used today by claude (`.claude.json`) and codex (`config.toml`) — secrets are encrypted at rest in our DB; the Sprite filesystem is ephemeral and isolated. The `env_keys:`/`secrets.yaml` path stays available as a future upgrade.
+
+## Implementation checklist
+
+Concrete files/lines to touch, organized by track:
+
+**`src/agent_on_demand/runtimes.py`**
+- Add `AgentModel` members for each supported `(provider, model)` pair, e.g. `GOOSE_ANTHROPIC_SONNET_4 = "goose/anthropic/claude-sonnet-4-20250514"`.
+- Add each new member to `MODEL_RUNTIME_MAP` mapping to `"goose"`.
+- Add `RUNTIMES["goose"] = RuntimeConfig(name="goose", cmd='goose run --text "$PROMPT" --output-format stream-json --mode auto --name "$AOD_SESSION_ID"', continue_cmd=<same + --resume>, env_var="ANTHROPIC_API_KEY")`.
+
+**`src/agent_on_demand/session_service/specs.py`**
+- Add `model: str | None = None` to `SessionSpec` (frozen dataclass). Existing callers pass nothing; only `_write_goose_config` reads it. This is the minimal honest change — the model genuinely determines session configuration for Goose.
+
+**`src/agent_on_demand/session_service/tasks.py`**
+- In `_build_spec_for_session` (around line 225), add `model=session.agent.model` to the `SessionSpec(...)` call. The `Agent` row is already fetched.
+
+**`src/agent_on_demand/session_service/provisioning.py`**
+- Add `_install_goose_runtime(sprite)` stage; call from `provision_session` after `_apply_network_policy` when `spec.runtime.name == "goose"` (skip if Sprite image bakes Goose in).
+- Add `_write_goose_config(sprite, spec, mcp_servers)` writing `~/.config/goose/config.yaml` with provider/model/mode/telemetry/keyring + `extensions:` block. Parse `spec.model` (`goose/<provider>/<model_id>`) to derive `GOOSE_PROVIDER` and `GOOSE_MODEL`.
+- Update `_write_mcp_config` to dispatch to `_write_goose_config` for `"goose"`, OR call it from `provision_session` directly (since config.yaml is needed even with zero MCP servers, unlike claude/codex/gemini).
+- **Do not** add `"goose"` to `_SKILLS_ROOTS`.
+
+**`tests/test_runtimes.py`**
+- Update `test_all_runtimes_defined` (line 6): add `"goose"` to set equality.
+- Update `test_each_runtime_has_unique_env_var` (line 63): relax with comment explaining intentional Anthropic-key sharing.
+- Add `test_goose_runtime_uses_name_and_resume` (mirror of `test_claude_runtime_uses_session_id_and_resume` at line 54).
+- Add coverage in `test_turn_command_selects_by_mode` for the `"goose"` runtime.
+
+**`tests/e2e/conftest.py:21-26`**
+- Add `"goose": "<cheap goose model id>"` to `RUNTIME_MODELS`.
+- Update `E2E_RUNTIMES` to include `"goose"`.
+- Seed `UserRuntimeKey(runtime="goose")` row in the e2e test deployment.
+
+**`tests/conftest.py`, `tests/test_agents.py`, `tests/test_api.py`, `tests/test_session_service.py`, `tests/test_tasks.py`**
+- Add Goose-runtime cases for create/update/list/version paths to mirror existing claude coverage.
+- The fake Sprites client (`tests/fakes/sprite.py`) is runtime-agnostic — no changes.
+
+**`README.md`** — update runtime lists at lines 66-76, 80-84, 116-117. **`CLAUDE.md`** — add Goose to the runtime callout if applicable.
+
+**Sprite base image (out of this repo)** — strongly preferred to bake Goose in, eliminating the `_install_goose_runtime` stage. Pin to a specific Goose release.
+
+## Remaining open questions
+
+These are product/UX questions, not blocking research findings:
+
+1. **UX of duplicate `ANTHROPIC_API_KEY` storage.** A user using both claude and goose-with-anthropic must configure the same Anthropic key twice (once per `UserRuntimeKey` row). Acceptable for v1, but worth a follow-up to consider key-sharing semantics.
+
+2. **Which Goose providers to support in v1.** The model-string encoding scales to all 15+ Goose providers, but each new provider added to `AgentModel` requires its own `(provider, model)` entries. Recommend launching with anthropic + openai and growing on demand.
+
+3. **Goose version pinning policy.** Track 3 recommends pinning the Sprite-image install to a specific tag (e.g. `v1.31.1`) for reproducibility. Choose a cadence for upgrades.
+
+## Related Research
+
+- [`thoughts/research/2026-04-18-session-backend-abstraction.md`](2026-04-18-session-backend-abstraction.md)
+- [`thoughts/research/2026-04-15-sprites-platform-research.md`](2026-04-15-sprites-platform-research.md)
+- [`thoughts/plans/2026-04-21-provision-stage-events.md`](../plans/2026-04-21-provision-stage-events.md)

--- a/thoughts/research/2026-04-21-meta-runtime-pattern.md
+++ b/thoughts/research/2026-04-21-meta-runtime-pattern.md
@@ -1,0 +1,336 @@
+---
+date: 2026-04-21
+researcher: Claude Code (synthesis + redesign)
+git_commit: 919a4d4fd679effee2099161911a3146aedc6a64
+branch: plans/provision-stage-events
+repository: ravi-hq/agent-on-demand
+topic: "Meta-runtime redesign: Runtime-as-protocol, provider-keyed credentials, all-creds-on-Sprite"
+tags: [research, redesign, runtimes, meta-runtime, goose, opencode, breaking-change]
+status: complete
+method: synthesis-and-redesign
+sources:
+  - thoughts/research/2026-04-21-goose-runtime-support.md
+  - thoughts/research/2026-04-21-opencode-runtime-support.md
+last_updated: 2026-04-21
+last_updated_by: Claude Code
+note: Supersedes the back-compat-preserving synthesis. Assumes no API stability or data preservation requirements.
+---
+
+# Research: Runtime redesign — provider-keyed credentials, Runtime-as-protocol, all-creds-on-Sprite
+
+**Date**: 2026-04-21
+**Researcher**: Claude Code
+**Git Commit**: [`919a4d4`](https://github.com/ravi-hq/agent-on-demand/commit/919a4d4fd679effee2099161911a3146aedc6a64)
+**Method**: Synthesis of [`goose`](2026-04-21-goose-runtime-support.md) and [`opencode`](2026-04-21-opencode-runtime-support.md) research, followed by ground-up redesign given no back-compat or data-preservation constraints.
+
+## Research Question
+
+The goose and opencode research efforts independently surfaced the same friction: fairy's `RuntimeConfig` is shaped for *pinned-provider* CLIs (claude → Anthropic, codex → OpenAI, gemini → Google), and *unpinned* CLIs (goose, opencode, future entrants) keep generating workarounds — env var aliases, model-string disambiguation prefixes, a `MODEL_RUNTIME_MAP` that nothing actually enforces, a `test_each_runtime_has_unique_env_var` invariant that no longer matches reality.
+
+Given (a) the existing approach works but won't scale to the next N runtimes, and (b) we have no back-compat or data preservation constraints, what's the right shape going forward?
+
+## Summary
+
+Stop patching. Rotate the data model around `(provider, model)` instead of `(runtime)`, make each `Runtime` a Python class implementing a small protocol, and dump *all* of a user's credentials onto every Sprite at provision time so the env-var-selection problem dissolves entirely.
+
+Concretely:
+
+1. **`Runtime` becomes a protocol/class**, one Python file per runtime. Owns `build_command`, `write_config`, `providers`, `skills_root`. Replaces the 4-field `RuntimeConfig` dataclass + scattered `_write_mcp_<runtime>` / `_SKILLS_ROOTS[runtime]` / shell-template `cmd`/`continue_cmd` indirection.
+2. **`UserCredential(user, kind, value_encrypted)`** replaces `UserRuntimeKey`. `kind` enumerates `provider:anthropic`, `provider:openai`, `runtime_token:claude-oauth`, etc. — one model handles both provider keys and runtime-specific auth tokens.
+3. **All user credentials get written to every Sprite.** `_write_env_file` becomes a flat dump: every `UserCredential` the user owns, mapped to its conventional env var name. No per-runtime env var selection, no aliasing, no translation.
+4. **Model is a free-form `provider/model_id` string** validated against a small `MODELS` registry. Replaces the `AgentModel` enum. Adding a model is one registry entry, no migration.
+5. **`MODEL_RUNTIME_MAP` becomes real enforcement.** Each `Runtime` declares `providers: set[str]`. Agent-create validates `model.provider ∈ runtime.providers`. Replaces the documentation-only map that nothing currently calls.
+6. **`claude-oauth` folds into `ClaudeRuntime`.** It's not a separate runtime — it's claude with a different credential. The runtime picks `CLAUDE_CODE_OAUTH_TOKEN` over `ANTHROPIC_API_KEY` based on which credential the user has. One fewer entry in `RUNTIMES`.
+
+The shell-template `bash -c "set -a; source ..."` indirection goes away. `_write_env_file` shrinks to ~10 lines. `MODEL_RUNTIME_MAP`, the `AgentModel` enum, the env var alias plumbing, the unique-env-var test, the `goose/<provider>/<model>` disambiguation prefix, and the `claude-oauth` runtime entry all disappear.
+
+## What the source docs established
+
+The synthesis from goose + opencode research confirmed several findings that survive the redesign and motivate it:
+
+- **`MODEL_RUNTIME_MAP` is documentation, not enforcement.** Never imported anywhere outside its declaration; agent-create takes `runtime` as an independent client field. The redesign makes it real.
+- **Stream is byte passthrough.** `stream.py` doesn't care what runtime emitted what — survives unchanged.
+- **Per-runtime config writers are the right seam.** Codex already does this implicitly (`_write_mcp_codex` writes the whole `config.toml`). The redesign generalizes: every runtime owns its `write_config`.
+- **Sprite base image is external and the same problem twice.** Both goose and opencode need binary pre-installation outside this repo. One coordinated base-image PR.
+- **Both meta-runtimes want one runtime entry, not one-per-provider.** Multi-provider runtimes are first-class in the redesign rather than a special case.
+- **Migrations are cosmetic in the existing schema.** No DB CHECK constraints; choices are app-level. Recreating tables is cheap.
+- **`test_each_runtime_has_unique_env_var` is the canary.** Both runtimes hit it. The redesign deletes it (no longer meaningful — env vars come from credentials, not runtimes).
+
+The goose/opencode docs each proposed a *workaround* for the env-var collision (alias translation, test relaxation). The redesign eliminates the underlying mismatch.
+
+## The new shape
+
+### `Runtime` protocol
+
+```python
+# src/agent_on_demand/runtimes/base.py
+from typing import Protocol, Literal
+from sprites import Sprite
+from agent_on_demand.session_service.specs import SessionSpec, McpServerSpec
+
+
+class Runtime(Protocol):
+    name: str
+    providers: set[str]            # which providers this runtime can serve
+    skills_root: str | None        # absolute path on Sprite, or None to disable skills
+
+    def build_command(
+        self, spec: SessionSpec, mode: Literal["run", "continue"]
+    ) -> list[str]:
+        """Argv for the per-turn command. Receives prompt via stdin."""
+
+    def write_config(
+        self, sprite: Sprite, spec: SessionSpec, mcp_servers: list[McpServerSpec]
+    ) -> None:
+        """Write any per-runtime config files on the Sprite (config.yaml, MCP, etc).
+        Called once at provision time, even if mcp_servers is empty."""
+```
+
+Implementations live in `src/agent_on_demand/runtimes/`:
+
+- `claude.py` → `ClaudeRuntime` — `providers={"anthropic"}`, picks token vs. API key based on user credentials, writes `~/.claude.json` for MCP, `skills_root="/home/sprite/.claude/skills"`
+- `codex.py` → `CodexRuntime` — `providers={"openai"}`, writes `~/.codex/config.toml`, `skills_root="/home/sprite/.codex/skills"`
+- `gemini.py` → `GeminiRuntime` — `providers={"google"}`, writes `~/.gemini/settings.json`, `skills_root="/home/sprite/.gemini/skills"`
+- `goose.py` → `GooseRuntime` — `providers={"anthropic", "openai", "google", ...}`, writes `~/.config/goose/config.yaml` (provider/model/mode/keyring/extensions in one file), `skills_root=None` (recipes incompatible with SKILL.md)
+- `opencode.py` → `OpencodeRuntime` — `providers={"anthropic", "openai", "google", "azure", "bedrock", ...}`, writes `~/.config/opencode/opencode.json`, `skills_root="/home/sprite/.config/opencode/skills"` (free SKILL.md compatibility)
+
+`RUNTIMES: dict[str, Runtime]` becomes a registry of class instances. The runtime's quirks (config file format, MCP serialization, resume flag, skills convention) all live in one file, testable in isolation.
+
+### Command building moves to Python
+
+The shell-template `cmd: str = '... -p "$PROMPT"'` indirection goes away. Today's flow:
+
+1. `RuntimeConfig.cmd` is a shell string with `$PROMPT`/`$AOD_SESSION_ID` placeholders
+2. `build_turn_command` wraps it in `bash -c "set -a; source /tmp/aod-env; set +a; PROMPT=$(cat); export PROMPT; exec ${cmd}"`
+3. Sprite executes the wrapped string
+
+New flow:
+
+1. `runtime.build_command(spec, mode)` returns `list[str]` — Python builds it
+2. Sprite executes the argv directly (`sprite.command(*argv, stdin=prompt_bytes)`)
+
+The wrapper script disappears. Quoting handled by sprite SDK. The prompt arrives via stdin (already supported) instead of via a `$PROMPT` env var. `build_command` is a pure function, trivially unit-testable per runtime.
+
+The env file is *still* sourced by the Sprite (via `bash -lc 'source /tmp/aod-env; exec "$@"' --` or equivalent — the sprite SDK pattern), but its contents are flat key=value with no template substitution semantics.
+
+### `UserCredential` model
+
+```python
+# src/agent_on_demand/models/auth.py
+class UserCredential(models.Model):
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    kind = models.CharField(max_length=64)  # "provider:anthropic", "runtime_token:claude-oauth"
+    value_encrypted = ...                   # same EncryptedField pattern as today
+    created_at = ...
+    updated_at = ...
+
+    class Meta:
+        unique_together = [("user", "kind")]
+```
+
+Replaces `UserRuntimeKey`. Drop the old table; recreate. The `kind` field is a structured string with two namespaces:
+
+- `provider:<name>` — provider API keys: `provider:anthropic`, `provider:openai`, `provider:google`, `provider:azure`, `provider:bedrock`, etc.
+- `runtime_token:<runtime>` — runtime-specific auth tokens that aren't provider keys: `runtime_token:claude-oauth`. This is rare; most runtimes use provider keys.
+
+A small registry maps kinds to env var names:
+
+```python
+CREDENTIAL_ENV_VAR: dict[str, str] = {
+    "provider:anthropic":         "ANTHROPIC_API_KEY",
+    "provider:openai":            "OPENAI_API_KEY",
+    "provider:google":            "GEMINI_API_KEY",
+    "provider:azure":             "AZURE_API_KEY",
+    "provider:bedrock":           "AWS_BEARER_TOKEN_BEDROCK",
+    "runtime_token:claude-oauth": "CLAUDE_CODE_OAUTH_TOKEN",
+    # ...
+}
+```
+
+### All credentials on every Sprite
+
+`_write_env_file` becomes ~10 lines:
+
+```python
+def _write_env_file(sprite: Sprite, spec: SessionSpec) -> None:
+    lines: list[str] = []
+    for cred in UserCredential.objects.filter(user=spec.user):
+        env_name = CREDENTIAL_ENV_VAR.get(cred.kind)
+        if env_name:
+            lines.append(f"{env_name}={shlex.quote(cred.value)}")
+    if spec.runtime_session_id:
+        lines.append(f"AOD_SESSION_ID={shlex.quote(spec.runtime_session_id)}")
+    if spec.model:
+        lines.append(f"AOD_MODEL={shlex.quote(spec.model)}")
+    for k, v in sorted((spec.environment.env_vars or {}).items()) if spec.environment else []:
+        lines.append(f"{k}={shlex.quote(v)}")
+    fs = sprite.filesystem()
+    (fs / ENV_FILE_PATH.lstrip("/")).write_text("\n".join(lines) + "\n")
+    sprite.command("chmod", "600", ENV_FILE_PATH).run()
+```
+
+No per-runtime env var selection. No alias translation. No `META_RUNTIMES` set. Every credential the user has registered shows up under its conventional env var name. The runtime CLI reads what it reads.
+
+**Trade-off (explicit decision)**: a compromised Sprite leaks the user's full credential set rather than the single key for the active runtime. Three things make this acceptable:
+
+1. **Sprites are short-lived per-session** — a compromise has bounded lifetime.
+2. **The marginal blast radius is proportional, not categorical** — if a Sprite is owned, *any* key on it leaks today; "all keys leak vs. one key leaks" is degree, not kind.
+3. **The user is authorizing the session** — the credentials in question are the user's own, used on their behalf.
+
+If a user has high-value credentials they don't want their own agents to be able to leak, those credentials don't belong in fairy. Codifying a "session-scoped credential" opt-out is **explicitly out of scope for v1** — revisit only if a real customer asks.
+
+### Model registry
+
+```python
+# src/agent_on_demand/models_registry.py (or wherever)
+@dataclass(frozen=True)
+class ModelDef:
+    id: str          # canonical "provider/model_id" string
+    provider: str    # "anthropic"
+    runtimes: set[str] | None = None  # optional; None means "any runtime whose providers includes this provider"
+
+MODELS: dict[str, ModelDef] = {
+    "anthropic/claude-sonnet-4-5":   ModelDef(id="anthropic/claude-sonnet-4-5", provider="anthropic"),
+    "anthropic/claude-haiku-4-5":    ModelDef(id="anthropic/claude-haiku-4-5",  provider="anthropic"),
+    "anthropic/claude-opus-4-7":     ModelDef(id="anthropic/claude-opus-4-7",   provider="anthropic"),
+    "openai/gpt-5":                  ModelDef(id="openai/gpt-5",                provider="openai"),
+    "openai/o3":                     ModelDef(id="openai/o3",                   provider="openai"),
+    "google/gemini-2.5-pro":         ModelDef(id="google/gemini-2.5-pro",       provider="google"),
+    # ...
+}
+```
+
+`AgentModel` enum is gone. `MODEL_RUNTIME_MAP` is gone. Adding a model is one registry entry, no migration.
+
+Validation at `POST /agents`:
+
+```python
+model_def = MODELS.get(req.model)
+if not model_def:
+    return error(422, f"Unknown model: {req.model}")
+
+runtime = RUNTIMES.get(req.runtime)
+if not runtime:
+    return error(422, f"Unknown runtime: {req.runtime}")
+
+if model_def.provider not in runtime.providers:
+    return error(422, f"Runtime {req.runtime} cannot serve model {req.model} (provider {model_def.provider} not in {runtime.providers})")
+
+if model_def.runtimes is not None and req.runtime not in model_def.runtimes:
+    return error(422, f"Model {req.model} not supported on runtime {req.runtime}")
+```
+
+This is the enforcement that `MODEL_RUNTIME_MAP` was supposed to provide. Today it doesn't exist; tomorrow it does.
+
+### `claude-oauth` dissolves
+
+`ClaudeRuntime.build_command` checks the user's credentials:
+
+```python
+def build_command(self, spec, mode):
+    if spec.user_has_credential("runtime_token:claude-oauth"):
+        # Use OAuth flow
+        return ["claude", "--dangerously-skip-permissions", "--print", ...] if mode == "continue" else [...]
+    else:
+        # Use API key flow
+        return ["claude", "--print", "--verbose", "--output-format", "stream-json", "--session-id", spec.runtime_session_id, ...]
+```
+
+The two runtime entries collapse into one. The user's credential set determines which auth path runs. One fewer `RUNTIMES` entry, one fewer `Runtime` class, one fewer test fixture.
+
+### Schema changes
+
+| Today | Tomorrow |
+|-------|----------|
+| `UserRuntimeKey(user, runtime)` table | `UserCredential(user, kind)` table |
+| `AgentModel` Python enum | Deleted |
+| `MODEL_RUNTIME_MAP` Python dict | Deleted |
+| `Agent.model` `CharField(choices=AgentModel.choices())` | `Agent.model` `CharField` (free-form, validated against MODELS at create) |
+| `Agent.runtime` `CharField(choices=RUNTIMES_CHOICES)` | `Agent.runtime` `CharField` (free-form, validated against RUNTIMES at create) |
+| `AgentSession.runtime` denormalized `CharField` | Same — keep for query convenience |
+| `AgentVersion.{model,runtime}` denormalized | Same — keep for version history correctness |
+| `RuntimeConfig` 4-field dataclass | `Runtime` Protocol with N implementations |
+| `_write_mcp_<runtime>` per-runtime functions | `Runtime.write_config` method per class |
+| `_SKILLS_ROOTS` dict | `Runtime.skills_root` attribute |
+| `RUNTIMES: dict[str, RuntimeConfig]` | `RUNTIMES: dict[str, Runtime]` |
+| `tests/test_runtimes.py::test_each_runtime_has_unique_env_var` | Deleted |
+
+No data migration — drop and recreate.
+
+## What this means for goose and opencode
+
+Both become drop-in `Runtime` implementations. No special-casing in `_write_env_file`, no env var alias translation, no `META_RUNTIMES` set, no model-string disambiguation prefix.
+
+**`GooseRuntime`** (~80 lines):
+- `providers = {"anthropic", "openai", "google", "azure", "bedrock"}` (start with anthropic + openai; add as demanded)
+- `skills_root = None` (recipes incompatible with SKILL.md)
+- `build_command` returns argv with `--text`, `--output-format stream-json`, `--mode auto`, `--name <session_id>`, `--provider <derived>`, `--model <derived>`, `--resume` for continue mode. Provider/model derived in Python from `spec.model.split("/", 1)`.
+- `write_config` writes `~/.config/goose/config.yaml` with provider/model/mode/keyring/telemetry + `extensions:` block (MCP)
+
+**`OpencodeRuntime`** (~80 lines):
+- `providers = {"anthropic", "openai", "google", "azure", "bedrock", ...}` (15-75 supported; pick the ones you want to expose)
+- `skills_root = "/home/sprite/.config/opencode/skills"` (native SKILL.md — free)
+- `build_command` returns `["opencode", "run", "--model", spec.model, "--format", "json", spec.prompt]` for run mode, `["opencode", "run", "--model", spec.model, "--format", "json", "--continue", spec.prompt]` for continue. Bare `provider/model_id` passed verbatim — no prefix games because the model string IS what opencode wants.
+- `write_config` writes `~/.config/opencode/opencode.json` with `mcp` block
+
+Both runtimes pick up their provider's API key from the env file because `_write_env_file` already dumped every credential the user owns.
+
+## What stays unchanged
+
+- `stream.py` (byte passthrough)
+- `Sprite` SDK usage (`sprite.command`, `sprite.filesystem`)
+- `_install_packages`, `_clone_repos`, `_apply_network_policy`, `_run_user_setup` provisioning stages
+- `Environment` model and its `env_vars` merging behavior
+- `provision_session` overall stage flow and failure handling
+- `tasks.py` outer structure (Procrastinate task, log buffering, exit code → status mapping)
+- Sprite base image dependency (still external — coordinate one PR for goose + opencode + anything else)
+
+## Cost
+
+Bigger PR than either previous plan, but everything internal — no API breakage to defend.
+
+| Change | Volume |
+|--------|--------|
+| Replace `RuntimeConfig` dataclass + `RUNTIMES` dict | 1 protocol file + 5 runtime class files (~50-80 lines each) |
+| Replace `AgentModel` enum + `MODEL_RUNTIME_MAP` | 1 dataclass + 1 dict (~50 lines) |
+| Replace `UserRuntimeKey` model | 1 Django model (~30 lines) + drop+recreate migration |
+| Rewrite `_write_env_file` | Net shrink: -15 lines |
+| Rewrite `build_turn_command` and tasks.py command path | Net shrink: -20 lines (no shell template wrapper) |
+| Rewrite `_write_mcp_config` dispatch + per-runtime writers | Net shrink: existing functions move into runtime classes |
+| Rewrite agent-create validation | Net add: ~20 lines for proper model+runtime+provider check |
+| Rewrite tests | Significant — each runtime class gets its own test file; existing `test_runtimes.py`/`test_tools_mcp.py`/`test_skills.py` rewritten or replaced |
+
+Net code volume probably similar or smaller. Conceptual complexity meaningfully lower.
+
+## Implementation order
+
+1. **Land the redesign infrastructure first.** Runtime protocol, `UserCredential` model, MODELS registry, rewrite `_write_env_file`, rewrite the command-build path in `tasks.py`, port existing claude/codex/gemini to `Runtime` classes, fold `claude-oauth` into `ClaudeRuntime`. Drop `UserRuntimeKey`, `AgentModel`, `MODEL_RUNTIME_MAP`. Delete `test_each_runtime_has_unique_env_var` and the rest of the now-obsolete test scaffolding. Rewrite the tests around the new shape.
+
+2. **Drop+recreate the relevant tables.** No data preservation. Squash migrations or just generate a clean reset for the affected models.
+
+3. **Land `OpencodeRuntime`.** First user of the new infrastructure end-to-end; gets `SKILL.md` reuse essentially free.
+
+4. **Land `GooseRuntime`.** Almost trivial at this point — write the class, register it, ship tests.
+
+5. **Coordinate the Sprite base image PR** (out-of-repo) in parallel with step 1; aim to land it before step 3 deploys.
+
+## Open questions
+
+1. **Model registry source.** Hardcoded dict (small, pinned) vs. dynamic fetch (opencode does this from models.dev). Hardcoded for v1. Revisit if maintenance burden grows or if customers ask for "use a model that just shipped without waiting for a fairy release."
+
+2. **Cross-runtime command-build seams.** `build_command` returns `list[str]` — does it also need to return env var overrides (e.g. a runtime that wants a non-credential env var set just for this command)? Lean no for v1; if it comes up, runtimes can write those into the session-specific config file instead.
+
+3. **`AgentSession.runtime` denormalization.** Keep for query convenience or drop in favor of joining through `agent_id`? Lean keep — it's cheap and avoids JOIN-on-every-list. Same logic for `AgentVersion`.
+
+4. **Sprite base image PR ownership.** Unchanged from prior docs — who lands the base image PR that pre-installs `goose`, `opencode-ai`, and any future binaries?
+
+5. **Provider env var coverage in `CREDENTIAL_ENV_VAR`.** v1 covers the common providers (anthropic, openai, google). Bedrock notably uses *multiple* env vars (`AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_BEARER_TOKEN_BEDROCK`). The `UserCredential.value` is a single string — for multi-var providers, we either store JSON in `value` or model multi-var providers as multiple `UserCredential` rows with kind suffixes (`provider:bedrock:access_key_id`, etc.). Defer until Bedrock support is actually requested.
+
+6. **Skills format unification.** Goose recipes are YAML with structure; SKILL.md is free-form Markdown. Translation is plausible (wrap SKILL.md content as the `instructions:` field of a recipe) but adds runtime-specific serialization to the skills writer. v1: `GooseRuntime.skills_root = None`. Revisit if customers want skills to work with goose.
+
+## Source documents
+
+- [`thoughts/research/2026-04-21-goose-runtime-support.md`](2026-04-21-goose-runtime-support.md) — 4-researcher team-research; original goose integration analysis
+- [`thoughts/research/2026-04-21-opencode-runtime-support.md`](2026-04-21-opencode-runtime-support.md) — 5-researcher team-research; original opencode integration analysis
+
+The two source docs document the *symptoms* (env var aliases, model-string prefixes, test invariants that no longer fit). This doc proposes the *cure* (rotate the data model, make Runtime a class, dump all credentials).

--- a/thoughts/research/2026-04-21-opencode-runtime-support.md
+++ b/thoughts/research/2026-04-21-opencode-runtime-support.md
@@ -1,0 +1,532 @@
+---
+date: 2026-04-21T20:00:00-07:00
+researcher: Claude Code (team-research skill)
+git_commit: 919a4d4fd679effee2099161911a3146aedc6a64
+branch: plans/provision-stage-events
+repository: ravi-hq/agent-on-demand
+topic: "Add opencode runtime support to agent-on-demand"
+tags: [research, team-research, runtimes, opencode, provisioning]
+status: complete
+method: agent-team
+team_size: 5
+tracks: [opencode-cli, runtime-execution, provisioning, api-surface, history]
+last_updated: 2026-04-21
+last_updated_by: Claude Code
+---
+
+# Research: Add opencode runtime support to agent-on-demand
+
+**Date**: 2026-04-21
+**Researcher**: Claude Code (team-research)
+**Git Commit**: [`919a4d4`](https://github.com/ravi-hq/agent-on-demand/commit/919a4d4fd679effee2099161911a3146aedc6a64)
+**Branch**: `plans/provision-stage-events`
+**Repository**: ravi-hq/agent-on-demand
+**Method**: Agent team (5 specialist researchers)
+
+## Research Question
+
+What does it take to add opencode (https://opencode.ai, sst/opencode) as a
+supported runtime alongside the existing `claude`, `claude-oauth`, `codex`, and
+`gemini` runtimes?
+
+## Summary
+
+Adding opencode is mostly mechanical once three non-trivial issues are addressed:
+
+1. **Sprite base image dependency** — opencode must be pre-installed on the
+   Sprite. fairy does not manage the base image; this is a Sprites platform
+   change (outside this repo), identical to how `claude`/`codex`/`gemini`
+   binaries are provided today.
+2. **Env var model mismatch** — opencode reads the native provider env vars
+   (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`) directly, but
+   fairy's `RuntimeConfig.env_var` is a single constant per runtime. Since
+   opencode is a multi-provider *meta-runtime*, its env var is effectively
+   model-dependent. This forces a design choice (see Design Decisions below).
+   A related test, `test_each_runtime_has_unique_env_var`, will need to adapt
+   if opencode reuses `ANTHROPIC_API_KEY`.
+3. **Model-flag plumbing** — opencode picks the model via `--model
+   provider/model-id` at invocation time. fairy's current `build_turn_command`
+   only plumbs `$PROMPT` and `$AOD_SESSION_ID` into the shell environment. A
+   new `$AOD_MODEL` (or equivalent) must be written into `/tmp/aod-env` so the
+   runtime cmd string can reference it.
+
+Beyond those, the wiring is drop-in: one `RuntimeConfig` entry, one
+`_write_mcp_opencode` function, one `_SKILLS_ROOTS` entry, choices migrations
+for `Agent.model`/`Agent.runtime`/`UserRuntimeKey.RUNTIME_CHOICES`, new enum
+entries and `MODEL_RUNTIME_MAP` rows, and parametrized MCP/skills tests
+following the existing patterns. `stream.py` needs no changes — it is already
+raw passthrough with no per-runtime parser.
+
+## Research Tracks
+
+### Track 1: Opencode CLI external capabilities
+**Researcher**: opencode-researcher
+**Scope**: Web research against opencode.ai/docs and sst/opencode
+
+#### Findings
+
+1. **Headless invocation** — `opencode run "<prompt>"` is the one-shot,
+   TUI-less, auto-approve command. No `--print` flag; `run` itself is the
+   non-interactive mode. ([opencode.ai/docs/cli/](https://opencode.ai/docs/cli/))
+
+2. **Output format** — `--format json` emits raw streaming JSON events to
+   stdout; default is human-readable terminal output. The JSON event schema is
+   **not publicly documented** — only that "raw JSON events" are emitted.
+   ([opencode.ai/docs/cli/](https://opencode.ai/docs/cli/))
+
+3. **Session resume** — Two flags: `--continue`/`-c` resumes the *last*
+   session; `--session <id>`/`-s <id>` resumes by ID. Session IDs are
+   **assigned by opencode on first run** — there is no pre-specification flag
+   analogous to Claude's `--session-id`. To use `--session`, the caller must
+   parse and persist the ID from turn-1 stdout.
+   ([opencode.ai/docs/cli/](https://opencode.ai/docs/cli/))
+
+4. **Auth env vars** — Opencode reads native provider env vars directly (no
+   `OPENCODE_API_KEY`):
+   - `ANTHROPIC_API_KEY` (Anthropic)
+   - `OPENAI_API_KEY` (OpenAI)
+   - `GOOGLE_GENERATIVE_AI_API_KEY` or `GEMINI_API_KEY` (Google)
+   - `AWS_*` (Bedrock), `AZURE_RESOURCE_NAME` (Azure), etc.
+   - `OPENCODE_CONFIG_CONTENT` allows inline JSON config injection (useful for
+     ephemeral containers).
+   ([opencode.ai/docs/providers/](https://opencode.ai/docs/providers/))
+
+5. **Model selection** — `--model provider/model-id` or `-m` flag; model list
+   is dynamic (fetched from models.dev at runtime, 75+ providers). Canonical
+   format examples:
+   - `anthropic/claude-opus-4-7`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5`
+   - `openai/gpt-4o`, `openai/gpt-5-mini`, `openai/o1-mini`
+   - `google/gemini-2.5-pro-preview-05-06`, `google/gemini-2.5-flash-lite-preview-09-2025`
+   ([opencode.ai/docs/cli/](https://opencode.ai/docs/cli/))
+
+6. **MCP support** — Config lives under an `"mcp"` key in
+   `~/.config/opencode/opencode.json`. Format differs from Claude's in two
+   small ways: `type` values are `"local"`/`"remote"` (not `"stdio"`/`"http"`),
+   `command` is a **single array combining command+args** (not
+   `command`+`args` split), and env is keyed as `"environment"` (not `"env"`).
+   ([opencode.ai/docs/mcp-servers/](https://opencode.ai/docs/mcp-servers/))
+
+7. **Skills convention** — Opencode natively reads agentskills.io-style
+   `SKILL.md` files with YAML frontmatter. Paths searched (in order):
+   `.opencode/skills/<name>/SKILL.md` (project),
+   `~/.config/opencode/skills/<name>/SKILL.md` (global — i.e.
+   `/home/sprite/.config/opencode/skills/<name>/SKILL.md`),
+   `.claude/skills/<name>/SKILL.md` (also read — shared with Claude Code),
+   `.agents/skills/<name>/SKILL.md`. Note: the global path is
+   `~/.config/opencode/skills/`, NOT `~/.opencode/skills/` (opencode-researcher
+   corrected an earlier assumption here).
+   ([opencode.ai/docs/skills/](https://opencode.ai/docs/skills/))
+
+8. **Install on Debian** — Two options: `npm i -g opencode-ai@latest` (package
+   name is `opencode-ai`, not `opencode`), or `curl -fsSL
+   https://opencode.ai/install | bash` (installs to `~/.opencode/bin` or
+   `$OPENCODE_INSTALL_DIR`). No apt/deb package.
+   ([sst/opencode README](https://github.com/sst/opencode))
+
+### Track 2: Runtime execution wiring
+**Researcher**: runtime-execution-researcher
+**Scope**: `src/agent_on_demand/runtimes.py`, `session_service/{turn,tasks,client,specs}.py`, `stream.py`, `models/sessions.py`
+
+#### Findings
+
+1. **RuntimeConfig contract** — Four fields: `name`, `cmd`, `continue_cmd`,
+   `env_var` ([`runtimes.py:48-53`](src/agent_on_demand/runtimes.py)).
+   Substitution is **pure shell expansion**, not Python formatting. The turn
+   command is assembled in
+   [`tasks.py::build_turn_command` (lines 98-109)](src/agent_on_demand/session_service/tasks.py)
+   as `set -a; source /tmp/aod-env; set +a; PROMPT=$(cat); export PROMPT; exec
+   <runtime_cmd>`. `$PROMPT` and `$AOD_SESSION_ID` resolve inside the Sprite's
+   `bash -c` invocation ([`tasks.py:371-381`](src/agent_on_demand/session_service/tasks.py)).
+
+2. **Per-runtime resume patterns** diverge:
+   - `claude`: pre-generated UUID as `--session-id` turn 1, `--resume` turn N (stored as `runtime_session_id` on `AgentSession`).
+   - `codex`: `--last` on resume (no ID plumbing).
+   - `gemini`: bare `--resume` flag (no ID plumbing).
+   - `claude-oauth`: identical to `claude` but with `CLAUDE_CODE_OAUTH_TOKEN`.
+
+3. **No wrapper script** — The `/run-agent.sh` dispatcher has been fully
+   removed; see `c677159` "Rip out the /run-agent.sh dispatcher". Everything
+   is inline in `build_turn_command` now.
+
+4. **Raw passthrough for stream output** — [`stream.py:39-53`](src/agent_on_demand/stream.py)
+   emits `AgentSessionLog.data` unchanged. `data` is a raw UTF-8 decoded
+   stdout/stderr `TextField` ([`models/sessions.py:112-153`](src/agent_on_demand/models/sessions.py)).
+   **No per-runtime parser exists.** Adding a new runtime requires zero
+   changes to `stream.py` or any log-ingestion code.
+
+5. **Mode selection is view-driven** — `POST /sessions` uses `mode="run"`
+   ([`views/sessions.py:264`](src/agent_on_demand/views/sessions.py)); `POST
+   /sessions/{id}/prompt` uses `mode="continue"`
+   ([`views/sessions.py:425`](src/agent_on_demand/views/sessions.py)).
+   `build_turn_command(runtime, mode)` picks `cmd` vs `continue_cmd`
+   accordingly.
+
+6. **API key plumbing** — `UserRuntimeKey.get_key_for(user, runtime)` →
+   `SessionSpec.api_key` → `_write_env_file` writes `{env_var}={api_key}` to
+   `/tmp/aod-env` on the Sprite
+   ([`provisioning.py:126`](src/agent_on_demand/session_service/provisioning.py)).
+   Keys never live in the web process during transit — the worker decrypts,
+   writes to Sprite filesystem, discards.
+
+7. **Draft opencode RuntimeConfig** — see Design Decisions section below; two
+   variants (`--continue` vs `--session <id>`) depending on how we handle
+   session-id capture.
+
+### Track 3: Per-runtime provisioning
+**Researcher**: provisioning-researcher
+**Scope**: `src/agent_on_demand/session_service/{provisioning,specs,client}.py`, `tests/test_tools_mcp.py`, `tests/test_skills.py`
+
+#### Findings
+
+1. **Provisioning stages** — Only two of eight stages branch on runtime name:
+   `mcp_config` (via `_write_mcp_config` at
+   [`provisioning.py:227-238`](src/agent_on_demand/session_service/provisioning.py))
+   and `skills` (via `_SKILLS_ROOTS` lookup at
+   [`provisioning.py:305-318`](src/agent_on_demand/session_service/provisioning.py)).
+   Everything else (network policy, env file, packages, repo clone, user
+   setup) is runtime-agnostic.
+
+2. **MCP config paths and formats per runtime**:
+   - Claude: `/home/sprite/.claude.json`, JSON `{"mcpServers": {...}}`, `type: "stdio"|"http"`, `command`+`args` split, `env` key.
+   - Codex: `/home/sprite/.codex/config.toml`, TOML `[mcp_servers.NAME]` sections, `bearer_token_env_var` extracted from Authorization header.
+   - Gemini: `/home/sprite/.gemini/settings.json`, JSON with `httpUrl` (not `url`) for URL servers, `trust: true` everywhere.
+   - Opencode (new): `/home/sprite/.config/opencode/opencode.json`, JSON `{"mcp": {...}}`, `type: "local"|"remote"`, `command` as single array, `environment` (not `env`).
+
+3. **Skills roots** ([`provisioning.py:30-35`](src/agent_on_demand/session_service/provisioning.py)):
+   ```python
+   _SKILLS_ROOTS = {
+       "claude":       "/home/sprite/.claude/skills",
+       "claude-oauth": "/home/sprite/.claude/skills",
+       "codex":        "/home/sprite/.codex/skills",
+       "gemini":       "/home/sprite/.gemini/skills",
+   }
+   ```
+   Opencode's global skills path is `/home/sprite/.config/opencode/skills/`
+   (not `/home/sprite/.opencode/skills/` as initially drafted). An alternative
+   is to reuse `"/home/sprite/.claude/skills"` since opencode also reads that
+   path — zero new directory, but mixes runtimes in one tree. Recommend the
+   dedicated path for clarity.
+
+4. **Env file is runtime-agnostic** — `_write_env_file`
+   ([`provisioning.py:122-139`](src/agent_on_demand/session_service/provisioning.py))
+   takes `spec.runtime.env_var` and writes `{env_var}=<api_key>`. No
+   per-runtime branching. For opencode this breaks down because opencode
+   wants the native provider env var, not a constant.
+
+5. **Runtime binaries are pre-installed by the Sprites platform** — There is
+   no Dockerfile, no `render.yaml` runtime-install step, no Sprite base image
+   definition in this repo. The `claude`/`codex`/`gemini` binaries are
+   expected to already be on PATH. **Adding opencode requires a Sprites
+   platform base image change — outside this codebase.** This is a hard
+   deployment dependency.
+
+6. **Test patterns** — Parametrized fake-sprite tests assert on
+   `fake_sprites.last_sprite().write_map()`:
+   - MCP: [`tests/test_tools_mcp.py`](tests/test_tools_mcp.py) —
+     `test_claude_mcp_url_server_writes_json` (line 55),
+     `test_codex_mcp_writes_toml` (line 138),
+     `test_gemini_mcp_writes_settings_json` (line 197).
+   - Skills: [`tests/test_skills.py`](tests/test_skills.py) —
+     `test_claude_skill_writes_skill_md_under_dot_claude` (line 72),
+     `test_codex_skill_writes_under_dot_codex` (line 95),
+     `test_gemini_skill_writes_under_dot_gemini` (line 120).
+   A new `test_opencode_mcp_writes_opencode_json` and
+   `test_opencode_skill_writes_under_dot_opencode` must follow the same
+   pattern.
+
+### Track 4: API surface, model mapping, and tests
+**Researcher**: api-surface-researcher
+**Scope**: `src/agent_on_demand/{runtimes,views/,models/,urls}.py`, `tests/test_runtimes.py`, `tests/e2e/`
+
+#### Findings
+
+1. **Model validation is Pydantic, at agent-create time** —
+   [`views/agents.py:116-121`](src/agent_on_demand/views/agents.py) rejects
+   unknown model strings with 422. `model` is validated against
+   `AgentModel.values()`.
+
+2. **No automatic model→runtime derivation** — `MODEL_RUNTIME_MAP` at
+   [`runtimes.py:32-45`](src/agent_on_demand/runtimes.py) **is never imported
+   or called anywhere** outside its declaration. `runtime` is an **independent
+   client-supplied field** on agent create, validated against `RUNTIMES` keys
+   ([`agents.py:238-242`](src/agent_on_demand/views/agents.py)). The Agent row
+   stores both; session-create reads `agent_obj.runtime` directly
+   ([`sessions.py:203`](src/agent_on_demand/views/sessions.py)). A client *can*
+   submit mismatched `model` + `runtime` today — there is no cross-validation.
+   The map is effectively documentation.
+
+3. **Runtime is a client-facing field** — Required on `POST /agents`, returned
+   in all serializations. Adding `"opencode"` as a valid value is not
+   API-breaking; clients just gain a new allowed string.
+
+4. **Migration needed** — Both `Agent.model` and `Agent.runtime` use Django
+   `choices=`, which means Django emits `AlterField` migrations when choices
+   change ([`models/agents.py:18-19`](src/agent_on_demand/models/agents.py)).
+   Also [`models/auth.py:51`](src/agent_on_demand/models/auth.py) defines
+   `UserRuntimeKey.RUNTIME_CHOICES`, which also changes. No DB-level CHECK
+   constraints; Postgres stores the values as opaque strings.
+   `AgentVersion.model`/`AgentVersion.runtime` are plain `CharField`s with no
+   choices — no migration needed there.
+
+5. **Hidden coupling — hardcoded runtime set** —
+   [`tests/test_runtimes.py:5-6`](tests/test_runtimes.py):
+   ```python
+   assert set(RUNTIMES) == {"claude", "codex", "gemini", "claude-oauth"}
+   ```
+   This will fail when opencode is added and must be updated. It is the *only*
+   Literal-style guard in the codebase — no view or serializer hardcodes the
+   runtime list.
+
+6. **Unique-env_var test collision risk** —
+   [`tests/test_runtimes.py:63-65`](tests/test_runtimes.py)
+   `test_each_runtime_has_unique_env_var` asserts all `env_var` values are
+   distinct. If opencode uses `ANTHROPIC_API_KEY` (same as `claude`), this
+   test breaks.
+
+7. **E2E parametrization** —
+   [`tests/e2e/conftest.py:21-26`](tests/e2e/conftest.py) has `RUNTIME_MODELS`
+   driving parametrized session lifecycle tests in
+   [`tests/e2e/test_sessions.py:24-29`](tests/e2e/test_sessions.py). Adding
+   `"opencode": "<model>"` and setting `E2E_RUNTIMES=opencode` is all that's
+   needed — no new test files.
+
+8. **Docs updates** — `README.md:69-75` has a manual runtime/model table that
+   must include opencode. No OpenAPI update needed beyond schema auto-gen.
+
+### Track 5: Historical context
+**Researcher**: history-researcher
+**Scope**: `thoughts/research/`, `thoughts/plans/`, git log of `runtimes.py` and `provisioning.py`, `README.md`, `CLAUDE.md`
+
+#### Findings
+
+1. **Prior runtime additions** — All three original runtimes (claude, codex,
+   gemini) landed in one commit at project inception (`3927cf9`). The only
+   post-launch runtime addition is `claude-oauth` (commit `cfe0170`), a 1-line
+   env-var change. There is no "add a runtime" precedent of the size opencode
+   will be.
+
+2. **MCP rollout conventions** — Documented in
+   `thoughts/research/2026-04-16-agent-tools-and-mcp.md` and
+   `thoughts/plans/2026-04-17-tools-mcp-examples-docs.md`. Core rules: MCP
+   auth lives in `Environment.env_vars` (encrypted), not on the agent; max 20
+   servers per agent; each runtime has a separate writer function and
+   distinct config path.
+
+3. **Skills rollout conventions** — `thoughts/research/2026-04-17-agent-skills-support.md`
+   and `thoughts/plans/2026-04-17-skills-phase-1.md`. All three runtimes
+   implement agentskills.io SKILL.md format — opencode natively supports the
+   same, which is a free compatibility win. Phase 1 is inline content only;
+   URL/git-fetch is Phase 3 (gated on public skill vulnerability rate).
+
+4. **Session service refactor has landed** — Commits `6a43cf0`, `c677159`,
+   `ae36ca6`, `c03f359`. `provision_session(user, spec: SessionSpec)` is the
+   current shape; no wrapper script. Planning for opencode should assume the
+   current (post-refactor) architecture.
+
+5. **CLAUDE.md convention** — Repeats the rule: "new models must be added to
+   both `AgentModel` *and* `MODEL_RUNTIME_MAP`". No `examples/` directory
+   exists; no docs/ update required by convention.
+
+6. **No prior opencode references** — A full-repo grep for "opencode"
+   returned zero hits across `.md`, `.py`, `.toml`, `.yaml`. Fresh territory.
+
+## Cross-Track Discoveries
+
+These emerged from connecting findings across tracks:
+
+- **Env var model mismatch is the biggest design issue.** `RuntimeConfig.env_var`
+  is a single constant per runtime (Track 2 finding 6), but opencode reads
+  native provider env vars that vary by model (Track 1 finding 4). Every
+  existing runtime has a 1:N model-to-env-var relationship (all claude models
+  → `ANTHROPIC_API_KEY`); opencode has a 1:1 model-to-env-var relationship
+  per registered model. This needs a design choice (below), not just a config
+  entry.
+- **Model flag requires new env plumbing.** Track 1 confirms opencode picks
+  model via `--model provider/model-id`, but Track 2 shows the turn command
+  only plumbs `$PROMPT` and `$AOD_SESSION_ID` — not `$MODEL`. The env file
+  writer (`_write_env_file`) must grow to include the model string so the cmd
+  can reference `"$AOD_MODEL"`. This is net-new infrastructure, but small.
+- **Skills path has a free compatibility win.** Track 1 finding 7 confirms
+  opencode reads `.claude/skills/` as a fallback. Combined with Track 3's
+  `_SKILLS_ROOTS` design, we could either give opencode its own path or point
+  it at the existing claude tree. Recommend its own path for clarity.
+- **Base image dependency sits outside this repo.** Tracks 3 and 4 both
+  independently flagged that runtime binaries are provided by the Sprites
+  platform, not fairy. The opencode code changes can merge and ship, but
+  sessions will fail until the base image is updated. This should be a
+  coordination step with whoever owns the Sprite base image.
+
+## Design Decisions
+
+These require explicit choices before implementation starts. Flagging for
+CEO/eng review.
+
+### D1. Session resume: `--continue` (simple) vs `--session <id>` (explicit)
+
+**`--continue` (recommended)**: Matches the codex `--last` pattern. No new
+session-id capture infrastructure. Works because fairy already enforces
+one-Sprite-per-session. Cost: if opencode ever spawns a subsession or the
+Sprite restarts with state, "last" is ambiguous — but neither condition holds
+today.
+
+**`--session <id>`**: Matches the claude pre-generated UUID pattern. Requires
+parsing session ID from turn-1 stdout and persisting to
+`AgentSession.runtime_session_id`. New parser, new contract with opencode's
+undocumented event schema, more failure modes.
+
+Recommend `--continue` unless someone has a specific reason to need explicit
+session IDs.
+
+### D2. Env var: per-provider vs one shared `ANTHROPIC_API_KEY`
+
+Opencode reuses `ANTHROPIC_API_KEY` for its Anthropic provider, colliding with
+claude's. Three options:
+
+- **D2a**: Set opencode's `env_var` to a provider-native name directly (e.g.
+  `"ANTHROPIC_API_KEY"`). Pro: zero translation. Con: breaks
+  `test_each_runtime_has_unique_env_var`; users with both claude and opencode
+  registered must use the same API key value for both.
+- **D2b**: AOD-managed alias (e.g. `OPENCODE_API_KEY`). Extend
+  `_write_env_file` to also export the provider-native name based on
+  model/provider. Pro: preserves the uniqueness test, independent user keys.
+  Con: small extension to `_write_env_file` logic; branches on model provider.
+- **D2c**: `OPENCODE_CONFIG_CONTENT` with inline config. Avoids env var plumbing
+  entirely. Con: more complex for little benefit; still need a per-provider
+  key somewhere.
+
+Recommend **D2b** — preserves per-runtime uniqueness semantics and lets a user
+rotate opencode keys independent of their direct claude keys.
+
+### D3. Model registration: single runtime vs one-per-provider
+
+Opencode is a multi-provider meta-runtime. Options:
+
+- **D3a (recommended)**: Single `"opencode"` runtime; `AgentModel` gains entries
+  like `OPENCODE_CLAUDE_HAIKU_4_5 = "anthropic/claude-haiku-4-5"`. The
+  `provider/` prefix is part of the stored string and gets passed to `--model`
+  via `$AOD_MODEL`.
+- **D3b**: One runtime per provider (`opencode-anthropic`, `opencode-openai`,
+  `opencode-google`). Cleaner D2 story (each runtime has one env_var), but
+  triples the maintenance surface and bloats `_SKILLS_ROOTS` / `RUNTIMES` /
+  migration rows.
+
+Recommend **D3a** — matches the existing pattern where one runtime covers many
+models.
+
+## Code References
+
+| File | Tracks | What changes |
+|------|--------|--------------|
+| `src/agent_on_demand/runtimes.py:5-20` | 2, 4 | Add `OPENCODE_*` entries to `AgentModel` |
+| `src/agent_on_demand/runtimes.py:32-45` | 4 | Add `"<model>": "opencode"` rows to `MODEL_RUNTIME_MAP` |
+| `src/agent_on_demand/runtimes.py:56-87` | 2 | Add `"opencode": RuntimeConfig(...)` to `RUNTIMES` |
+| `src/agent_on_demand/session_service/provisioning.py:30-35` | 3 | Add `"opencode": "/home/sprite/.config/opencode/skills"` to `_SKILLS_ROOTS` |
+| `src/agent_on_demand/session_service/provisioning.py:122-139` | 2, 3 | Extend `_write_env_file` to write `AOD_MODEL` and opencode provider env var (D2b) |
+| `src/agent_on_demand/session_service/provisioning.py:227-238` | 3 | Add `elif runtime_name == "opencode": _write_mcp_opencode(sprite, servers)` |
+| `src/agent_on_demand/session_service/provisioning.py` (new) | 3 | Add `_write_mcp_opencode(sprite, servers)` helper |
+| `src/agent_on_demand/session_service/tasks.py:98-109` | 2 | Confirm `$AOD_MODEL` expands in the sourced env |
+| `src/agent_on_demand/models/agents.py:18-19` | 4 | Choices on `model`/`runtime` regenerate → new migration |
+| `src/agent_on_demand/models/auth.py:51` | 4 | `RUNTIME_CHOICES` on `UserRuntimeKey` → migration |
+| `tests/test_runtimes.py:5-6` | 4 | Update hardcoded `{"claude","codex","gemini","claude-oauth"}` set |
+| `tests/test_runtimes.py:63-65` | 4 | Adjust `test_each_runtime_has_unique_env_var` per D2 choice |
+| `tests/test_tools_mcp.py` | 3 | Add `test_opencode_mcp_*` parametrization |
+| `tests/test_skills.py` | 3 | Add `test_opencode_skill_writes_under_dot_opencode` |
+| `tests/e2e/conftest.py:21-26` | 4 | Add `"opencode": "<canonical-model>"` to `RUNTIME_MODELS` |
+| `README.md:69-75` | 4, 5 | Add opencode row to runtime/model table |
+| **Sprite base image** (external) | 3 | Pre-install `opencode` binary (`npm i -g opencode-ai@latest` or curl script) |
+
+## Drafted Artifacts
+
+Assuming D1=`--continue`, D2=`OPENCODE_API_KEY` alias (D2b), D3=single runtime
+(D3a):
+
+### `runtimes.py` — `RuntimeConfig` entry
+
+```python
+"opencode": RuntimeConfig(
+    name="opencode",
+    cmd='opencode run --model "$AOD_MODEL" --format json "$PROMPT"',
+    continue_cmd='opencode run --model "$AOD_MODEL" --format json --continue "$PROMPT"',
+    env_var="OPENCODE_API_KEY",
+),
+```
+
+### `provisioning.py` — `_write_mcp_opencode`
+
+```python
+def _write_mcp_opencode(sprite: Sprite, servers: list[McpServerSpec]) -> None:
+    sprite.command("mkdir", "-p", "/home/sprite/.config/opencode").run()
+    config: dict[str, dict] = {}
+    for s in servers:
+        if s.type == "url":
+            entry: dict = {"type": "remote", "url": s.url, "enabled": True}
+            if s.headers:
+                entry["headers"] = s.headers
+        elif s.type == "stdio":
+            entry = {
+                "type": "local",
+                "command": [s.command, *s.args],
+                "enabled": True,
+            }
+            if s.env:
+                entry["environment"] = s.env
+        config[s.name] = entry
+    fs = sprite.filesystem()
+    (fs / "home/sprite/.config/opencode/opencode.json").write_text(
+        json.dumps({"mcp": config}, indent=2)
+    )
+```
+
+### `_write_env_file` extension (D2b sketch)
+
+Add `AOD_MODEL` for all runtimes (harmless constant; only opencode reads it),
+plus translate `OPENCODE_API_KEY` into the native provider env var based on
+the model's provider prefix:
+
+```python
+# Inside _write_env_file, after existing lines:
+if spec.agent_model:  # e.g. "anthropic/claude-haiku-4-5"
+    lines.append(f"AOD_MODEL={shlex.quote(spec.agent_model)}")
+    if spec.runtime.name == "opencode":
+        provider = spec.agent_model.split("/", 1)[0]
+        native = {
+            "anthropic": "ANTHROPIC_API_KEY",
+            "openai": "OPENAI_API_KEY",
+            "google": "GEMINI_API_KEY",
+        }.get(provider)
+        if native:
+            lines.append(f"{native}={shlex.quote(spec.api_key)}")
+```
+
+## Historical Context
+
+- `thoughts/research/2026-04-16-agent-tools-and-mcp.md` — original MCP design,
+  cross-runtime config-path table, validation rules.
+- `thoughts/research/2026-04-17-agent-skills-support.md` — skills architecture,
+  agentskills.io conformance, SKILL_EOF injection hazard.
+- `thoughts/plans/2026-04-19-session-service-api-refactor.md` — the
+  `SessionSpec` / wrapper-removal refactor that shaped the current
+  `provision_session` signature.
+- Commits to reference for style/scope: `3927cf9` (original runtimes batch),
+  `cfe0170` (claude-oauth 1-line addition — tiny counter-example to opencode's
+  complexity).
+
+## Open Questions
+
+1. **Who owns the Sprite base image?** Adding opencode to the base image is a
+   prerequisite. This doc doesn't answer that — it's a coordination question
+   for whoever controls the Sprites platform image.
+2. **Which opencode models do we register first?** Suggest starting with one
+   cheap model per provider (`anthropic/claude-haiku-4-5`, `openai/gpt-4o`,
+   `google/gemini-2.5-flash-lite-preview-09-2025`) to validate the integration
+   end-to-end without model-list bloat.
+3. **Does UserRuntimeKey need a per-provider key story?** D2b stores one
+   `OPENCODE_API_KEY` per user. If a user wants to mix opencode+Anthropic and
+   opencode+OpenAI in different agents, they'd need two separate
+   UserRuntimeKey rows — but today UserRuntimeKey is keyed on `(user,
+   runtime)`. This would need a small schema extension (or a convention that
+   OPENCODE_API_KEY covers all providers a user actually uses).
+4. **JSON event schema stability.** Opencode's `--format json` output is
+   undocumented. If we ever add a per-runtime parser, we'd need to reverse-
+   engineer or upstream a PR to document the schema. Not blocking for initial
+   support (stream.py is raw passthrough).


### PR DESCRIPTION
## Summary
Pre-implementation research artifacts for the two new runtimes on the roadmap (goose, opencode), plus a meta-runtime-pattern writeup that distills the shared structure behind `RuntimeConfig` so the next additions land without bespoke per-runtime branches in `session_service/`.

Three research docs under `thoughts/research/`:
- `2026-04-21-goose-runtime-support.md`
- `2026-04-21-opencode-runtime-support.md`
- `2026-04-21-meta-runtime-pattern.md`

No code changes. These are just being tracked in git alongside the rest of `thoughts/` so future work on goose/opencode has the context.

## Test plan
- [ ] CI passes (these are docs-only; lint/test/validate-openapi should all be no-ops for the diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)