### PR TITLE
Redesign landing page with hero, live terminal, and runtime strip

### DIFF
--- a/src/agent_on_demand/static/ui/styles.css
+++ b/src/agent_on_demand/static/ui/styles.css
@@ -173,32 +173,312 @@ dl.kv dd { margin: 0; }
   overflow: auto;
 }
 
-.landing-hero { padding: 1.5rem 0 0.5rem; }
-.landing-hero h1 { font-size: 2.2rem; margin-bottom: 0.5rem; }
-.landing-hero .lede { font-size: 1.1rem; color: var(--fg); max-width: 640px; }
-.landing-ctas { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 1.25rem; }
-.btn-primary, .btn-secondary {
+/* ============== Buttons (shared) ============== */
+.btn-primary, .btn-secondary, .btn-ghost {
   display: inline-block;
-  padding: 0.55rem 1rem;
-  border-radius: 4px;
+  padding: 0.6rem 1.05rem;
+  border-radius: 6px;
   text-decoration: none;
   font-weight: 500;
+  transition: transform 0.12s ease, background 0.12s ease, filter 0.12s ease;
 }
 .btn-primary { background: var(--accent); color: #fff; }
 .btn-primary:hover { background: #1f5891; }
 .btn-secondary { background: var(--card); color: var(--accent); border: 1px solid var(--border); }
 .btn-secondary:hover { background: #f0f0f0; }
-
-.landing-cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1rem;
-  margin: 2rem 0;
+.btn-ghost {
+  background: rgba(255, 255, 255, 0.04);
+  color: #e7eaf3;
+  border: 1px solid rgba(255, 255, 255, 0.14);
 }
-.landing-cards .card { padding: 1rem 1.1rem; }
-.landing-cards .card h3 { margin: 0 0 0.4rem; }
-.landing-cards .card p { margin: 0; color: var(--muted); }
+.btn-ghost:hover { background: rgba(255, 255, 255, 0.1); }
 
-.landing-block { margin: 2rem 0; }
-.landing-block h2 { margin-bottom: 0.5rem; }
-.landing-block p { max-width: 720px; }
+/* ============== Landing page ============== */
+body.landing-body main { max-width: none; padding: 0; }
+
+.landing-page { display: block; }
+.landing-container {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* --- Hero --- */
+.landing-hero {
+  position: relative;
+  padding: 4.5rem 0 5rem;
+  color: #e7eaf3;
+  background:
+    radial-gradient(1200px 520px at 82% -10%, rgba(91, 124, 255, 0.28), transparent 60%),
+    radial-gradient(900px 520px at 8% 120%, rgba(181, 141, 255, 0.22), transparent 60%),
+    linear-gradient(180deg, #0b0e15 0%, #0b0e15 100%);
+  border-bottom: 1px solid #161b28;
+  overflow: hidden;
+}
+.landing-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+  background-size: 48px 48px;
+  -webkit-mask-image: radial-gradient(ellipse 85% 65% at 50% 35%, #000 40%, transparent 100%);
+  mask-image: radial-gradient(ellipse 85% 65% at 50% 35%, #000 40%, transparent 100%);
+  pointer-events: none;
+}
+.landing-hero > .landing-container { position: relative; }
+
+.landing-hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+  gap: 3rem;
+  align-items: center;
+}
+@media (max-width: 900px) {
+  .landing-hero-grid { grid-template-columns: 1fr; gap: 2.25rem; }
+  .landing-hero { padding: 3rem 0 3.5rem; }
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #9aa3bd;
+  padding: 0.35rem 0.7rem;
+  border: 1px solid #232a3d;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.02);
+  margin-bottom: 1.25rem;
+}
+
+.landing-hero h1 {
+  font-size: clamp(2rem, 5.2vw, 3.4rem);
+  font-weight: 700;
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+  margin: 0 0 1rem;
+  color: #fff;
+}
+.landing-hero h1 .grad {
+  background: linear-gradient(90deg, #7aa2ff 0%, #c4a8ff 50%, #ff9fd1 100%);
+  -webkit-background-clip: text;
+          background-clip: text;
+  color: transparent;
+}
+.landing-hero .lede {
+  font-size: 1.08rem;
+  color: #b8c0d6;
+  max-width: 560px;
+  margin: 0 0 1.5rem;
+}
+.landing-hero .lede code {
+  padding: 0.08rem 0.35rem;
+  background: rgba(122, 162, 255, 0.12);
+  color: #c6d4ff;
+  border: 1px solid rgba(122, 162, 255, 0.22);
+  border-radius: 4px;
+}
+
+.landing-ctas { display: flex; gap: 0.65rem; flex-wrap: wrap; margin-top: 1.25rem; }
+.landing-hero .btn-primary {
+  background: linear-gradient(180deg, #5f82ff 0%, #3a5cff 100%);
+  border: 1px solid #3a5cff;
+  box-shadow: 0 8px 24px rgba(58, 92, 255, 0.35),
+              inset 0 1px 0 rgba(255, 255, 255, 0.18);
+}
+.landing-hero .btn-primary:hover { filter: brightness(1.08); transform: translateY(-1px); }
+.landing-hero .btn-ghost:hover { transform: translateY(-1px); }
+
+.hero-meta {
+  display: flex;
+  gap: 1.4rem;
+  flex-wrap: wrap;
+  margin-top: 1.75rem;
+  color: #8d95ae;
+  font-size: 0.88rem;
+}
+.dot {
+  display: inline-block;
+  width: 7px; height: 7px;
+  border-radius: 999px;
+  margin-right: 0.45rem;
+  vertical-align: middle;
+}
+.dot-green { background: #52d39a; box-shadow: 0 0 10px rgba(82, 211, 154, 0.8); }
+.dot-blue { background: #5f82ff; box-shadow: 0 0 10px rgba(95, 130, 255, 0.8); }
+.dot-violet { background: #b58dff; box-shadow: 0 0 10px rgba(181, 141, 255, 0.8); }
+.dot.pulse { animation: dot-pulse 2.2s ease-in-out infinite; }
+@keyframes dot-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(82, 211, 154, 0.55); }
+  50%      { box-shadow: 0 0 0 6px rgba(82, 211, 154, 0); }
+}
+
+/* --- Terminal --- */
+.terminal {
+  background: #0d1017;
+  border: 1px solid #1e2434;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.55),
+              0 0 0 1px rgba(255, 255, 255, 0.02) inset;
+}
+.terminal-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.42rem;
+  padding: 0.6rem 0.9rem;
+  border-bottom: 1px solid #1e2434;
+  background: linear-gradient(180deg, #151a28, #0d1017);
+}
+.tdot { width: 11px; height: 11px; border-radius: 999px; background: #2a3042; }
+.tdot:nth-child(1) { background: #ff5f57; }
+.tdot:nth-child(2) { background: #febc2e; }
+.tdot:nth-child(3) { background: #28c840; }
+.terminal-title {
+  margin-left: auto;
+  font-size: 0.76rem;
+  color: #6d7590;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.terminal-body {
+  margin: 0;
+  padding: 1rem 1.15rem 1.2rem;
+  background: transparent;
+  color: #c9cfe2;
+  border: none;
+  white-space: pre;
+  overflow-x: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  line-height: 1.6;
+  border-radius: 0;
+}
+.terminal-body .c-mute { color: #6d7590; }
+.terminal-body .c-cmd  { color: #7aa2ff; }
+.terminal-body .c-evt  { color: #ff9fd1; }
+.terminal-body .c-str  { color: #b5e39a; }
+
+.caret {
+  display: inline-block;
+  color: #7aa2ff;
+  animation: caret-blink 1s steps(2) infinite;
+}
+@keyframes caret-blink {
+  0%, 49%   { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .caret, .dot.pulse { animation: none; }
+}
+
+/* --- Features --- */
+.landing-features {
+  margin-top: 3.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+.feature {
+  padding: 1.25rem 1.25rem 1.1rem;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  transition: transform 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.feature:hover {
+  transform: translateY(-2px);
+  border-color: #c7cee0;
+  box-shadow: 0 10px 30px rgba(30, 40, 80, 0.06);
+}
+.feature-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px; height: 36px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #eef2ff 0%, #f7eefb 100%);
+  color: #5f82ff;
+  margin-bottom: 0.7rem;
+}
+.feature h3 { margin: 0 0 0.3rem; font-size: 1.05rem; }
+.feature p  { margin: 0; color: var(--muted); font-size: 0.95rem; }
+
+/* --- Code showcase --- */
+.landing-code { margin-top: 4rem; }
+.section-head h2 {
+  font-size: clamp(1.4rem, 2.4vw, 1.85rem);
+  letter-spacing: -0.015em;
+  margin: 0 0 0.35rem;
+}
+.section-head .muted { margin: 0 0 1rem; }
+
+.code-block {
+  background: #0d1017;
+  color: #c9cfe2;
+  border: 1px solid #1e2434;
+  border-radius: 10px;
+  padding: 1.1rem 1.25rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85rem;
+  line-height: 1.65;
+  overflow-x: auto;
+  white-space: pre;
+  word-break: normal;
+  box-shadow: 0 10px 30px rgba(30, 40, 80, 0.08);
+}
+.code-block .c-mute { color: #6d7590; }
+.code-block .c-cmd  { color: #7aa2ff; }
+.code-block .c-str  { color: #b5e39a; }
+
+/* --- Runtime strip --- */
+.runtime-strip { margin-top: 4rem; text-align: center; }
+.runtime-strip h2 {
+  font-size: clamp(1.05rem, 1.8vw, 1.25rem);
+  margin: 0 0 1rem;
+  color: var(--muted);
+  font-weight: 500;
+  letter-spacing: 0.005em;
+}
+.runtime-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.6rem;
+  max-width: 720px;
+  margin: 0 auto;
+}
+.runtime-chip {
+  padding: 0.75rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9rem;
+  color: var(--fg);
+  background: var(--card);
+  transition: transform 0.12s ease, border-color 0.12s ease;
+}
+.runtime-chip:hover { transform: translateY(-1px); border-color: #b9c1d4; }
+.runtime-chip-muted {
+  color: var(--muted);
+  border-style: dashed;
+  background: transparent;
+}
+
+/* --- Outro --- */
+.landing-outro {
+  margin-top: 4rem;
+  padding-bottom: 4rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2.5rem;
+}
+.landing-block h2 {
+  margin: 0 0 0.55rem;
+  font-size: 1.35rem;
+  letter-spacing: -0.01em;
+}
+.landing-block p { max-width: 720px; margin: 0 0 0.9rem; }
+.landing-block .btn-secondary { margin-right: 0.5rem; }

--- a/src/agent_on_demand/templates/ui/base.html
+++ b/src/agent_on_demand/templates/ui/base.html
@@ -6,7 +6,7 @@
   <title>{% block title %}Agent on Demand{% endblock %}</title>
   <link rel="stylesheet" href="{% static 'ui/styles.css' %}">
 </head>
-<body>
+<body class="{% block body_class %}{% endblock %}">
   <header class="topbar">
     <a class="brand" href="{% url 'landing' %}">Agent on Demand</a>
     {% if user.is_authenticated %}

--- a/src/agent_on_demand/templates/ui/landing.html
+++ b/src/agent_on_demand/templates/ui/landing.html
@@ -1,63 +1,140 @@
 {% extends "ui/base.html" %}
-{% block title %}Agent on Demand{% endblock %}
+{% block title %}Agent on Demand · Coding agents as an API{% endblock %}
+{% block body_class %}landing-body{% endblock %}
 {% block content %}
-  <section class="landing-hero">
-    <h1>Agent on Demand</h1>
-    <p class="lede">
-      A REST API for running AI coding agents on sandboxed cloud machines.
-      Define an <strong>agent</strong> (model + runtime), wire up an
-      <strong>environment</strong> (packages, env vars, network rules), and start
-      a <strong>session</strong>. Stream output back over SSE. Multi-turn when
-      you need it.
-    </p>
-    <div class="landing-ctas">
-      {% if user.is_authenticated %}
-        <a class="btn-primary" href="{% url 'ui-dashboard' %}">Open dashboard</a>
-      {% else %}
-        <a class="btn-primary" href="{% url 'ui-register' %}">Create an account</a>
-      {% endif %}
-      <a class="btn-secondary" href="https://ravi-hq.github.io/agent-on-demand">Read the docs</a>
-      <a class="btn-secondary" href="https://github.com/ravi-hq/agent-on-demand">GitHub</a>
-    </div>
-  </section>
+  <div class="landing-page">
 
-  <section class="landing-cards">
-    <div class="card">
-      <h3>Agents</h3>
-      <p>A runtime + model pairing. Claude, Codex, Gemini, and more. Optional MCP servers and system prompts.</p>
-    </div>
-    <div class="card">
-      <h3>Environments</h3>
-      <p>Packages, env vars, setup scripts, DNS allow-lists. Encrypted at rest. Versioned.</p>
-    </div>
-    <div class="card">
-      <h3>Sessions</h3>
-      <p>One agent run on one environment. Stream output over SSE. Resume with new prompts.</p>
-    </div>
-  </section>
+    <section class="landing-hero">
+      <div class="landing-container landing-hero-grid">
+        <div class="landing-hero-copy">
+          <div class="eyebrow">
+            <span class="dot dot-green pulse"></span>
+            REST API · Open source · Apache-2.0
+          </div>
+          <h1>
+            Spawn a coding agent
+            <span class="grad">in one request.</span>
+          </h1>
+          <p class="lede">
+            Agent on Demand is a REST API for running Claude Code, Codex and
+            Gemini CLI on fresh, sandboxed cloud machines. Define an agent,
+            wire up an environment, <code>POST /sessions</code>, stream the
+            output over SSE. Multi-turn when you need it.
+          </p>
+          <div class="landing-ctas">
+            {% if user.is_authenticated %}
+              <a class="btn-primary" href="{% url 'ui-dashboard' %}">Open dashboard →</a>
+            {% else %}
+              <a class="btn-primary" href="{% url 'ui-register' %}">Get started — it's free →</a>
+            {% endif %}
+            <a class="btn-ghost" href="https://ravi-hq.github.io/agent-on-demand">Read the docs</a>
+            <a class="btn-ghost" href="https://github.com/ravi-hq/agent-on-demand">GitHub ↗</a>
+          </div>
+          <div class="hero-meta">
+            <span><span class="dot dot-green"></span> Sandboxed per session</span>
+            <span><span class="dot dot-blue"></span> Bring your own keys</span>
+            <span><span class="dot dot-violet"></span> Versioned &amp; auditable</span>
+          </div>
+        </div>
 
-  <section class="landing-block">
-    <h2>Powered by Sprites</h2>
-    <p>
-      Every session runs inside a fresh sandbox provisioned on
-      <a href="https://sprites.dev">sprites.dev</a>. You bring your own Sprites
-      token and your own model API keys, stored encrypted and scoped per-user.
-      No shared credentials, no credential pooling.
-    </p>
-  </section>
+        <div class="terminal" aria-hidden="true">
+          <div class="terminal-bar">
+            <span class="tdot"></span><span class="tdot"></span><span class="tdot"></span>
+            <span class="terminal-title">aod.ravi.id · live session</span>
+          </div>
+<pre class="terminal-body"><span class="c-mute">$</span> <span class="c-cmd">curl -N https://aod.ravi.id/sessions/s_4f2c/stream \
+    -H "Authorization: Bearer $AOD_KEY"</span>
 
-  <section class="landing-block">
-    <h2>Open source. Contributors welcome.</h2>
-    <p>
-      Agent on Demand is Apache-2.0 and lives on
-      <a href="https://github.com/ravi-hq/agent-on-demand">GitHub</a>. We'd
-      especially love help adding more runtimes and model backends. If your
-      favorite agent CLI isn't supported, open a PR, file an issue, or come
-      say hello.
-    </p>
-    <p>
-      <a class="btn-secondary" href="https://github.com/ravi-hq/agent-on-demand/issues">Browse issues</a>
-      <a class="btn-secondary" href="https://ravi-hq.github.io/agent-on-demand">Architecture docs</a>
-    </p>
-  </section>
+<span class="c-evt">event:</span> session.started
+<span class="c-evt">data:</span>  <span class="c-str">{"id":"s_4f2c","agent":"claude-sonnet-4-6"}</span>
+
+<span class="c-evt">event:</span> turn.chunk
+<span class="c-evt">data:</span>  <span class="c-str">{"text":"Reading src/payments.py…"}</span>
+
+<span class="c-evt">event:</span> turn.chunk
+<span class="c-evt">data:</span>  <span class="c-str">{"text":"Applying refactor across 3 files…"}</span>
+
+<span class="c-evt">event:</span> turn.completed
+<span class="c-evt">data:</span>  <span class="c-str">{"status":"ok","files_changed":3,"tokens":41_208}</span><span class="caret">▍</span></pre>
+        </div>
+      </div>
+    </section>
+
+    <section class="landing-container landing-features">
+      <div class="feature">
+        <div class="feature-icon">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="12" rx="2"/><path d="M8 20h8M12 16v4"/><circle cx="9" cy="10" r="1.2" fill="currentColor"/><circle cx="15" cy="10" r="1.2" fill="currentColor"/></svg>
+        </div>
+        <h3>Agents</h3>
+        <p>Runtime + model. Claude Code, Codex, Gemini CLI. Optional MCP servers, system prompts. Versioned with optimistic concurrency.</p>
+      </div>
+      <div class="feature">
+        <div class="feature-icon">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l8 4v6c0 5-3.5 8.5-8 10-4.5-1.5-8-5-8-10V6l8-4z"/><path d="M9 12l2 2 4-4"/></svg>
+        </div>
+        <h3>Environments</h3>
+        <p>Packages, setup scripts, env vars, DNS allow-lists. Secrets encrypted at rest, never echoed back. DNS-enforced egress when you need it.</p>
+      </div>
+      <div class="feature">
+        <div class="feature-icon">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12h3l2-6 4 12 2-6h5"/></svg>
+        </div>
+        <h3>Sessions</h3>
+        <p>One agent on one environment. Stream turns over SSE. Resume with follow-up prompts. Every turn logged, replayable, terminable.</p>
+      </div>
+    </section>
+
+    <section class="landing-container landing-code">
+      <div class="section-head">
+        <h2>Five lines. One session.</h2>
+        <p class="muted">The whole API fits on a postcard. Create it, prompt it, stream it.</p>
+      </div>
+<pre class="code-block"><span class="c-mute"># 1. Create an agent (runtime + model)</span>
+<span class="c-cmd">curl -X POST https://aod.ravi.id/agents</span> \
+  -H <span class="c-str">"Authorization: Bearer $AOD_KEY"</span> \
+  -d <span class="c-str">'{"name":"refactor-bot","model":"claude-sonnet-4-6"}'</span>
+
+<span class="c-mute"># 2. Start a session and stream the output</span>
+<span class="c-cmd">curl -N https://aod.ravi.id/sessions</span> \
+  -H <span class="c-str">"Authorization: Bearer $AOD_KEY"</span> \
+  -d <span class="c-str">'{"agent_id":"…","environment_id":"…","prompt":"refactor payments.py"}'</span>
+</pre>
+    </section>
+
+    <section class="landing-container runtime-strip">
+      <h2>Runs the agent CLI you already use.</h2>
+      <div class="runtime-grid">
+        <div class="runtime-chip">claude</div>
+        <div class="runtime-chip">codex</div>
+        <div class="runtime-chip">gemini</div>
+        <div class="runtime-chip runtime-chip-muted">+ your PR welcome</div>
+      </div>
+    </section>
+
+    <section class="landing-container landing-outro">
+      <div class="landing-block">
+        <h2>Powered by Sprites.</h2>
+        <p>
+          Every session runs inside a fresh sandbox provisioned on
+          <a href="https://sprites.dev">sprites.dev</a>. You bring your own
+          Sprites token and your own model API keys — stored encrypted and
+          scoped per-user. No shared credentials, no credential pooling.
+        </p>
+      </div>
+      <div class="landing-block">
+        <h2>Open source. Contributors welcome.</h2>
+        <p>
+          Agent on Demand is Apache-2.0 and lives on
+          <a href="https://github.com/ravi-hq/agent-on-demand">GitHub</a>.
+          We'd especially love help adding more runtimes and model backends.
+          If your favorite agent CLI isn't supported, open a PR.
+        </p>
+        <p>
+          <a class="btn-secondary" href="https://github.com/ravi-hq/agent-on-demand/issues">Browse issues</a>
+          <a class="btn-secondary" href="https://ravi-hq.github.io/agent-on-demand">Architecture docs</a>
+        </p>
+      </div>
+    </section>
+
+  </div>
 {% endblock %}


### PR DESCRIPTION
## Summary

Punches up the bland landing at `/` (aod.ravi.id) with a proper dev-tool hero.

- **Hero**: full-bleed dark section with radial gradient + subtle grid pattern, pulsing status dot, headline with gradient accent ("Spawn a coding agent **in one request.**"), and a right-side mock terminal rendering a streaming SSE session (`session.started` → `turn.chunk` → `turn.completed`) with a blinking caret.
- **Features**: three hover-lifted cards with inline SVG icons for Agents / Environments / Sessions.
- **Code showcase**: "Five lines. One session." with a real curl example (create agent → stream session).
- **Runtime strip**: monospace chips for the CLIs actually in `runtimes.py` — `claude`, `codex`, `gemini`, `+ your PR welcome`.
- **Outro**: "Powered by Sprites" + "Open source" kept, in a two-column layout.

## Plumbing

- `base.html` now exposes a `{% block body_class %}` so the landing can opt out of `main`'s 960px cap via `body.landing-body main { max-width: none; padding: 0 }`.
- `landing.html` is a single `.landing-page` wrapper with per-section `.landing-container` at 1120px.
- `styles.css` replaces the old `.landing-*` rules and adds `.btn-ghost` for the dark hero. Respects `prefers-reduced-motion` (disables caret + dot pulse).
- Strings required by `tests/test_ui.py` (`sprites.dev`, `/ui/register`, `Open dashboard` when logged in, absence of `Create an account` when logged in) are preserved.

## Test plan

- [x] `make test` — unit + integration pass (22 `test_ui.py` tests incl. landing)
- [x] Visual: desktop (1440) and mobile (390) screenshots, no horizontal overflow, no console errors
- [x] Grid collapses to single column < 900px
- [ ] Re-check rendered output on the deploy preview / prod after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)