### PR TITLE
Port runtimes, rewrite session_service, drop legacy shapes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,8 @@ It manages three resources: **agents**, **environments**, and **sessions**. See
   - `models/` — `Agent`, `Environment`, `Session`, version history
   - `views/` — All HTTP endpoints (per-resource routers)
   - `urls.py` — Route table (single source of truth for the API surface)
-  - `runtimes.py` — `AgentModel` enum and `MODEL_RUNTIME_MAP`
+  - `runtimes/` — per-runtime `Runtime` classes (`claude.py`, `codex.py`, `gemini.py`) and the `RUNTIMES` registry
+  - `models_catalog.py` — `MODELS` dict keyed by canonical `provider/model_id` strings
   - `session_service/` — Sprites orchestration
     - `provisioning.py` — `provision_session`, per-stage helpers
     - `tasks.py` — `execute_turn` Procrastinate task (runs in worker process)
@@ -55,8 +56,10 @@ directly (without `make`), `tests/e2e/conftest.py` defaults to
 
 ## Conventions
 
-- **Runtimes**: new models must be added to both `AgentModel` *and*
-  `MODEL_RUNTIME_MAP` in `src/agent_on_demand/runtimes.py`.
+- **Runtimes**: new models go in `src/agent_on_demand/models_catalog.py`; ensure
+  the `provider` is in the target `Runtime`'s `providers` set. New runtimes are
+  one file per class under `src/agent_on_demand/runtimes/` and must be added to
+  the `RUNTIMES` dict in `runtimes/__init__.py`.
 - **Versioning**: `agents` and `environments` use optimistic concurrency —
   updates require the current `version` and return a new row in
   `{agent,environment}_versions`. Tests to reference: `test_agents.py::TestAgentVersioning`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ It manages three resources: **agents**, **environments**, and **sessions**. See
   - `models/` — `Agent`, `Environment`, `Session`, version history
   - `views/` — All HTTP endpoints (per-resource routers)
   - `urls.py` — Route table (single source of truth for the API surface)
-  - `runtimes/` — per-runtime `Runtime` classes (`claude.py`, `codex.py`, `gemini.py`) and the `RUNTIMES` registry
+  - `runtimes/` — per-runtime `Runtime` classes (`claude.py`, `codex.py`, `gemini.py`, `opencode.py`) and the `RUNTIMES` registry
   - `models_catalog.py` — `MODELS` dict keyed by canonical `provider/model_id` strings
   - `session_service/` — Sprites orchestration
     - `provisioning.py` — `provision_session`, per-stage helpers

--- a/README.md
+++ b/README.md
@@ -66,17 +66,29 @@ Authentication is via `Authorization: Bearer <token>`.
 Supported runtimes (selected by `runtime` on an agent) and their models.
 Model strings follow the canonical `provider/model_id` form:
 
-| Runtime  | Providers    | Example models                                                                   |
-| -------- | ------------ | -------------------------------------------------------------------------------- |
-| `claude` | `anthropic`  | `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5` |
-| `codex`  | `openai`     | `openai/gpt-4.1`, `openai/o3`, `openai/o4-mini`                                  |
-| `gemini` | `google`     | `google/gemini-2.5-pro`, `google/gemini-2.5-flash`                               |
+| Runtime    | Providers                       | Example models                                                                   |
+| ---------- | ------------------------------- | -------------------------------------------------------------------------------- |
+| `claude`   | `anthropic`                     | `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5` |
+| `codex`    | `openai`                        | `openai/gpt-4.1`, `openai/o3`, `openai/o4-mini`                                  |
+| `gemini`   | `google`                        | `google/gemini-2.5-pro`, `google/gemini-2.5-flash`                               |
+| `opencode` | `anthropic`, `openai`, `google` | any `anthropic/*`, `openai/*`, or `google/*` in the model catalog                |
 
 A model is servable by a runtime whose `providers` set contains the model's
 `provider`. The Claude runtime authenticates via an Anthropic API key by
 default and falls back to OAuth automatically when the user has a
 `runtime_token:claude-oauth` credential registered — the former `claude-oauth`
 runtime was folded into `claude`.
+
+`opencode` is a multi-provider meta-runtime: one `opencode` CLI fronts many
+providers and picks provider+model per invocation via `--model
+provider/model_id`. It reads the native provider env vars
+(`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY`) directly, which
+are sourced from the user's registered `UserCredential` rows. Opencode is
+**not pre-installed** on the Sprite base image — sessions install it via
+`npm i -g opencode-ai` during the `install_runtime` provisioning stage (which
+runs before any network policy is applied, so `registry.npmjs.org` does not
+need to be in `allowed_hosts`). First-session provisioning takes ~10–30s
+longer than the pre-baked runtimes as a result.
 
 Runtime list: `src/agent_on_demand/runtimes/`. Model catalog:
 `src/agent_on_demand/models_catalog.py`.
@@ -87,7 +99,7 @@ Agents do not have a configurable tool allowlist. Each session runs its runtime
 CLI with that CLI's full default tool set — `bash`, `read`, `write`, `edit`,
 `glob`, `grep`, `web_fetch`, `web_search`, etc. Any MCP servers configured on
 the agent are additionally exposed to the runtime. This applies to every
-runtime (`claude`, `codex`, `gemini`).
+runtime (`claude`, `codex`, `gemini`, `opencode`).
 
 There is no per-agent way to disable or restrict individual built-in tools.
 
@@ -119,7 +131,7 @@ Optional:
   serves). Export a different value to point at another deployment. Note that
   running `pytest` directly (without `make`) defaults to `http://localhost:8000`
   via `tests/e2e/conftest.py`.
-- `E2E_RUNTIMES` — comma-separated subset of `claude,codex,gemini`
+- `E2E_RUNTIMES` — comma-separated subset of `claude,codex,gemini,opencode`
   (default `claude`)
 - `E2E_TIMEOUT` — max seconds to wait for a session (default `180`)
 

--- a/README.md
+++ b/README.md
@@ -63,17 +63,23 @@ Authentication is via `Authorization: Bearer <token>`.
 
 ## Runtimes
 
-Supported runtimes (selected by `runtime` on an agent) and their model
-families:
+Supported runtimes (selected by `runtime` on an agent) and their models.
+Model strings follow the canonical `provider/model_id` form:
 
-| Runtime        | Example models                                 |
-| -------------- | ---------------------------------------------- |
-| `claude`       | `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5` |
-| `claude-oauth` | same as `claude`, OAuth auth path              |
-| `codex`        | `gpt-4.1`, `o3`, `o4-mini`                     |
-| `gemini`       | `gemini-2.5-pro`, `gemini-2.5-flash`           |
+| Runtime  | Providers    | Example models                                                                   |
+| -------- | ------------ | -------------------------------------------------------------------------------- |
+| `claude` | `anthropic`  | `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5` |
+| `codex`  | `openai`     | `openai/gpt-4.1`, `openai/o3`, `openai/o4-mini`                                  |
+| `gemini` | `google`     | `google/gemini-2.5-pro`, `google/gemini-2.5-flash`                               |
 
-Full list in `src/agent_on_demand/runtimes.py`.
+A model is servable by a runtime whose `providers` set contains the model's
+`provider`. The Claude runtime authenticates via an Anthropic API key by
+default and falls back to OAuth automatically when the user has a
+`runtime_token:claude-oauth` credential registered — the former `claude-oauth`
+runtime was folded into `claude`.
+
+Runtime list: `src/agent_on_demand/runtimes/`. Model catalog:
+`src/agent_on_demand/models_catalog.py`.
 
 ## Tools
 
@@ -81,7 +87,7 @@ Agents do not have a configurable tool allowlist. Each session runs its runtime
 CLI with that CLI's full default tool set — `bash`, `read`, `write`, `edit`,
 `glob`, `grep`, `web_fetch`, `web_search`, etc. Any MCP servers configured on
 the agent are additionally exposed to the runtime. This applies to every
-runtime (`claude`, `claude-oauth`, `codex`, `gemini`).
+runtime (`claude`, `codex`, `gemini`).
 
 There is no per-agent way to disable or restrict individual built-in tools.
 
@@ -113,7 +119,7 @@ Optional:
   serves). Export a different value to point at another deployment. Note that
   running `pytest` directly (without `make`) defaults to `http://localhost:8000`
   via `tests/e2e/conftest.py`.
-- `E2E_RUNTIMES` — comma-separated subset of `claude,codex,gemini,claude-oauth`
+- `E2E_RUNTIMES` — comma-separated subset of `claude,codex,gemini`
   (default `claude`)
 - `E2E_TIMEOUT` — max seconds to wait for a session (default `180`)
 

--- a/src/agent_on_demand/admin.py
+++ b/src/agent_on_demand/admin.py
@@ -13,10 +13,11 @@ from agent_on_demand.models import (
     AgentSessionLog,
     Environment,
     EnvironmentVersion,
+    UserCredential,
     UserQuota,
-    UserRuntimeKey,
     UserSpritesKey,
 )
+from agent_on_demand.models.auth import CREDENTIAL_ENV_VAR
 
 
 class APIKeyInline(admin.TabularInline):
@@ -26,10 +27,10 @@ class APIKeyInline(admin.TabularInline):
     readonly_fields = ("key_prefix", "created_at")
 
 
-class UserRuntimeKeyInline(admin.TabularInline):
-    model = UserRuntimeKey
+class UserCredentialInline(admin.TabularInline):
+    model = UserCredential
     extra = 0
-    fields = ("runtime", "created_at", "updated_at")
+    fields = ("kind", "created_at", "updated_at")
     readonly_fields = ("created_at", "updated_at")
 
 
@@ -54,7 +55,7 @@ admin.site.unregister(User)
 class UserAdmin(BaseUserAdmin):
     inlines = list(BaseUserAdmin.inlines) + [
         APIKeyInline,
-        UserRuntimeKeyInline,
+        UserCredentialInline,
         UserSpritesKeyInline,
         UserQuotaInline,
     ]
@@ -90,41 +91,46 @@ class APIKeyAdmin(admin.ModelAdmin):
             super().save_model(request, obj, form, change)
 
 
-class UserRuntimeKeyForm(forms.ModelForm):
-    api_key = forms.CharField(
+class UserCredentialForm(forms.ModelForm):
+    kind = forms.ChoiceField(
+        choices=[(k, k) for k in CREDENTIAL_ENV_VAR],
+        help_text="Credential kind (e.g. provider:anthropic). Determines the "
+        "env var that gets exported on Sprite startup.",
+    )
+    value = forms.CharField(
         widget=forms.PasswordInput(render_value=True),
-        help_text="The API key for this runtime. Stored encrypted.",
+        help_text="The credential value. Stored encrypted.",
     )
 
     class Meta:
-        model = UserRuntimeKey
-        fields = ("user", "runtime", "api_key")
+        model = UserCredential
+        fields = ("user", "kind", "value")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.instance.pk:
-            self.fields["api_key"].initial = self.instance.get_api_key()
+            self.fields["value"].initial = self.instance.get_value()
 
     def save(self, commit=True):
         instance = super().save(commit=False)
-        instance.set_api_key(self.cleaned_data["api_key"])
+        instance.set_value(self.cleaned_data["value"])
         if commit:
             instance.save()
         return instance
 
 
-@admin.register(UserRuntimeKey)
-class UserRuntimeKeyAdmin(admin.ModelAdmin):
-    form = UserRuntimeKeyForm
-    list_display = ("user", "runtime", "created_at", "updated_at")
-    list_filter = ("runtime",)
-    search_fields = ("user__email", "runtime")
+@admin.register(UserCredential)
+class UserCredentialAdmin(admin.ModelAdmin):
+    form = UserCredentialForm
+    list_display = ("user", "kind", "created_at", "updated_at")
+    list_filter = ("kind",)
+    search_fields = ("user__email", "kind")
     readonly_fields = ("created_at", "updated_at")
 
     def get_fields(self, request, obj=None):
         if obj is None:
-            return ("user", "runtime", "api_key")
-        return ("user", "runtime", "api_key", "created_at", "updated_at")
+            return ("user", "kind", "value")
+        return ("user", "kind", "value", "created_at", "updated_at")
 
 
 class UserSpritesKeyForm(forms.ModelForm):

--- a/src/agent_on_demand/migrations/0016_runtime_redesign.py
+++ b/src/agent_on_demand/migrations/0016_runtime_redesign.py
@@ -1,0 +1,112 @@
+"""Rewrite: migrate Agent.model strings to provider/model_id, convert
+UserRuntimeKey rows to UserCredential rows, fold claude-oauth runtime into
+claude, drop choices from Agent.model/runtime, and drop the
+UserRuntimeKey table.
+
+Data migration runs first so the old rows are still available to read.
+"""
+
+from django.db import migrations, models
+
+
+MODEL_RENAMES = {
+    # anthropic
+    "claude-opus-4-6": "anthropic/claude-opus-4-6",
+    "claude-sonnet-4-6": "anthropic/claude-sonnet-4-6",
+    "claude-haiku-4-5": "anthropic/claude-haiku-4-5",
+    "claude-opus-4-0-20250514": "anthropic/claude-opus-4-0-20250514",
+    "claude-sonnet-4-0-20250514": "anthropic/claude-sonnet-4-0-20250514",
+    "claude-sonnet-4-5-20250514": "anthropic/claude-sonnet-4-5-20250514",
+    "claude-3-5-haiku-20241022": "anthropic/claude-3-5-haiku-20241022",
+    # openai
+    "gpt-4.1": "openai/gpt-4.1",
+    "o3": "openai/o3",
+    "o4-mini": "openai/o4-mini",
+    # google
+    "gemini-2.5-pro": "google/gemini-2.5-pro",
+    "gemini-2.5-flash": "google/gemini-2.5-flash",
+}
+
+RUNTIME_TO_PROVIDER_KIND = {
+    "claude": "provider:anthropic",
+    "codex": "provider:openai",
+    "gemini": "provider:google",
+    "claude-oauth": "runtime_token:claude-oauth",
+}
+
+
+def migrate_data(apps, schema_editor):
+    Agent = apps.get_model("fairy", "Agent")
+    AgentVersion = apps.get_model("fairy", "AgentVersion")
+    UserRuntimeKey = apps.get_model("fairy", "UserRuntimeKey")
+    UserCredential = apps.get_model("fairy", "UserCredential")
+
+    for agent in Agent.objects.all():
+        changed_fields = []
+        if agent.model in MODEL_RENAMES:
+            agent.model = MODEL_RENAMES[agent.model]
+            changed_fields.append("model")
+        if agent.runtime == "claude-oauth":
+            agent.runtime = "claude"
+            changed_fields.append("runtime")
+        if changed_fields:
+            agent.save(update_fields=changed_fields)
+
+    for av in AgentVersion.objects.all():
+        changed_fields = []
+        if av.model in MODEL_RENAMES:
+            av.model = MODEL_RENAMES[av.model]
+            changed_fields.append("model")
+        if av.runtime == "claude-oauth":
+            av.runtime = "claude"
+            changed_fields.append("runtime")
+        if changed_fields:
+            av.save(update_fields=changed_fields)
+
+    for urk in UserRuntimeKey.objects.all():
+        kind = RUNTIME_TO_PROVIDER_KIND.get(urk.runtime)
+        if kind is None:
+            continue
+        UserCredential.objects.update_or_create(
+            user=urk.user,
+            kind=kind,
+            defaults={"value_encrypted": urk.encrypted_key},
+        )
+
+
+def unmigrate_data(apps, schema_editor):
+    # Best-effort reverse: recreate UserRuntimeKey rows from UserCredential.
+    UserRuntimeKey = apps.get_model("fairy", "UserRuntimeKey")
+    UserCredential = apps.get_model("fairy", "UserCredential")
+    kind_to_runtime = {v: k for k, v in RUNTIME_TO_PROVIDER_KIND.items()}
+    for cred in UserCredential.objects.all():
+        runtime = kind_to_runtime.get(cred.kind)
+        if runtime is None:
+            continue
+        UserRuntimeKey.objects.update_or_create(
+            user=cred.user,
+            runtime=runtime,
+            defaults={"encrypted_key": cred.value_encrypted},
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("fairy", "0015_usercredential"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_data, reverse_code=unmigrate_data),
+        migrations.AlterField(
+            model_name="agent",
+            name="model",
+            field=models.CharField(max_length=100),
+        ),
+        migrations.AlterField(
+            model_name="agent",
+            name="runtime",
+            field=models.CharField(max_length=32),
+        ),
+        migrations.DeleteModel(name="UserRuntimeKey"),
+    ]

--- a/src/agent_on_demand/models/__init__.py
+++ b/src/agent_on_demand/models/__init__.py
@@ -1,5 +1,5 @@
 from agent_on_demand.models.agents import Agent, AgentVersion
-from agent_on_demand.models.auth import APIKey, UserCredential, UserRuntimeKey, UserSpritesKey
+from agent_on_demand.models.auth import APIKey, UserCredential, UserSpritesKey
 from agent_on_demand.models.environments import Environment, EnvironmentVersion
 from agent_on_demand.models.quota import UserQuota
 from agent_on_demand.models.sessions import (
@@ -21,6 +21,5 @@ __all__ = [
     "SessionTurn",
     "UserQuota",
     "UserCredential",
-    "UserRuntimeKey",
     "UserSpritesKey",
 ]

--- a/src/agent_on_demand/models/agents.py
+++ b/src/agent_on_demand/models/agents.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.db import models
 
 from agent_on_demand.models.environments import Environment
-from agent_on_demand.runtimes import RUNTIMES, AgentModel
 
 
 class Agent(models.Model):
@@ -15,8 +14,8 @@ class Agent(models.Model):
     name = models.CharField(max_length=200)
     description = models.TextField(blank=True, default="")
     system = models.TextField(blank=True, default="")
-    model = models.CharField(max_length=100, choices=AgentModel.choices())
-    runtime = models.CharField(max_length=32, choices=[(name, name) for name in RUNTIMES])
+    model = models.CharField(max_length=100)
+    runtime = models.CharField(max_length=32)
     environment = models.ForeignKey(
         Environment, on_delete=models.SET_NULL, null=True, blank=True, related_name="agents"
     )

--- a/src/agent_on_demand/models/auth.py
+++ b/src/agent_on_demand/models/auth.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.db import models
 
 from agent_on_demand.crypto import decrypt, encrypt
-from agent_on_demand.runtimes import RUNTIMES
 
 
 class APIKey(models.Model):
@@ -45,40 +44,6 @@ class APIKey(models.Model):
         )
         instance.save()
         return instance, raw_key
-
-
-class UserRuntimeKey(models.Model):
-    RUNTIME_CHOICES = [(name, name) for name in RUNTIMES]
-
-    user = models.ForeignKey(
-        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="runtime_keys"
-    )
-    runtime = models.CharField(max_length=32, choices=RUNTIME_CHOICES)
-    encrypted_key = models.BinaryField()
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
-
-    class Meta:
-        db_table = "user_runtime_keys"
-        constraints = [
-            models.UniqueConstraint(fields=["user", "runtime"], name="unique_user_runtime"),
-        ]
-
-    def __str__(self):
-        return f"{self.user} — {self.runtime}"
-
-    def set_api_key(self, raw_key: str):
-        self.encrypted_key = encrypt(raw_key)
-
-    def get_api_key(self) -> str:
-        return decrypt(bytes(self.encrypted_key))
-
-    @classmethod
-    def get_key_for(cls, user, runtime: str) -> str | None:
-        try:
-            return cls.objects.get(user=user, runtime=runtime).get_api_key()
-        except cls.DoesNotExist:
-            return None
 
 
 CREDENTIAL_ENV_VAR: dict[str, str] = {

--- a/src/agent_on_demand/runtimes/__init__.py
+++ b/src/agent_on_demand/runtimes/__init__.py
@@ -1,87 +1,12 @@
-from dataclasses import dataclass
-from enum import StrEnum
+from agent_on_demand.runtimes.base import Runtime
+from agent_on_demand.runtimes.claude import ClaudeRuntime
+from agent_on_demand.runtimes.codex import CodexRuntime
+from agent_on_demand.runtimes.gemini import GeminiRuntime
 
-
-class AgentModel(StrEnum):
-    # Claude
-    CLAUDE_OPUS_4_6 = "claude-opus-4-6"
-    CLAUDE_SONNET_4_6 = "claude-sonnet-4-6"
-    CLAUDE_HAIKU_4_5 = "claude-haiku-4-5"
-    CLAUDE_OPUS_4 = "claude-opus-4-0-20250514"
-    CLAUDE_SONNET_4 = "claude-sonnet-4-0-20250514"
-    CLAUDE_SONNET_4_5 = "claude-sonnet-4-5-20250514"
-    CLAUDE_HAIKU_3_5 = "claude-3-5-haiku-20241022"
-    # OpenAI / Codex
-    GPT_4_1 = "gpt-4.1"
-    O3 = "o3"
-    O4_MINI = "o4-mini"
-    # Gemini
-    GEMINI_2_5_PRO = "gemini-2.5-pro"
-    GEMINI_2_5_FLASH = "gemini-2.5-flash"
-
-    @classmethod
-    def choices(cls) -> list[tuple[str, str]]:
-        return [(m.value, m.value) for m in cls]
-
-    @classmethod
-    def values(cls) -> set[str]:
-        return {m.value for m in cls}
-
-
-# Which runtime each model family maps to
-MODEL_RUNTIME_MAP: dict[str, str] = {
-    "claude-opus-4-6": "claude",
-    "claude-sonnet-4-6": "claude",
-    "claude-haiku-4-5": "claude",
-    "claude-opus-4-0-20250514": "claude",
-    "claude-sonnet-4-0-20250514": "claude",
-    "claude-sonnet-4-5-20250514": "claude",
-    "claude-3-5-haiku-20241022": "claude",
-    "gpt-4.1": "codex",
-    "o3": "codex",
-    "o4-mini": "codex",
-    "gemini-2.5-pro": "gemini",
-    "gemini-2.5-flash": "gemini",
+RUNTIMES: dict[str, Runtime] = {
+    "claude": ClaudeRuntime(),
+    "codex": CodexRuntime(),
+    "gemini": GeminiRuntime(),
 }
 
-
-@dataclass(frozen=True)
-class RuntimeConfig:
-    name: str
-    cmd: str  # shell command template — $PROMPT is substituted by the wrapper script
-    continue_cmd: str  # command template for continuing an existing session
-    env_var: str  # which env var holds the API key
-
-
-RUNTIMES: dict[str, RuntimeConfig] = {
-    # Claude: we pre-generate a session UUID at AOD session-create time and
-    # pass it as --session-id on turn 1, then --resume <uuid> on every
-    # subsequent turn. This is more reliable than --continue in --print mode
-    # (which has been observed to silently fork new sessions).
-    "claude": RuntimeConfig(
-        name="claude",
-        cmd='claude --print --verbose --output-format stream-json --session-id "$AOD_SESSION_ID" -p "$PROMPT"',
-        continue_cmd='claude --dangerously-skip-permissions --print --verbose --output-format stream-json --resume "$AOD_SESSION_ID" -p "$PROMPT"',
-        env_var="ANTHROPIC_API_KEY",
-    ),
-    "codex": RuntimeConfig(
-        name="codex",
-        cmd=('echo "$PROMPT" | codex exec --dangerously-bypass-approvals-and-sandbox --json'),
-        continue_cmd=(
-            'codex exec resume --last --dangerously-bypass-approvals-and-sandbox --json "$PROMPT"'
-        ),
-        env_var="CODEX_API_KEY",
-    ),
-    "gemini": RuntimeConfig(
-        name="gemini",
-        cmd='gemini --output-format stream-json -p "$PROMPT"',
-        continue_cmd='gemini --resume --output-format stream-json -p "$PROMPT"',
-        env_var="GEMINI_API_KEY",
-    ),
-    "claude-oauth": RuntimeConfig(
-        name="claude-oauth",
-        cmd='claude --print --verbose --output-format stream-json --session-id "$AOD_SESSION_ID" -p "$PROMPT"',
-        continue_cmd='claude --dangerously-skip-permissions --print --verbose --output-format stream-json --resume "$AOD_SESSION_ID" -p "$PROMPT"',
-        env_var="CLAUDE_CODE_OAUTH_TOKEN",
-    ),
-}
+__all__ = ["Runtime", "RUNTIMES"]

--- a/src/agent_on_demand/runtimes/__init__.py
+++ b/src/agent_on_demand/runtimes/__init__.py
@@ -2,11 +2,13 @@ from agent_on_demand.runtimes.base import Runtime
 from agent_on_demand.runtimes.claude import ClaudeRuntime
 from agent_on_demand.runtimes.codex import CodexRuntime
 from agent_on_demand.runtimes.gemini import GeminiRuntime
+from agent_on_demand.runtimes.opencode import OpencodeRuntime
 
 RUNTIMES: dict[str, Runtime] = {
     "claude": ClaudeRuntime(),
     "codex": CodexRuntime(),
     "gemini": GeminiRuntime(),
+    "opencode": OpencodeRuntime(),
 }
 
 __all__ = ["Runtime", "RUNTIMES"]

--- a/src/agent_on_demand/runtimes/claude.py
+++ b/src/agent_on_demand/runtimes/claude.py
@@ -12,10 +12,9 @@ if TYPE_CHECKING:
 class ClaudeRuntime:
     """Runtime for Anthropic's Claude Code CLI.
 
-    Folds in the former `claude-oauth` runtime: `build_command` picks the
-    command shape based on whether the user has a `runtime_token:claude-oauth`
-    credential registered. The auth itself comes from the env file written
-    during provisioning (ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN).
+    Auth comes from the env file written during provisioning
+    (ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN); the CLI picks it up on
+    its own, so the command shape is the same for both.
     """
 
     name = "claude"
@@ -28,33 +27,15 @@ class ClaudeRuntime:
     def build_command(
         self, spec: "SessionSpec", mode: Literal["run", "continue"]
     ) -> list[str]:
-        from agent_on_demand.models.auth import UserCredential
-
         session_id = spec.runtime_session_id or ""
-        has_oauth = UserCredential.objects.filter(
-            user=spec.user, kind="runtime_token:claude-oauth"
-        ).exists()
-
-        if mode == "continue" or has_oauth:
-            # Both OAuth and continue mode require --dangerously-skip-permissions
-            # to allow tool use without interactive prompts.
-            return [
-                "claude",
-                "--dangerously-skip-permissions",
-                "--print",
-                "--verbose",
-                "--output-format",
-                "stream-json",
-                "--resume" if mode == "continue" else "--session-id",
-                session_id,
-            ]
         return [
             "claude",
+            "--dangerously-skip-permissions",
             "--print",
             "--verbose",
             "--output-format",
             "stream-json",
-            "--session-id",
+            "--resume" if mode == "continue" else "--session-id",
             session_id,
         ]
 

--- a/src/agent_on_demand/runtimes/claude.py
+++ b/src/agent_on_demand/runtimes/claude.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Literal
+
+from sprites import Sprite
+
+if TYPE_CHECKING:
+    from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
+
+
+class ClaudeRuntime:
+    """Runtime for Anthropic's Claude Code CLI.
+
+    Folds in the former `claude-oauth` runtime: `build_command` picks the
+    command shape based on whether the user has a `runtime_token:claude-oauth`
+    credential registered. The auth itself comes from the env file written
+    during provisioning (ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN).
+    """
+
+    name = "claude"
+    providers: set[str] = {"anthropic"}
+    skills_root: str | None = "/home/sprite/.claude/skills"
+
+    def install(self, sprite: Sprite) -> None:
+        return None
+
+    def build_command(
+        self, spec: "SessionSpec", mode: Literal["run", "continue"]
+    ) -> list[str]:
+        from agent_on_demand.models.auth import UserCredential
+
+        session_id = spec.runtime_session_id or ""
+        has_oauth = UserCredential.objects.filter(
+            user=spec.user, kind="runtime_token:claude-oauth"
+        ).exists()
+
+        if mode == "continue" or has_oauth:
+            # Both OAuth and continue mode require --dangerously-skip-permissions
+            # to allow tool use without interactive prompts.
+            return [
+                "claude",
+                "--dangerously-skip-permissions",
+                "--print",
+                "--verbose",
+                "--output-format",
+                "stream-json",
+                "--resume" if mode == "continue" else "--session-id",
+                session_id,
+            ]
+        return [
+            "claude",
+            "--print",
+            "--verbose",
+            "--output-format",
+            "stream-json",
+            "--session-id",
+            session_id,
+        ]
+
+    def write_config(
+        self,
+        sprite: Sprite,
+        spec: "SessionSpec",
+        mcp_servers: list["McpServerSpec"],
+    ) -> None:
+        config: dict[str, dict] = {}
+        for s in mcp_servers:
+            if s.type == "url":
+                entry: dict = {"type": "http", "url": s.url}
+                if s.headers:
+                    entry["headers"] = s.headers
+                config[s.name] = entry
+            elif s.type == "stdio":
+                entry = {"type": "stdio", "command": s.command, "args": s.args}
+                if s.env:
+                    entry["env"] = s.env
+                config[s.name] = entry
+        if not config:
+            return
+        fs = sprite.filesystem()
+        (fs / "home/sprite/.claude.json").write_text(
+            json.dumps({"mcpServers": config}, indent=2)
+        )

--- a/src/agent_on_demand/runtimes/codex.py
+++ b/src/agent_on_demand/runtimes/codex.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from sprites import Sprite
+
+if TYPE_CHECKING:
+    from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
+
+
+class CodexRuntime:
+    """Runtime for OpenAI's Codex CLI."""
+
+    name = "codex"
+    providers: set[str] = {"openai"}
+    skills_root: str | None = "/home/sprite/.codex/skills"
+
+    def install(self, sprite: Sprite) -> None:
+        return None
+
+    def build_command(
+        self, spec: "SessionSpec", mode: Literal["run", "continue"]
+    ) -> list[str]:
+        if mode == "continue":
+            return [
+                "codex",
+                "exec",
+                "resume",
+                "--last",
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--json",
+            ]
+        return [
+            "codex",
+            "exec",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--json",
+        ]
+
+    def write_config(
+        self,
+        sprite: Sprite,
+        spec: "SessionSpec",
+        mcp_servers: list["McpServerSpec"],
+    ) -> None:
+        if not mcp_servers:
+            return
+        lines: list[str] = []
+        for s in mcp_servers:
+            lines.append(f"[mcp_servers.{s.name}]")
+            if s.type == "url":
+                lines.append(f'url = "{s.url}"')
+                for key, val in s.headers.items():
+                    if key.lower() == "authorization" and val.startswith("Bearer "):
+                        token = val.removeprefix("Bearer ").strip()
+                        if token.startswith("${") and token.endswith("}"):
+                            lines.append(f'bearer_token_env_var = "{token[2:-1]}"')
+                lines.append("required = true")
+            elif s.type == "stdio":
+                lines.append(f'command = "{s.command}"')
+                if s.args:
+                    args_str = ", ".join(f'"{a}"' for a in s.args)
+                    lines.append(f"args = [{args_str}]")
+                if s.env:
+                    lines.append(f"[mcp_servers.{s.name}.env]")
+                    for key, val in s.env.items():
+                        lines.append(f'{key} = "{val}"')
+            lines.append("")
+        fs = sprite.filesystem()
+        (fs / "home/sprite/.codex/config.toml").write_text("\n".join(lines))

--- a/src/agent_on_demand/runtimes/gemini.py
+++ b/src/agent_on_demand/runtimes/gemini.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Literal
+
+from sprites import Sprite
+
+if TYPE_CHECKING:
+    from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
+
+
+class GeminiRuntime:
+    """Runtime for Google's Gemini CLI."""
+
+    name = "gemini"
+    providers: set[str] = {"google"}
+    skills_root: str | None = "/home/sprite/.gemini/skills"
+
+    def install(self, sprite: Sprite) -> None:
+        return None
+
+    def build_command(
+        self, spec: "SessionSpec", mode: Literal["run", "continue"]
+    ) -> list[str]:
+        if mode == "continue":
+            return ["gemini", "--resume", "--output-format", "stream-json"]
+        return ["gemini", "--output-format", "stream-json"]
+
+    def write_config(
+        self,
+        sprite: Sprite,
+        spec: "SessionSpec",
+        mcp_servers: list["McpServerSpec"],
+    ) -> None:
+        config: dict[str, dict] = {}
+        for s in mcp_servers:
+            if s.type == "url":
+                entry: dict = {"httpUrl": s.url, "trust": True}
+                if s.headers:
+                    entry["headers"] = s.headers
+                config[s.name] = entry
+            elif s.type == "stdio":
+                entry = {"command": s.command, "args": s.args, "trust": True}
+                if s.env:
+                    entry["env"] = s.env
+                config[s.name] = entry
+        if not config:
+            return
+        fs = sprite.filesystem()
+        (fs / "home/sprite/.gemini/settings.json").write_text(
+            json.dumps({"mcpServers": config}, indent=2)
+        )

--- a/src/agent_on_demand/runtimes/opencode.py
+++ b/src/agent_on_demand/runtimes/opencode.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Literal
+
+from sprites import Sprite
+
+if TYPE_CHECKING:
+    from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
+
+
+OPENCODE_VERSION = "0.5.0"
+
+
+class OpencodeRuntime:
+    """Runtime for sst/opencode — a multi-provider meta-runtime CLI.
+
+    One `opencode` binary fronts 75+ providers; the provider+model is picked
+    per invocation via `--model provider/model_id`. Opencode reads the native
+    provider env vars (ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY)
+    directly, which the env-file writer already dumps for every registered
+    `UserCredential`, so no auth plumbing is needed here.
+
+    Not pre-installed on the Sprite base image — `install` runs `npm i -g
+    opencode-ai@<pinned>` on each provision. If the Environment has
+    `networking_type="limited"`, the allowed-hosts list must include
+    `registry.npmjs.org`.
+    """
+
+    name = "opencode"
+    providers: set[str] = {"anthropic", "openai", "google"}
+    skills_root: str | None = "/home/sprite/.config/opencode/skills"
+
+    def install(self, sprite: Sprite) -> None:
+        sprite.command(
+            "bash", "-lc", f"npm install -g opencode-ai@{OPENCODE_VERSION}"
+        ).run()
+
+    def build_command(
+        self, spec: "SessionSpec", mode: Literal["run", "continue"]
+    ) -> list[str]:
+        argv = ["opencode", "run", "--model", spec.model, "--format", "json"]
+        if mode == "continue":
+            argv.append("--continue")
+        return argv
+
+    def write_config(
+        self,
+        sprite: Sprite,
+        spec: "SessionSpec",
+        mcp_servers: list["McpServerSpec"],
+    ) -> None:
+        config: dict[str, dict] = {}
+        for s in mcp_servers:
+            if s.type == "url":
+                entry: dict = {"type": "remote", "url": s.url, "enabled": True}
+                if s.headers:
+                    entry["headers"] = s.headers
+            elif s.type == "stdio":
+                entry = {
+                    "type": "local",
+                    "command": [s.command, *s.args],
+                    "enabled": True,
+                }
+                if s.env:
+                    entry["environment"] = s.env
+            else:
+                continue
+            config[s.name] = entry
+        if not config:
+            return
+        fs = sprite.filesystem()
+        (fs / "home/sprite/.config/opencode/opencode.json").write_text(
+            json.dumps({"mcp": config}, indent=2)
+        )

--- a/src/agent_on_demand/session_service/provisioning.py
+++ b/src/agent_on_demand/session_service/provisioning.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import contextlib
 import io
-import json
 import logging
 import shlex
 import time
@@ -33,7 +32,7 @@ from agent_on_demand.observability import get_tracer
 
 from .client import best_effort_delete, require_client
 from .errors import ProvisionError
-from .specs import McpServerSpec, RepoSpec, SessionSpec, SkillSpec
+from .specs import RepoSpec, SessionSpec
 
 ENV_FILE_PATH = "/tmp/aod-env"
 GIT_CREDS_PATH = "/tmp/.git-credentials"
@@ -46,11 +45,12 @@ PACKAGE_MANAGER_ORDER = ["apt", "cargo", "gem", "go", "npm", "pip"]
 # Stage names emitted both as `ProvisionError.stage` tags (server-side logging)
 # and as `stage` SSE events (see site/docs/api/streaming.md). Keep in sync.
 STAGE_CREATE_SPRITE = "create_sprite"
+STAGE_INSTALL_RUNTIME = "install_runtime"
 STAGE_NETWORK_POLICY = "network_policy"
 STAGE_ENV_FILE = "env_file"
 STAGE_GIT_CREDENTIALS = "git_credentials"
 STAGE_PROVISION_SETUP = "provision_setup"
-STAGE_MCP_CONFIG = "mcp_config"
+STAGE_RUNTIME_CONFIG = "runtime_config"
 STAGE_SKILLS = "skills"
 STAGE_RUNTIME_START = "runtime_start"
 
@@ -104,14 +104,6 @@ def stage_timer(session_id: str | None, stage: str) -> Iterator[None]:
         )
 
 
-_SKILLS_ROOTS: dict[str, str] = {
-    "claude": "/home/sprite/.claude/skills",
-    "claude-oauth": "/home/sprite/.claude/skills",
-    "codex": "/home/sprite/.codex/skills",
-    "gemini": "/home/sprite/.gemini/skills",
-}
-
-
 def provision_session(user, spec: SessionSpec, session_id: str | None = None) -> Sprite:
     """Create a Sprite and run all setup stages against it.
 
@@ -149,12 +141,13 @@ def provision_session(user, spec: SessionSpec, session_id: str | None = None) ->
             raise
 
         try:
+            _install_runtime(sprite, spec, session_id)
             _apply_network_policy(sprite, env, session_id)
             _write_env_file(sprite, spec, session_id)
             _write_git_credentials(sprite, spec.repos, session_id)
             _run_provision_setup(sprite, spec, session_id)
-            _write_mcp_config(sprite, spec.runtime.name, spec.mcp_servers, session_id)
-            _write_skills(sprite, spec.runtime.name, spec.skills, session_id)
+            _write_runtime_config(sprite, spec, session_id)
+            _write_skills(sprite, spec, session_id)
         except ProvisionError as e:
             span.set_attribute("aod.failure_stage", e.stage)
             best_effort_delete(client, spec.name)
@@ -191,6 +184,19 @@ def destroy_session(user, sprite_name: str) -> None:
     best_effort_delete(client, sprite_name)
 
 
+def _install_runtime(sprite: Sprite, spec: SessionSpec, session_id: str | None) -> None:
+    """Run per-runtime `install` hook before the network policy locks things
+    down. For pre-baked runtimes (claude/codex/gemini) this is a no-op; for
+    meta-runtimes that fetch binaries, internet access is required here."""
+    with stage_timer(session_id, STAGE_INSTALL_RUNTIME):
+        try:
+            spec.runtime.install(sprite)
+        except SpriteError as e:
+            raise ProvisionError(
+                f"Failed to install runtime: {e}", stage=STAGE_INSTALL_RUNTIME
+            ) from e
+
+
 def _apply_network_policy(sprite: Sprite, env: Environment | None, session_id: str | None) -> None:
     if env is None or env.networking_type != "limited":
         return
@@ -210,10 +216,22 @@ def _apply_network_policy(sprite: Sprite, env: Environment | None, session_id: s
 def _write_env_file(sprite: Sprite, spec: SessionSpec, session_id: str | None) -> None:
     """Write /tmp/aod-env (fs.write only — chmod happens in the provision
     script). The file is sourced (with `set -a`) by the per-turn dispatcher,
-    so every line must be a valid KEY=value shell assignment."""
-    lines: list[str] = [f"{spec.runtime.env_var}={shlex.quote(spec.api_key)}"]
+    so every line must be a valid KEY=value shell assignment.
+
+    Precedence: user credentials first (so their env-var names are mapped
+    from `CREDENTIAL_ENV_VAR`), then the session metadata, then any
+    Environment.env_vars last — per-environment overrides win."""
+    from agent_on_demand.models.auth import CREDENTIAL_ENV_VAR, UserCredential
+
+    lines: list[str] = []
+    for cred in UserCredential.objects.filter(user=spec.user):
+        env_name = CREDENTIAL_ENV_VAR.get(cred.kind)
+        if env_name:
+            lines.append(f"{env_name}={shlex.quote(cred.get_value())}")
     if spec.runtime_session_id:
         lines.append(f"AOD_SESSION_ID={shlex.quote(spec.runtime_session_id)}")
+    if spec.model:
+        lines.append(f"AOD_MODEL={shlex.quote(spec.model)}")
     env = spec.environment
     if env is not None:
         for key in sorted(env.env_vars or {}):
@@ -352,12 +370,10 @@ def _directories_for_post_script_writes(spec: SessionSpec) -> list[str]:
             dirs.append("/home/sprite/.codex")
         elif spec.runtime.name == "gemini":
             dirs.append("/home/sprite/.gemini")
-        # claude/claude-oauth write to /home/sprite/.claude.json (no mkdir).
-    if spec.skills:
-        root = _SKILLS_ROOTS.get(spec.runtime.name)
-        if root:
-            for s in spec.skills:
-                dirs.append(f"{root}/{s.name}")
+        # claude writes to /home/sprite/.claude.json (no mkdir).
+    if spec.skills and spec.runtime.skills_root:
+        for s in spec.skills:
+            dirs.append(f"{spec.runtime.skills_root}/{s.name}")
     return dirs
 
 
@@ -381,103 +397,38 @@ def _package_commands(manager: str, pkgs: list[str]) -> list[str]:
     return []
 
 
-def _write_mcp_config(
+def _write_runtime_config(
     sprite: Sprite,
-    runtime_name: str,
-    servers: list[McpServerSpec],
+    spec: SessionSpec,
     session_id: str | None,
 ) -> None:
-    if not servers:
-        return
-    with stage_timer(session_id, STAGE_MCP_CONFIG):
+    """Delegate config writes to the runtime. Always runs at provision time —
+    meta-runtimes need their config files even when there are no MCP servers.
+    Individual runtimes can skip the fs write themselves when they have
+    nothing to say."""
+    with stage_timer(session_id, STAGE_RUNTIME_CONFIG):
         try:
-            if runtime_name in ("claude", "claude-oauth"):
-                _write_mcp_claude(sprite, servers)
-            elif runtime_name == "codex":
-                _write_mcp_codex(sprite, servers)
-            elif runtime_name == "gemini":
-                _write_mcp_gemini(sprite, servers)
+            spec.runtime.write_config(sprite, spec, spec.mcp_servers)
         except SpriteError as e:
-            raise ProvisionError(f"Failed to write MCP config: {e}", stage=STAGE_MCP_CONFIG) from e
-
-
-def _write_mcp_claude(sprite: Sprite, servers: list[McpServerSpec]) -> None:
-    config: dict[str, dict] = {}
-    for s in servers:
-        if s.type == "url":
-            entry: dict = {"type": "http", "url": s.url}
-            if s.headers:
-                entry["headers"] = s.headers
-            config[s.name] = entry
-        elif s.type == "stdio":
-            entry = {"type": "stdio", "command": s.command, "args": s.args}
-            if s.env:
-                entry["env"] = s.env
-            config[s.name] = entry
-    fs = sprite.filesystem()
-    (fs / "home/sprite/.claude.json").write_text(json.dumps({"mcpServers": config}, indent=2))
-
-
-def _write_mcp_codex(sprite: Sprite, servers: list[McpServerSpec]) -> None:
-    lines: list[str] = []
-    for s in servers:
-        lines.append(f"[mcp_servers.{s.name}]")
-        if s.type == "url":
-            lines.append(f'url = "{s.url}"')
-            for key, val in s.headers.items():
-                if key.lower() == "authorization" and val.startswith("Bearer "):
-                    token = val.removeprefix("Bearer ").strip()
-                    if token.startswith("${") and token.endswith("}"):
-                        lines.append(f'bearer_token_env_var = "{token[2:-1]}"')
-            lines.append("required = true")
-        elif s.type == "stdio":
-            lines.append(f'command = "{s.command}"')
-            if s.args:
-                args_str = ", ".join(f'"{a}"' for a in s.args)
-                lines.append(f"args = [{args_str}]")
-            if s.env:
-                lines.append(f"[mcp_servers.{s.name}.env]")
-                for key, val in s.env.items():
-                    lines.append(f'{key} = "{val}"')
-        lines.append("")
-    fs = sprite.filesystem()
-    (fs / "home/sprite/.codex/config.toml").write_text("\n".join(lines))
-
-
-def _write_mcp_gemini(sprite: Sprite, servers: list[McpServerSpec]) -> None:
-    config: dict[str, dict] = {}
-    for s in servers:
-        if s.type == "url":
-            entry: dict = {"httpUrl": s.url, "trust": True}
-            if s.headers:
-                entry["headers"] = s.headers
-            config[s.name] = entry
-        elif s.type == "stdio":
-            entry = {"command": s.command, "args": s.args, "trust": True}
-            if s.env:
-                entry["env"] = s.env
-            config[s.name] = entry
-    fs = sprite.filesystem()
-    (fs / "home/sprite/.gemini/settings.json").write_text(
-        json.dumps({"mcpServers": config}, indent=2)
-    )
+            raise ProvisionError(
+                f"Failed to write runtime config: {e}", stage=STAGE_RUNTIME_CONFIG
+            ) from e
 
 
 def _write_skills(
     sprite: Sprite,
-    runtime_name: str,
-    skills: list[SkillSpec],
+    spec: SessionSpec,
     session_id: str | None,
 ) -> None:
-    if not skills:
+    if not spec.skills:
         return
-    root = _SKILLS_ROOTS.get(runtime_name)
+    root = spec.runtime.skills_root
     if root is None:
         return
     with stage_timer(session_id, STAGE_SKILLS):
         try:
             fs = sprite.filesystem()
-            for s in skills:
+            for s in spec.skills:
                 dir_path = f"{root}/{s.name}"
                 (fs / f"{dir_path.lstrip('/')}/SKILL.md").write_text(s.content)
         except SpriteError as e:

--- a/src/agent_on_demand/session_service/provisioning.py
+++ b/src/agent_on_demand/session_service/provisioning.py
@@ -370,6 +370,8 @@ def _directories_for_post_script_writes(spec: SessionSpec) -> list[str]:
             dirs.append("/home/sprite/.codex")
         elif spec.runtime.name == "gemini":
             dirs.append("/home/sprite/.gemini")
+        elif spec.runtime.name == "opencode":
+            dirs.append("/home/sprite/.config/opencode")
         # claude writes to /home/sprite/.claude.json (no mkdir).
     if spec.skills and spec.runtime.skills_root:
         for s in spec.skills:

--- a/src/agent_on_demand/session_service/specs.py
+++ b/src/agent_on_demand/session_service/specs.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from agent_on_demand.models import Environment
-from agent_on_demand.runtimes import RuntimeConfig
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import User
+
+    from agent_on_demand.runtimes import Runtime
 
 
 @dataclass(frozen=True)
@@ -47,8 +52,9 @@ class SessionSpec:
     """
 
     name: str
-    runtime: RuntimeConfig
-    api_key: str
+    runtime: "Runtime"
+    model: str
+    user: "User"
     runtime_session_id: str | None
     environment: Environment | None
     repos: list[RepoSpec]

--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -43,10 +43,9 @@ from agent_on_demand.models import (
     AgentSession,
     AgentSessionLog,
     SessionTurn,
-    UserRuntimeKey,
 )
 from agent_on_demand.observability import get_tracer
-from agent_on_demand.runtimes import RUNTIMES, RuntimeConfig
+from agent_on_demand.runtimes import RUNTIMES, Runtime
 
 from .errors import NoSpritesKeyError, ProvisionError
 from .provisioning import (
@@ -101,18 +100,23 @@ class TaggingQueueWriter(io.RawIOBase):
         return len(data)
 
 
-def build_turn_command(runtime: RuntimeConfig, mode: str) -> str:
-    """Render the per-turn `bash -c` script.
+_ENV_SOURCE_SHIM = 'set -a; source /tmp/aod-env; set +a; exec "$@"'
 
-    Per turn we (1) source /tmp/aod-env to expose the runtime API key,
-    AOD_SESSION_ID, and any Environment.env_vars; (2) slurp stdin into
-    $PROMPT so the runtime CLI can reference it via `-p "$PROMPT"`; (3)
-    exec the mode-appropriate runtime CLI. The string contains no secrets
-    (the API key sources at runtime from the env file) so it's safe to
-    appear in Sprites server-side WS URL logs.
+
+def build_turn_argv(runtime: Runtime, spec, mode: str) -> list[str]:
+    """Return the full argv for the per-turn `sprite.command`.
+
+    The first three elements are a thin `bash -lc` shim that sources
+    `/tmp/aod-env` (so credential and Environment env vars reach the
+    runtime CLI's process) and then execs the runtime argv verbatim. No
+    template substitution — the runtime's `build_command` already inlined
+    any session-id or model values from the spec.
+
+    Prompt delivery is out of band: callers attach `cmd.stdin` with the
+    prompt bytes so it flows through the bash shim into the runtime CLI.
     """
-    runtime_cmd = runtime.cmd if mode == "run" else runtime.continue_cmd
-    return f"set -a; source /tmp/aod-env; set +a; PROMPT=$(cat); export PROMPT; exec {runtime_cmd}"
+    argv = runtime.build_command(spec, mode)
+    return ["bash", "-lc", _ENV_SOURCE_SHIM, "--", *argv]
 
 
 @procrastinate_app.task(queue="sessions", name="provision_session", pass_context=False)
@@ -162,11 +166,6 @@ def _provision_session_inner(
         return
 
     spec = _build_spec_for_session(session)
-    if spec is None:
-        _mark_provision_failed(
-            session, turn_id, f"No API key configured for runtime: {session.runtime}"
-        )
-        return
 
     tracer = get_tracer()
     with tracer.start_as_current_span(
@@ -197,17 +196,14 @@ def _provision_session_inner(
     )
 
 
-def _build_spec_for_session(session: AgentSession) -> SessionSpec | None:
-    """Rehydrate a SessionSpec from persisted session state. Returns None when
-    the user no longer has an API key configured for the session's runtime."""
-    api_key = UserRuntimeKey.get_key_for(session.user, session.runtime)
-    if api_key is None:
-        return None
-
+def _build_spec_for_session(session: AgentSession) -> SessionSpec:
+    """Rehydrate a SessionSpec from persisted session state."""
     agent = session.agent
     mcp_servers: list[McpServerSpec] = []
     skills: list[SkillSpec] = []
+    model = ""
     if agent is not None:
+        model = agent.model
         for s in agent.mcp_servers or []:
             mcp_servers.append(
                 McpServerSpec(
@@ -231,7 +227,8 @@ def _build_spec_for_session(session: AgentSession) -> SessionSpec | None:
     return SessionSpec(
         name=session.sprite_name,
         runtime=RUNTIMES[session.runtime],
-        api_key=api_key,
+        model=model,
+        user=session.user,
         runtime_session_id=str(session.runtime_session_id) if session.runtime_session_id else None,
         environment=session.environment,
         repos=repos,
@@ -316,9 +313,9 @@ def _execute_turn_inner(
     mode: str,
     timeout: float,
 ) -> None:
-    session = AgentSession.objects.select_related("user").get(pk=session_id)
+    session = AgentSession.objects.select_related("user", "agent", "environment").get(pk=session_id)
     turn = SessionTurn.objects.get(pk=turn_id)
-    runtime = RUNTIMES[session.runtime]
+    spec = _build_spec_for_session(session)
 
     tracer = get_tracer()
     with tracer.start_as_current_span(
@@ -333,10 +330,10 @@ def _execute_turn_inner(
         },
     ) as span:
         sprite = resume_session(session.user, session.sprite_name)
-        _execute_turn_body(session, turn, runtime, sprite, prompt, mode, timeout, span)
+        _execute_turn_body(session, turn, spec, sprite, prompt, mode, timeout, span)
 
 
-def _execute_turn_body(session, turn, runtime, sprite, prompt, mode, timeout, span) -> None:
+def _execute_turn_body(session, turn, spec, sprite, prompt, mode, timeout, span) -> None:
 
     output_q: queue.Queue = queue.Queue(maxsize=4096)
     db_buffer: list[AgentSessionLog] = []
@@ -370,14 +367,14 @@ def _execute_turn_body(session, turn, runtime, sprite, prompt, mode, timeout, sp
                 close_old_connections()
                 time.sleep(delay)
 
+    argv = build_turn_argv(spec.runtime, spec, mode)
+
     def _run_command():
         # NOTE: if you add DB writes inside this inner thread, wrap the body
         # in close_old_connections()/finally. Today it only drives the SDK.
         try:
             cmd = sprite.command(
-                "bash",
-                "-c",
-                build_turn_command(runtime, mode),
+                *argv,
                 cwd="/home/sprite",
                 timeout=timeout,
             )

--- a/src/agent_on_demand/views/agents.py
+++ b/src/agent_on_demand/views/agents.py
@@ -11,7 +11,8 @@ from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from agent_on_demand.auth import require_api_key
 from agent_on_demand.models import Agent, AgentVersion, Environment
-from agent_on_demand.runtimes import RUNTIMES, AgentModel
+from agent_on_demand.models_catalog import MODELS
+from agent_on_demand.runtimes import RUNTIMES
 
 
 AGENT_VERSIONED_FIELDS = (
@@ -116,8 +117,8 @@ class CreateAgentRequest(BaseModel):
     @field_validator("model")
     @classmethod
     def validate_model(cls, v: str) -> str:
-        if v not in AgentModel.values():
-            raise ValueError(f"Unknown model: {v}. Must be one of: {sorted(AgentModel.values())}")
+        if v not in MODELS:
+            raise ValueError(f"Unknown model: {v}. Must be one of: {sorted(MODELS)}")
         return v
 
     @field_validator("mcp_servers")
@@ -146,8 +147,8 @@ class UpdateAgentRequest(BaseModel):
     @field_validator("model")
     @classmethod
     def validate_model(cls, v: str | None) -> str | None:
-        if v is not None and v not in AgentModel.values():
-            raise ValueError(f"Unknown model: {v}. Must be one of: {sorted(AgentModel.values())}")
+        if v is not None and v not in MODELS:
+            raise ValueError(f"Unknown model: {v}. Must be one of: {sorted(MODELS)}")
         return v
 
     @field_validator("mcp_servers")
@@ -163,6 +164,20 @@ class UpdateAgentRequest(BaseModel):
         if v is not None:
             _validate_skills(v)
         return v
+
+
+def _check_runtime_model_compat(runtime_name: str, model_id: str) -> str | None:
+    """Return an error message if model isn't servable by runtime, else None."""
+    runtime = RUNTIMES[runtime_name]
+    model = MODELS[model_id]
+    if model.provider not in runtime.providers:
+        return (
+            f"Runtime {runtime_name} cannot serve model {model_id}: "
+            f"provider {model.provider} not in {sorted(runtime.providers)}"
+        )
+    if model.runtimes is not None and runtime_name not in model.runtimes:
+        return f"Model {model_id} not supported on runtime {runtime_name}"
+    return None
 
 
 def _serialize_agent(agent: Agent) -> dict:
@@ -240,6 +255,9 @@ def agents_list_create(request):
                 {"detail": f"Unknown runtime: {req.runtime}. Must be one of: {list(RUNTIMES)}"},
                 status=400,
             )
+        compat_err = _check_runtime_model_compat(req.runtime, req.model)
+        if compat_err is not None:
+            return JsonResponse({"detail": compat_err}, status=422)
 
         env_obj = None
         if req.environment_id:
@@ -328,6 +346,13 @@ def agent_detail(request, agent_id):
                 {"detail": f"Unknown runtime: {req.runtime}. Must be one of: {list(RUNTIMES)}"},
                 status=400,
             )
+
+        effective_runtime = req.runtime or agent.runtime
+        effective_model = req.model or agent.model
+        if effective_runtime in RUNTIMES and effective_model in MODELS:
+            compat_err = _check_runtime_model_compat(effective_runtime, effective_model)
+            if compat_err is not None:
+                return JsonResponse({"detail": compat_err}, status=422)
 
         # Detect changes
         changed = False

--- a/src/agent_on_demand/views/sessions.py
+++ b/src/agent_on_demand/views/sessions.py
@@ -22,8 +22,9 @@ from agent_on_demand.models import (
     SessionResource,
     SessionTurn,
     UserQuota,
-    UserRuntimeKey,
 )
+from agent_on_demand.models.auth import CREDENTIAL_ENV_VAR, UserCredential
+from agent_on_demand.models_catalog import MODELS
 from agent_on_demand.runtimes import RUNTIMES
 from agent_on_demand.stream import stream_session_from_db
 
@@ -207,12 +208,37 @@ def _create_session(request):
             status=400,
         )
 
-    api_key = UserRuntimeKey.get_key_for(request.user, runtime)
-    if api_key is None:
+    # Ensure the user has registered at least one credential that this runtime
+    # can authenticate with. A runtime accepts either a provider credential
+    # (e.g. `provider:anthropic` for Claude's Anthropic API) or a
+    # runtime-specific token (e.g. `runtime_token:claude-oauth`).
+    runtime_obj = RUNTIMES[runtime]
+    accepted_kinds = {f"provider:{p}" for p in runtime_obj.providers}
+    accepted_kinds |= {
+        kind for kind in CREDENTIAL_ENV_VAR if kind.startswith(f"runtime_token:{runtime}")
+    }
+    has_credential = UserCredential.objects.filter(
+        user=request.user, kind__in=accepted_kinds
+    ).exists()
+    if not has_credential:
         return JsonResponse(
             {"detail": f"No API key configured for runtime: {runtime}"},
             status=400,
         )
+
+    # Agent's model must be servable by the agent's runtime.
+    if agent_obj.model in MODELS:
+        model = MODELS[agent_obj.model]
+        if model.provider not in runtime_obj.providers:
+            return JsonResponse(
+                {
+                    "detail": (
+                        f"Runtime {runtime} cannot serve model {agent_obj.model}: "
+                        f"provider {model.provider} not in {sorted(runtime_obj.providers)}"
+                    )
+                },
+                status=422,
+            )
 
     # Sync pre-check so missing Sprites creds return 400 immediately rather
     # than surfacing as a failed session the client has to poll for.

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -7,7 +7,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "dev-insecure-key-change-in-prod")
 
-# Dedicated KEK for encrypted model fields (UserSpritesKey, UserRuntimeKey). Split
+# Dedicated KEK for encrypted model fields (UserSpritesKey, UserCredential). Split
 # from SECRET_KEY so session-signing keys can be rotated independently of the
 # field-encryption key. Rotating this key still requires a re-encrypt migration.
 FIELD_ENCRYPTION_KEY = os.environ.get("FIELD_ENCRYPTION_KEY")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -22,6 +22,7 @@ RUNTIME_MODELS = {
     "claude": "anthropic/claude-haiku-4-5",
     "codex": "openai/o4-mini",
     "gemini": "google/gemini-2.5-flash",
+    "opencode": "anthropic/claude-haiku-4-5",
 }
 
 DEFAULT_TIMEOUT = int(os.environ.get("E2E_TIMEOUT", "180"))

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -19,10 +19,9 @@ import requests
 
 # Cheapest model per runtime for fast, inexpensive tests
 RUNTIME_MODELS = {
-    "claude": "claude-haiku-4-5",
-    "codex": "o4-mini",
-    "gemini": "gemini-2.5-flash",
-    "claude-oauth": "claude-haiku-4-5",
+    "claude": "anthropic/claude-haiku-4-5",
+    "codex": "openai/o4-mini",
+    "gemini": "google/gemini-2.5-flash",
 }
 
 DEFAULT_TIMEOUT = int(os.environ.get("E2E_TIMEOUT", "180"))

--- a/tests/e2e/test_agents.py
+++ b/tests/e2e/test_agents.py
@@ -16,7 +16,7 @@ class TestAgentCRUD:
     def test_create_agent_full(self, api, create_agent):
         agent = create_agent(
             name=_unique("e2e-agent"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
             system="You are a helpful assistant.",
             description="E2E test agent",
@@ -37,7 +37,7 @@ class TestAgentCRUD:
         )
         assert agent["type"] == "agent"
         assert agent["name"].startswith("e2e-agent-")
-        assert agent["model"] == "claude-sonnet-4-6"
+        assert agent["model"] == "anthropic/claude-sonnet-4-6"
         assert agent["runtime"] == "claude"
         assert agent["system"] == "You are a helpful assistant."
         assert agent["description"] == "E2E test agent"
@@ -49,7 +49,7 @@ class TestAgentCRUD:
     def test_create_agent_minimal(self, api, create_agent):
         agent = create_agent(
             name=_unique("e2e-min"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
         )
         assert agent["system"] is None or agent["system"] == ""
@@ -69,7 +69,7 @@ class TestAgentCRUD:
     def test_create_agent_invalid_runtime_rejected(self, api):
         resp = api.create_agent(
             name=_unique("e2e-bad"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="invalid",
         )
         assert resp.status_code == 400
@@ -81,7 +81,7 @@ class TestAgentCRUD:
     def test_get_agent(self, api, create_agent):
         agent = create_agent(
             name=_unique("e2e-get"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
         )
         resp = api.get_agent(agent["id"])
@@ -95,7 +95,7 @@ class TestAgentCRUD:
     def test_list_agents(self, api, create_agent):
         agent = create_agent(
             name=_unique("e2e-list"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
         )
         resp = api.list_agents()
@@ -113,7 +113,7 @@ class TestAgentVersioning:
     def test_update_increments_version(self, api, create_agent):
         agent = create_agent(
             name=_unique("e2e-ver"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
             system="v1 prompt",
         )
@@ -131,7 +131,7 @@ class TestAgentVersioning:
     def test_update_version_mismatch_rejected(self, api, create_agent):
         agent = create_agent(
             name=_unique("e2e-vmis"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
         )
         resp = api.update_agent(agent["id"], version=99, name="new")
@@ -140,7 +140,7 @@ class TestAgentVersioning:
     def test_no_change_update_keeps_version(self, api, create_agent):
         agent = create_agent(
             name=_unique("e2e-noop"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
         )
         resp = api.update_agent(
@@ -153,7 +153,7 @@ class TestAgentVersioning:
     def test_list_versions(self, api, create_agent):
         agent = create_agent(
             name=_unique("e2e-versions"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
         )
         api.update_agent(agent["id"], version=1, system="updated")
@@ -168,7 +168,7 @@ class TestAgentVersioning:
     def test_metadata_merge_semantics(self, api, create_agent):
         agent = create_agent(
             name=_unique("e2e-meta"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
             metadata={"key1": "val1", "key2": "val2"},
         )
@@ -191,7 +191,7 @@ class TestAgentArchive:
     def test_archive(self, api, create_agent):
         agent = create_agent(
             name=_unique("e2e-arch"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
         )
         resp = api.archive_agent(agent["id"])
@@ -201,7 +201,7 @@ class TestAgentArchive:
     def test_archive_idempotent_409(self, api, create_agent):
         agent = create_agent(
             name=_unique("e2e-arch2"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
         )
         api.archive_agent(agent["id"])
@@ -211,7 +211,7 @@ class TestAgentArchive:
     def test_update_archived_rejected(self, api, create_agent):
         agent = create_agent(
             name=_unique("e2e-archup"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
         )
         api.archive_agent(agent["id"])
@@ -221,7 +221,7 @@ class TestAgentArchive:
     def test_list_excludes_archived(self, api, create_agent):
         agent = create_agent(
             name=_unique("e2e-archhide"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
         )
         api.archive_agent(agent["id"])
@@ -252,7 +252,7 @@ class TestAgentMcp:
     def test_create_with_mcp(self, api, create_agent):
         agent = create_agent(
             name=_unique("e2e-mcp"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
             mcp_servers=[
                 {
@@ -269,7 +269,7 @@ class TestAgentMcp:
     def test_mcp_server_missing_name_rejected(self, api):
         resp = api.create_agent(
             name=_unique("e2e-badmcp"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
             mcp_servers=[{"type": "url", "url": "https://example.com/mcp"}],
         )
@@ -278,7 +278,7 @@ class TestAgentMcp:
     def test_mcp_server_duplicate_names_rejected(self, api):
         resp = api.create_agent(
             name=_unique("e2e-dupmcp"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
             mcp_servers=[
                 {"name": "s", "url": "https://a.com/mcp"},
@@ -291,7 +291,7 @@ class TestAgentMcp:
         servers = [{"name": f"s{i}", "url": f"https://s{i}.com/mcp"} for i in range(21)]
         resp = api.create_agent(
             name=_unique("e2e-maxmcp"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
             mcp_servers=servers,
         )
@@ -300,7 +300,7 @@ class TestAgentMcp:
     def test_update_mcp_versioned(self, api, create_agent):
         agent = create_agent(
             name=_unique("e2e-mcpver"),
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
         )
         resp = api.update_agent(

--- a/tests/e2e/test_environments.py
+++ b/tests/e2e/test_environments.py
@@ -261,7 +261,7 @@ class TestEnvironmentInSession:
         self, api, create_agent, create_session, create_environment, runtime
     ):
         """A domain outside allowed_hosts resolves to DNS REFUSED inside the sprite."""
-        if runtime not in ("claude", "claude-oauth"):
+        if runtime != "claude":
             pytest.skip("Hardcoded allowed_hosts assume the claude runtime's API host")
 
         env = create_environment(
@@ -302,7 +302,7 @@ class TestEnvironmentInSession:
         self, api, create_agent, create_session, create_environment, runtime
     ):
         """A domain inside allowed_hosts resolves normally inside the sprite."""
-        if runtime not in ("claude", "claude-oauth"):
+        if runtime != "claude":
             pytest.skip("Hardcoded allowed_hosts assume the claude runtime's API host")
 
         env = create_environment(

--- a/tests/e2e/test_mcp.py
+++ b/tests/e2e/test_mcp.py
@@ -118,11 +118,7 @@ def _everything_server_spec() -> dict:
     }
 
 
-# claude-oauth is intentionally excluded — Anthropic OAuth accounts can have
-# MCP disabled at the org policy tier (observed as "org_level_disabled" in the
-# stream), so MCP invocation is not portably testable on that runtime. Other
-# e2e suites still exercise claude-oauth for non-MCP paths.
-_MCP_RUNTIMES = [r for r in RUNTIME_MODELS.keys() if r != "claude-oauth"]
+_MCP_RUNTIMES = list(RUNTIME_MODELS.keys())
 
 
 @pytest.fixture(scope="class", params=_MCP_RUNTIMES)

--- a/tests/runtimes/test_claude.py
+++ b/tests/runtimes/test_claude.py
@@ -1,0 +1,154 @@
+"""ClaudeRuntime behavior: build_command (API-key + OAuth paths),
+write_config (MCP JSON at /home/sprite/.claude.json), skills_root."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.contrib.auth.models import User
+
+from agent_on_demand.models import UserCredential
+from agent_on_demand.runtimes.claude import ClaudeRuntime
+from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
+from tests.fakes.sprite import RecordingSprite
+
+
+SESSION_UUID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="claudeuser", password="p")
+
+
+def _spec(user) -> SessionSpec:
+    return SessionSpec(
+        name="sprite-x",
+        runtime=ClaudeRuntime(),
+        model="anthropic/claude-sonnet-4-6",
+        user=user,
+        runtime_session_id=SESSION_UUID,
+        environment=None,
+        repos=[],
+        mcp_servers=[],
+        skills=[],
+    )
+
+
+def test_skills_root():
+    assert ClaudeRuntime().skills_root == "/home/sprite/.claude/skills"
+
+
+def test_providers():
+    assert ClaudeRuntime().providers == {"anthropic"}
+
+
+@pytest.mark.django_db
+def test_build_command_run_api_key(user):
+    argv = ClaudeRuntime().build_command(_spec(user), "run")
+    assert argv == [
+        "claude",
+        "--print",
+        "--verbose",
+        "--output-format",
+        "stream-json",
+        "--session-id",
+        SESSION_UUID,
+    ]
+
+
+@pytest.mark.django_db
+def test_build_command_continue_api_key(user):
+    argv = ClaudeRuntime().build_command(_spec(user), "continue")
+    assert argv == [
+        "claude",
+        "--dangerously-skip-permissions",
+        "--print",
+        "--verbose",
+        "--output-format",
+        "stream-json",
+        "--resume",
+        SESSION_UUID,
+    ]
+
+
+@pytest.mark.django_db
+def test_build_command_uses_dangerously_skip_permissions_when_user_has_oauth(user):
+    cred = UserCredential(user=user, kind="runtime_token:claude-oauth")
+    cred.set_value("oauth-token")
+    cred.save()
+
+    argv = ClaudeRuntime().build_command(_spec(user), "run")
+    assert "--dangerously-skip-permissions" in argv
+    # Run mode still uses --session-id, not --resume.
+    assert "--session-id" in argv
+    assert "--resume" not in argv
+
+
+@pytest.mark.django_db
+def test_write_config_url_server(user):
+    sprite = RecordingSprite("s")
+    spec = _spec(user)
+    ClaudeRuntime().write_config(
+        sprite,
+        spec,
+        [McpServerSpec(name="github", type="url", url="https://mcp.github.com/mcp")],
+    )
+    cfg = json.loads(sprite.write_map()["/home/sprite/.claude.json"])
+    assert cfg == {
+        "mcpServers": {"github": {"type": "http", "url": "https://mcp.github.com/mcp"}}
+    }
+
+
+@pytest.mark.django_db
+def test_write_config_url_server_with_headers(user):
+    sprite = RecordingSprite("s")
+    spec = _spec(user)
+    ClaudeRuntime().write_config(
+        sprite,
+        spec,
+        [
+            McpServerSpec(
+                name="private",
+                type="url",
+                url="https://mcp.example.com/mcp",
+                headers={"Authorization": "Bearer ${SECRET}"},
+            )
+        ],
+    )
+    cfg = json.loads(sprite.write_map()["/home/sprite/.claude.json"])
+    assert cfg["mcpServers"]["private"]["headers"] == {"Authorization": "Bearer ${SECRET}"}
+
+
+@pytest.mark.django_db
+def test_write_config_stdio_server(user):
+    sprite = RecordingSprite("s")
+    spec = _spec(user)
+    ClaudeRuntime().write_config(
+        sprite,
+        spec,
+        [
+            McpServerSpec(
+                name="local",
+                type="stdio",
+                command="npx",
+                args=["-y", "@some/mcp-server"],
+                env={"API_KEY": "val"},
+            )
+        ],
+    )
+    cfg = json.loads(sprite.write_map()["/home/sprite/.claude.json"])
+    assert cfg["mcpServers"]["local"] == {
+        "type": "stdio",
+        "command": "npx",
+        "args": ["-y", "@some/mcp-server"],
+        "env": {"API_KEY": "val"},
+    }
+
+
+@pytest.mark.django_db
+def test_write_config_empty_mcp_servers_writes_nothing(user):
+    sprite = RecordingSprite("s")
+    ClaudeRuntime().write_config(sprite, _spec(user), [])
+    assert "/home/sprite/.claude.json" not in sprite.write_map()

--- a/tests/runtimes/test_claude.py
+++ b/tests/runtimes/test_claude.py
@@ -1,5 +1,5 @@
-"""ClaudeRuntime behavior: build_command (API-key + OAuth paths),
-write_config (MCP JSON at /home/sprite/.claude.json), skills_root."""
+"""ClaudeRuntime behavior: build_command, write_config (MCP JSON at
+/home/sprite/.claude.json), skills_root."""
 
 from __future__ import annotations
 
@@ -8,7 +8,6 @@ import json
 import pytest
 from django.contrib.auth.models import User
 
-from agent_on_demand.models import UserCredential
 from agent_on_demand.runtimes.claude import ClaudeRuntime
 from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
 from tests.fakes.sprite import RecordingSprite
@@ -45,10 +44,11 @@ def test_providers():
 
 
 @pytest.mark.django_db
-def test_build_command_run_api_key(user):
+def test_build_command_run(user):
     argv = ClaudeRuntime().build_command(_spec(user), "run")
     assert argv == [
         "claude",
+        "--dangerously-skip-permissions",
         "--print",
         "--verbose",
         "--output-format",
@@ -59,7 +59,7 @@ def test_build_command_run_api_key(user):
 
 
 @pytest.mark.django_db
-def test_build_command_continue_api_key(user):
+def test_build_command_continue(user):
     argv = ClaudeRuntime().build_command(_spec(user), "continue")
     assert argv == [
         "claude",
@@ -71,19 +71,6 @@ def test_build_command_continue_api_key(user):
         "--resume",
         SESSION_UUID,
     ]
-
-
-@pytest.mark.django_db
-def test_build_command_uses_dangerously_skip_permissions_when_user_has_oauth(user):
-    cred = UserCredential(user=user, kind="runtime_token:claude-oauth")
-    cred.set_value("oauth-token")
-    cred.save()
-
-    argv = ClaudeRuntime().build_command(_spec(user), "run")
-    assert "--dangerously-skip-permissions" in argv
-    # Run mode still uses --session-id, not --resume.
-    assert "--session-id" in argv
-    assert "--resume" not in argv
 
 
 @pytest.mark.django_db

--- a/tests/runtimes/test_codex.py
+++ b/tests/runtimes/test_codex.py
@@ -1,0 +1,104 @@
+"""CodexRuntime behavior: build_command, write_config (TOML at
+/home/sprite/.codex/config.toml), skills_root."""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+
+from agent_on_demand.runtimes.codex import CodexRuntime
+from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
+from tests.fakes.sprite import RecordingSprite
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="codexuser", password="p")
+
+
+def _spec(user) -> SessionSpec:
+    return SessionSpec(
+        name="sprite-x",
+        runtime=CodexRuntime(),
+        model="openai/gpt-4.1",
+        user=user,
+        runtime_session_id=None,
+        environment=None,
+        repos=[],
+        mcp_servers=[],
+        skills=[],
+    )
+
+
+def test_skills_root():
+    assert CodexRuntime().skills_root == "/home/sprite/.codex/skills"
+
+
+def test_providers():
+    assert CodexRuntime().providers == {"openai"}
+
+
+@pytest.mark.django_db
+def test_build_command_run(user):
+    argv = CodexRuntime().build_command(_spec(user), "run")
+    assert argv == [
+        "codex",
+        "exec",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--json",
+    ]
+
+
+@pytest.mark.django_db
+def test_build_command_continue(user):
+    argv = CodexRuntime().build_command(_spec(user), "continue")
+    assert argv == [
+        "codex",
+        "exec",
+        "resume",
+        "--last",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--json",
+    ]
+
+
+@pytest.mark.django_db
+def test_write_config_url_server(user):
+    sprite = RecordingSprite("s")
+    spec = _spec(user)
+    CodexRuntime().write_config(
+        sprite,
+        spec,
+        [McpServerSpec(name="github", type="url", url="https://mcp.github.com/mcp")],
+    )
+    toml = sprite.write_map()["/home/sprite/.codex/config.toml"]
+    assert "[mcp_servers.github]" in toml
+    assert 'url = "https://mcp.github.com/mcp"' in toml
+    assert "required = true" in toml
+
+
+@pytest.mark.django_db
+def test_write_config_bearer_token_env_var(user):
+    sprite = RecordingSprite("s")
+    spec = _spec(user)
+    CodexRuntime().write_config(
+        sprite,
+        spec,
+        [
+            McpServerSpec(
+                name="api",
+                type="url",
+                url="https://mcp.example.com/mcp",
+                headers={"Authorization": "Bearer ${MY_TOKEN}"},
+            )
+        ],
+    )
+    toml = sprite.write_map()["/home/sprite/.codex/config.toml"]
+    assert 'bearer_token_env_var = "MY_TOKEN"' in toml
+
+
+@pytest.mark.django_db
+def test_write_config_empty_mcp_servers_writes_nothing(user):
+    sprite = RecordingSprite("s")
+    CodexRuntime().write_config(sprite, _spec(user), [])
+    assert "/home/sprite/.codex/config.toml" not in sprite.write_map()

--- a/tests/runtimes/test_gemini.py
+++ b/tests/runtimes/test_gemini.py
@@ -1,0 +1,94 @@
+"""GeminiRuntime behavior: build_command, write_config (JSON at
+/home/sprite/.gemini/settings.json), skills_root."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.contrib.auth.models import User
+
+from agent_on_demand.runtimes.gemini import GeminiRuntime
+from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
+from tests.fakes.sprite import RecordingSprite
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="geminiuser", password="p")
+
+
+def _spec(user) -> SessionSpec:
+    return SessionSpec(
+        name="sprite-x",
+        runtime=GeminiRuntime(),
+        model="google/gemini-2.5-pro",
+        user=user,
+        runtime_session_id=None,
+        environment=None,
+        repos=[],
+        mcp_servers=[],
+        skills=[],
+    )
+
+
+def test_skills_root():
+    assert GeminiRuntime().skills_root == "/home/sprite/.gemini/skills"
+
+
+def test_providers():
+    assert GeminiRuntime().providers == {"google"}
+
+
+@pytest.mark.django_db
+def test_build_command_run(user):
+    argv = GeminiRuntime().build_command(_spec(user), "run")
+    assert argv == ["gemini", "--output-format", "stream-json"]
+
+
+@pytest.mark.django_db
+def test_build_command_continue(user):
+    argv = GeminiRuntime().build_command(_spec(user), "continue")
+    assert argv == ["gemini", "--resume", "--output-format", "stream-json"]
+
+
+@pytest.mark.django_db
+def test_write_config_url_server(user):
+    sprite = RecordingSprite("s")
+    spec = _spec(user)
+    GeminiRuntime().write_config(
+        sprite,
+        spec,
+        [McpServerSpec(name="github", type="url", url="https://mcp.github.com/mcp")],
+    )
+    cfg = json.loads(sprite.write_map()["/home/sprite/.gemini/settings.json"])
+    assert cfg["mcpServers"]["github"]["httpUrl"] == "https://mcp.github.com/mcp"
+    assert cfg["mcpServers"]["github"]["trust"] is True
+
+
+@pytest.mark.django_db
+def test_write_config_stdio_server(user):
+    sprite = RecordingSprite("s")
+    spec = _spec(user)
+    GeminiRuntime().write_config(
+        sprite,
+        spec,
+        [
+            McpServerSpec(
+                name="local",
+                type="stdio",
+                command="npx",
+                args=["-y", "@some/mcp-server"],
+            )
+        ],
+    )
+    cfg = json.loads(sprite.write_map()["/home/sprite/.gemini/settings.json"])
+    assert cfg["mcpServers"]["local"]["command"] == "npx"
+    assert cfg["mcpServers"]["local"]["trust"] is True
+
+
+@pytest.mark.django_db
+def test_write_config_empty_mcp_servers_writes_nothing(user):
+    sprite = RecordingSprite("s")
+    GeminiRuntime().write_config(sprite, _spec(user), [])
+    assert "/home/sprite/.gemini/settings.json" not in sprite.write_map()

--- a/tests/runtimes/test_opencode.py
+++ b/tests/runtimes/test_opencode.py
@@ -1,0 +1,159 @@
+"""OpencodeRuntime behavior: install (npm), build_command (run + --continue),
+write_config (JSON at /home/sprite/.config/opencode/opencode.json with
+opencode's schema), skills_root."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.contrib.auth.models import User
+
+from agent_on_demand.runtimes.opencode import OPENCODE_VERSION, OpencodeRuntime
+from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
+from tests.fakes.sprite import RecordingSprite
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="opencodeuser", password="p")
+
+
+def _spec(user, model: str = "anthropic/claude-haiku-4-5") -> SessionSpec:
+    return SessionSpec(
+        name="sprite-x",
+        runtime=OpencodeRuntime(),
+        model=model,
+        user=user,
+        runtime_session_id=None,
+        environment=None,
+        repos=[],
+        mcp_servers=[],
+        skills=[],
+    )
+
+
+def test_skills_root():
+    assert OpencodeRuntime().skills_root == "/home/sprite/.config/opencode/skills"
+
+
+def test_providers():
+    assert OpencodeRuntime().providers == {"anthropic", "openai", "google"}
+
+
+def test_install_runs_npm_global():
+    sprite = RecordingSprite("s")
+    OpencodeRuntime().install(sprite)
+    assert len(sprite.commands) == 1
+    argv = sprite.commands[0].argv
+    assert argv[0] == "bash"
+    assert argv[1] == "-lc"
+    assert f"opencode-ai@{OPENCODE_VERSION}" in argv[2]
+    assert "npm install -g" in argv[2]
+
+
+@pytest.mark.django_db
+def test_build_command_run(user):
+    argv = OpencodeRuntime().build_command(_spec(user), "run")
+    assert argv == [
+        "opencode",
+        "run",
+        "--model",
+        "anthropic/claude-haiku-4-5",
+        "--format",
+        "json",
+    ]
+
+
+@pytest.mark.django_db
+def test_build_command_continue(user):
+    argv = OpencodeRuntime().build_command(_spec(user), "continue")
+    assert argv == [
+        "opencode",
+        "run",
+        "--model",
+        "anthropic/claude-haiku-4-5",
+        "--format",
+        "json",
+        "--continue",
+    ]
+
+
+@pytest.mark.django_db
+def test_build_command_passes_through_provider_prefix(user):
+    """Model string passes through unchanged — opencode takes provider/model_id."""
+    argv = OpencodeRuntime().build_command(_spec(user, model="openai/gpt-4.1"), "run")
+    assert argv[3] == "openai/gpt-4.1"
+
+
+@pytest.mark.django_db
+def test_write_config_url_server(user):
+    sprite = RecordingSprite("s")
+    OpencodeRuntime().write_config(
+        sprite,
+        _spec(user),
+        [McpServerSpec(name="github", type="url", url="https://mcp.github.com/mcp")],
+    )
+    cfg = json.loads(sprite.write_map()["/home/sprite/.config/opencode/opencode.json"])
+    assert cfg == {
+        "mcp": {
+            "github": {
+                "type": "remote",
+                "url": "https://mcp.github.com/mcp",
+                "enabled": True,
+            }
+        }
+    }
+
+
+@pytest.mark.django_db
+def test_write_config_url_server_with_headers(user):
+    sprite = RecordingSprite("s")
+    OpencodeRuntime().write_config(
+        sprite,
+        _spec(user),
+        [
+            McpServerSpec(
+                name="private",
+                type="url",
+                url="https://mcp.example.com/mcp",
+                headers={"Authorization": "Bearer ${SECRET}"},
+            )
+        ],
+    )
+    cfg = json.loads(sprite.write_map()["/home/sprite/.config/opencode/opencode.json"])
+    assert cfg["mcp"]["private"]["headers"] == {"Authorization": "Bearer ${SECRET}"}
+
+
+@pytest.mark.django_db
+def test_write_config_stdio_server(user):
+    sprite = RecordingSprite("s")
+    OpencodeRuntime().write_config(
+        sprite,
+        _spec(user),
+        [
+            McpServerSpec(
+                name="local",
+                type="stdio",
+                command="npx",
+                args=["-y", "@some/mcp-server"],
+                env={"API_KEY": "val"},
+            )
+        ],
+    )
+    cfg = json.loads(sprite.write_map()["/home/sprite/.config/opencode/opencode.json"])
+    # Opencode quirks: `command` is a single combined array (not command+args
+    # split), env key is `environment`, type is `local` (not `stdio`).
+    assert cfg["mcp"]["local"] == {
+        "type": "local",
+        "command": ["npx", "-y", "@some/mcp-server"],
+        "enabled": True,
+        "environment": {"API_KEY": "val"},
+    }
+
+
+@pytest.mark.django_db
+def test_write_config_empty_mcp_servers_writes_nothing(user):
+    sprite = RecordingSprite("s")
+    OpencodeRuntime().write_config(sprite, _spec(user), [])
+    assert "/home/sprite/.config/opencode/opencode.json" not in sprite.write_map()

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -5,7 +5,7 @@ import pytest
 from django.contrib.auth.models import User
 from django.test import Client
 
-from agent_on_demand.models import Agent, AgentVersion, APIKey, UserRuntimeKey, UserSpritesKey
+from agent_on_demand.models import Agent, AgentVersion, APIKey, UserCredential, UserSpritesKey
 
 
 @pytest.fixture
@@ -35,10 +35,10 @@ def sprites_key(user):
 
 @pytest.fixture
 def runtime_key(user, sprites_key):
-    urk = UserRuntimeKey(user=user, runtime="claude")
-    urk.set_api_key("fake-anthropic-key")
-    urk.save()
-    return urk
+    cred = UserCredential(user=user, kind="provider:anthropic")
+    cred.set_value("fake-anthropic-key")
+    cred.save()
+    return cred
 
 
 SAMPLE_SKILL = {
@@ -55,7 +55,7 @@ def agent(user):
         name="Test Agent",
         description="A test agent",
         system="You are a helpful assistant.",
-        model="claude-sonnet-4-6",
+        model="anthropic/claude-sonnet-4-6",
         runtime="claude",
         skills=[SAMPLE_SKILL],
         metadata={"team": "platform"},
@@ -85,7 +85,7 @@ def test_create_agent(client: Client, auth_headers):
         data=json.dumps(
             {
                 "name": "My Agent",
-                "model": "claude-sonnet-4-6",
+                "model": "anthropic/claude-sonnet-4-6",
                 "runtime": "claude",
                 "system": "You are helpful.",
                 "description": "Does things",
@@ -99,7 +99,7 @@ def test_create_agent(client: Client, auth_headers):
     assert resp.status_code == 201
     data = resp.json()
     assert data["name"] == "My Agent"
-    assert data["model"] == "claude-sonnet-4-6"
+    assert data["model"] == "anthropic/claude-sonnet-4-6"
     assert data["runtime"] == "claude"
     assert data["system"] == "You are helpful."
     assert data["description"] == "Does things"
@@ -117,7 +117,7 @@ def test_create_agent(client: Client, auth_headers):
 def test_create_agent_minimal(client: Client, auth_headers):
     resp = client.post(
         "/agents",
-        data=json.dumps({"name": "Minimal", "model": "claude-sonnet-4-6", "runtime": "claude"}),
+        data=json.dumps({"name": "Minimal", "model": "anthropic/claude-sonnet-4-6", "runtime": "claude"}),
         content_type="application/json",
         **auth_headers,
     )
@@ -144,12 +144,31 @@ def test_create_agent_invalid_model(client: Client, auth_headers):
 def test_create_agent_invalid_runtime(client: Client, auth_headers):
     resp = client.post(
         "/agents",
-        data=json.dumps({"name": "Bad", "model": "claude-sonnet-4-6", "runtime": "nope"}),
+        data=json.dumps({"name": "Bad", "model": "anthropic/claude-sonnet-4-6", "runtime": "nope"}),
         content_type="application/json",
         **auth_headers,
     )
     assert resp.status_code == 400
     assert "Unknown runtime" in resp.json()["detail"]
+
+
+@pytest.mark.django_db
+def test_create_agent_runtime_model_mismatch(client: Client, auth_headers):
+    """Runtime's providers must include the model's provider."""
+    resp = client.post(
+        "/agents",
+        data=json.dumps(
+            {
+                "name": "Bad",
+                "model": "openai/gpt-4.1",
+                "runtime": "claude",
+            }
+        ),
+        content_type="application/json",
+        **auth_headers,
+    )
+    assert resp.status_code == 422
+    assert "cannot serve model" in resp.json()["detail"]
 
 
 @pytest.mark.django_db

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,8 +11,8 @@ from agent_on_demand.models import (
     AgentSession,
     AgentSessionLog,
     SessionTurn,
+    UserCredential,
     UserQuota,
-    UserRuntimeKey,
     UserSpritesKey,
 )
 
@@ -65,24 +65,24 @@ def sprites_key(user):
 
 @pytest.fixture
 def runtime_key(user, sprites_key):
-    """Create a UserRuntimeKey for the claude runtime.
+    """Create a UserCredential for the anthropic provider (Claude runtime).
 
     Depends on `sprites_key` so tests that exercise session create/prompt also
     have the per-user Sprites token configured.
     """
-    urk = UserRuntimeKey(user=user, runtime="claude")
-    urk.set_api_key("fake-anthropic-key")
-    urk.save()
-    return urk
+    cred = UserCredential(user=user, kind="provider:anthropic")
+    cred.set_value("fake-anthropic-key")
+    cred.save()
+    return cred
 
 
 @pytest.fixture
 def runtime_key_without_sprites(user):
-    """Runtime key configured, but no UserSpritesKey — for negative tests."""
-    urk = UserRuntimeKey(user=user, runtime="claude")
-    urk.set_api_key("fake-anthropic-key")
-    urk.save()
-    return urk
+    """Runtime credential configured, but no UserSpritesKey — for negative tests."""
+    cred = UserCredential(user=user, kind="provider:anthropic")
+    cred.set_value("fake-anthropic-key")
+    cred.save()
+    return cred
 
 
 @pytest.fixture
@@ -90,7 +90,7 @@ def agent(user):
     return Agent.objects.create(
         user=user,
         name="Test Agent",
-        model="claude-sonnet-4-6",
+        model="anthropic/claude-sonnet-4-6",
         runtime="claude",
         version=1,
     )
@@ -179,7 +179,7 @@ def test_run_agent_not_found(client: Client, auth_headers):
 
 @pytest.mark.django_db
 def test_run_no_runtime_key(client: Client, auth_headers, agent):
-    """Authenticated but no UserRuntimeKey configured for the agent's runtime."""
+    """Authenticated but no UserCredential configured for the agent's runtime."""
     resp = client.post(
         "/sessions",
         data=json.dumps({"agent_id": str(agent.id), "prompt": "hello"}),
@@ -192,7 +192,7 @@ def test_run_no_runtime_key(client: Client, auth_headers, agent):
 
 @pytest.mark.django_db
 def test_run_no_sprites_key(client: Client, auth_headers, runtime_key_without_sprites, agent):
-    """Runtime key is set but no UserSpritesKey — session create must 400."""
+    """Runtime credential is set but no UserSpritesKey — session create must 400."""
     resp = client.post(
         "/sessions",
         data=json.dumps({"agent_id": str(agent.id), "prompt": "hello"}),

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -12,7 +12,7 @@ from agent_on_demand.models import (
     APIKey,
     Environment,
     EnvironmentVersion,
-    UserRuntimeKey,
+    UserCredential,
     UserSpritesKey,
 )
 
@@ -47,10 +47,10 @@ def sprites_key(user):
 
 @pytest.fixture
 def runtime_key(user, sprites_key):
-    urk = UserRuntimeKey(user=user, runtime="claude")
-    urk.set_api_key("fake-anthropic-key")
-    urk.save()
-    return urk
+    cred = UserCredential(user=user, kind="provider:anthropic")
+    cred.set_value("fake-anthropic-key")
+    cred.save()
+    return cred
 
 
 @pytest.fixture
@@ -82,7 +82,7 @@ def agent(user):
     return Agent.objects.create(
         user=user,
         name="Test Agent",
-        model="claude-sonnet-4-6",
+        model="anthropic/claude-sonnet-4-6",
         runtime="claude",
         version=1,
     )
@@ -648,7 +648,7 @@ class TestSessionEnvironmentIntegration:
         agent = Agent.objects.create(
             user=user,
             name="Agent",
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
             environment=environment,
             version=1,
@@ -677,7 +677,7 @@ class TestSessionEnvironmentIntegration:
         agent = Agent.objects.create(
             user=user,
             name="Agent",
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
             environment=environment,
             version=1,
@@ -781,7 +781,7 @@ class TestAgentEnvironmentIntegration:
             data=json.dumps(
                 {
                     "name": "My Agent",
-                    "model": "claude-sonnet-4-6",
+                    "model": "anthropic/claude-sonnet-4-6",
                     "runtime": "claude",
                     "environment_id": str(environment.id),
                 }
@@ -798,7 +798,7 @@ class TestAgentEnvironmentIntegration:
             data=json.dumps(
                 {
                     "name": "My Agent",
-                    "model": "claude-sonnet-4-6",
+                    "model": "anthropic/claude-sonnet-4-6",
                     "runtime": "claude",
                 }
             ),
@@ -812,7 +812,7 @@ class TestAgentEnvironmentIntegration:
         agent = Agent.objects.create(
             user=user,
             name="Agent",
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
             version=1,
         )

--- a/tests/test_models_catalog.py
+++ b/tests/test_models_catalog.py
@@ -1,7 +1,22 @@
 import pytest
 
 from agent_on_demand.models_catalog import MODELS, ModelDef
-from agent_on_demand.runtimes import AgentModel
+
+
+EXPECTED_MODELS = {
+    "anthropic/claude-opus-4-6",
+    "anthropic/claude-sonnet-4-6",
+    "anthropic/claude-haiku-4-5",
+    "anthropic/claude-opus-4-0-20250514",
+    "anthropic/claude-sonnet-4-0-20250514",
+    "anthropic/claude-sonnet-4-5-20250514",
+    "anthropic/claude-3-5-haiku-20241022",
+    "openai/gpt-4.1",
+    "openai/o3",
+    "openai/o4-mini",
+    "google/gemini-2.5-pro",
+    "google/gemini-2.5-flash",
+}
 
 
 def test_models_catalog_importable():
@@ -18,32 +33,8 @@ def test_all_entries_have_provider_matching_id_prefix():
         assert model_def.id == key, f"ModelDef.id '{model_def.id}' does not match dict key '{key}'"
 
 
-def test_models_catalog_covers_all_agent_model_values():
-    """Every AgentModel value maps to an entry in MODELS (with provider/ prefix added)."""
-    provider_map = {
-        # claude models → anthropic
-        "claude-opus-4-6": "anthropic",
-        "claude-sonnet-4-6": "anthropic",
-        "claude-haiku-4-5": "anthropic",
-        "claude-opus-4-0-20250514": "anthropic",
-        "claude-sonnet-4-0-20250514": "anthropic",
-        "claude-sonnet-4-5-20250514": "anthropic",
-        "claude-3-5-haiku-20241022": "anthropic",
-        # openai models
-        "gpt-4.1": "openai",
-        "o3": "openai",
-        "o4-mini": "openai",
-        # google models
-        "gemini-2.5-pro": "google",
-        "gemini-2.5-flash": "google",
-    }
-    for model_value in AgentModel.values():
-        assert model_value in provider_map, f"AgentModel value '{model_value}' not in provider_map"
-        provider = provider_map[model_value]
-        catalog_key = f"{provider}/{model_value}"
-        assert catalog_key in MODELS, (
-            f"Expected '{catalog_key}' in MODELS for AgentModel value '{model_value}'"
-        )
+def test_models_catalog_covers_all_expected_keys():
+    assert set(MODELS) >= EXPECTED_MODELS
 
 
 def test_model_def_is_frozen():

--- a/tests/test_networking_wiring.py
+++ b/tests/test_networking_wiring.py
@@ -10,7 +10,7 @@ from agent_on_demand.models import (
     APIKey,
     Environment,
     EnvironmentVersion,
-    UserRuntimeKey,
+    UserCredential,
     UserSpritesKey,
 )
 
@@ -42,10 +42,10 @@ def sprites_key(user):
 
 @pytest.fixture
 def runtime_key(user, sprites_key):
-    urk = UserRuntimeKey(user=user, runtime="claude")
-    urk.set_api_key("fake-anthropic-key")
-    urk.save()
-    return urk
+    cred = UserCredential(user=user, kind="provider:anthropic")
+    cred.set_value("fake-anthropic-key")
+    cred.save()
+    return cred
 
 
 @pytest.fixture
@@ -53,7 +53,7 @@ def agent(user):
     return Agent.objects.create(
         user=user,
         name="Test Agent",
-        model="claude-sonnet-4-6",
+        model="anthropic/claude-sonnet-4-6",
         runtime="claude",
         version=1,
     )

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -19,7 +19,7 @@ from django.contrib.auth.models import User
 from django.test import Client
 
 from agent_on_demand import observability
-from agent_on_demand.models import APIKey, UserRuntimeKey, UserSpritesKey
+from agent_on_demand.models import APIKey, UserCredential, UserSpritesKey
 
 
 SENSITIVE_PROMPT = "PLEASE_DO_NOT_LEAK_THIS_PROMPT_TEXT_2026"
@@ -45,9 +45,9 @@ def runtime_keys(user):
     usk = UserSpritesKey(user=user)
     usk.set_api_key("fake-sprites")
     usk.save()
-    urk = UserRuntimeKey(user=user, runtime="claude")
-    urk.set_api_key("fake-anthropic")
-    urk.save()
+    cred = UserCredential(user=user, kind="provider:anthropic")
+    cred.set_value("fake-anthropic")
+    cred.save()
 
 
 @pytest.fixture
@@ -87,7 +87,7 @@ def test_agent_created_event_fires_with_safe_props(client: Client, auth_headers,
         data=json.dumps(
             {
                 "name": "obs-agent",
-                "model": "claude-sonnet-4-6",
+                "model": "anthropic/claude-sonnet-4-6",
                 "runtime": "claude",
                 "system": "SYSTEM_PROMPT_BODY_SHOULD_NOT_LEAK",
                 "skills": [
@@ -107,7 +107,7 @@ def test_agent_created_event_fires_with_safe_props(client: Client, auth_headers,
     assert len(matched) == 1
     props = matched[0]["properties"]
     assert props["runtime"] == "claude"
-    assert props["model"] == "claude-sonnet-4-6"
+    assert props["model"] == "anthropic/claude-sonnet-4-6"
     assert props["skill_count"] == 1
     assert props["system_length"] == len("SYSTEM_PROMPT_BODY_SHOULD_NOT_LEAK")
 
@@ -174,7 +174,7 @@ def test_session_created_event_excludes_prompt_and_repo_url(
         data=json.dumps(
             {
                 "name": "a",
-                "model": "claude-sonnet-4-6",
+                "model": "anthropic/claude-sonnet-4-6",
                 "runtime": "claude",
                 "environment_id": env_id,
             }

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -9,7 +9,7 @@ from agent_on_demand.models import (
     AgentSession,
     APIKey,
     SessionResource,
-    UserRuntimeKey,
+    UserCredential,
     UserSpritesKey,
 )
 
@@ -44,10 +44,10 @@ def sprites_key(user):
 
 @pytest.fixture
 def runtime_key(user, sprites_key):
-    urk = UserRuntimeKey(user=user, runtime="claude")
-    urk.set_api_key("fake-anthropic-key")
-    urk.save()
-    return urk
+    cred = UserCredential(user=user, kind="provider:anthropic")
+    cred.set_value("fake-anthropic-key")
+    cred.save()
+    return cred
 
 
 @pytest.fixture
@@ -55,7 +55,7 @@ def agent(user):
     return Agent.objects.create(
         user=user,
         name="Test Agent",
-        model="claude-sonnet-4-6",
+        model="anthropic/claude-sonnet-4-6",
         runtime="claude",
         version=1,
     )

--- a/tests/test_runtimes.py
+++ b/tests/test_runtimes.py
@@ -1,6 +1,6 @@
 """Generic registry-level tests for the runtime package. Per-runtime
 build_command / write_config / skills behavior is exercised in
-`tests/runtimes/test_{claude,codex,gemini}.py`."""
+`tests/runtimes/test_{claude,codex,gemini,opencode}.py`."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from agent_on_demand.runtimes import RUNTIMES, Runtime
 
 
 def test_all_runtimes_defined():
-    assert set(RUNTIMES) == {"claude", "codex", "gemini"}
+    assert set(RUNTIMES) == {"claude", "codex", "gemini", "opencode"}
 
 
 def test_every_runtime_has_non_empty_providers():

--- a/tests/test_runtimes.py
+++ b/tests/test_runtimes.py
@@ -1,76 +1,39 @@
-from agent_on_demand.runtimes import RUNTIMES
-from agent_on_demand.session_service.tasks import build_turn_command as _build_turn_command
+"""Generic registry-level tests for the runtime package. Per-runtime
+build_command / write_config / skills behavior is exercised in
+`tests/runtimes/test_{claude,codex,gemini}.py`."""
+
+from __future__ import annotations
+
+from agent_on_demand.runtimes import RUNTIMES, Runtime
 
 
 def test_all_runtimes_defined():
-    assert set(RUNTIMES) == {"claude", "codex", "gemini", "claude-oauth"}
+    assert set(RUNTIMES) == {"claude", "codex", "gemini"}
 
 
-def test_turn_command_reads_prompt_from_stdin():
-    """PROMPT is per-turn state; the turn command slurps it from stdin so it
-    never touches the Sprite filesystem and never leaks into WS URL query
-    params (which is what argv / env= would do)."""
-    cmd = _build_turn_command(RUNTIMES["claude"], "run")
-    assert "PROMPT=$(cat)" in cmd
-    assert "/tmp/aod-prompt.txt" not in cmd
-    assert '"$PROMPT"' in cmd
+def test_every_runtime_has_non_empty_providers():
+    for name, runtime in RUNTIMES.items():
+        assert runtime.name == name
+        assert runtime.providers, f"{name} has empty providers"
 
 
-def test_turn_command_sources_env_file():
-    """The turn command sources /tmp/aod-env (with `set -a`) so the runtime
-    API key and AOD_SESSION_ID are exported at exec time without being
-    baked into argv (where they would land in WS URL query params)."""
-    claude = RUNTIMES["claude"]
-    cmd = _build_turn_command(claude, "run")
-    assert "source /tmp/aod-env" in cmd
-    assert "set -a" in cmd
-    # API key env-var name never appears in the command string — it only
-    # lives in the env file that bash sources at runtime.
-    assert claude.env_var not in cmd
+def test_every_runtime_implements_the_protocol():
+    """Runtime is a Protocol — instances don't inherit from it, but must
+    still expose `name`, `providers`, `skills_root`, `install`, `build_command`,
+    and `write_config`."""
+    required_attrs = ("name", "providers", "skills_root")
+    required_methods = ("install", "build_command", "write_config")
+    for runtime in RUNTIMES.values():
+        for attr in required_attrs:
+            assert hasattr(runtime, attr), f"{runtime.name} missing {attr}"
+        for method in required_methods:
+            assert callable(getattr(runtime, method, None)), (
+                f"{runtime.name}.{method} must be callable"
+            )
 
 
-def test_turn_command_selects_by_mode():
-    """`run` and `continue` render different runtime CLIs."""
-    claude = RUNTIMES["claude"]
-    run_cmd = _build_turn_command(claude, "run")
-    cont_cmd = _build_turn_command(claude, "continue")
-    assert claude.cmd in run_cmd
-    assert claude.continue_cmd in cont_cmd
-    assert claude.continue_cmd not in run_cmd
-    assert claude.cmd not in cont_cmd
+def test_runtime_module_exports():
+    from agent_on_demand import runtimes
 
-
-def test_turn_command_has_no_setup_sections():
-    """All provisioning (packages, clone, MCP, skills) ran in
-    `provision_session`. The per-turn command never re-does any of it."""
-    cmd = _build_turn_command(RUNTIMES["claude"], "run")
-    assert "apt-get" not in cmd
-    assert "pip install" not in cmd
-    assert "git clone" not in cmd
-    assert "mkdir -p /home/sprite/.claude/skills" not in cmd
-    assert "/tmp/aod-initialized" not in cmd
-
-
-def test_claude_runtime_uses_session_id_and_resume():
-    claude = RUNTIMES["claude"]
-    assert '--session-id "$AOD_SESSION_ID"' in claude.cmd
-    assert '--resume "$AOD_SESSION_ID"' in claude.continue_cmd
-    oauth = RUNTIMES["claude-oauth"]
-    assert '--session-id "$AOD_SESSION_ID"' in oauth.cmd
-    assert '--resume "$AOD_SESSION_ID"' in oauth.continue_cmd
-
-
-def test_each_runtime_has_unique_env_var():
-    env_vars = [r.env_var for r in RUNTIMES.values()]
-    assert len(env_vars) == len(set(env_vars))
-
-
-def test_turn_command_carries_no_mcp_flags():
-    """MCP config is auto-discovered from each runtime's default path
-    (Claude → ~/.claude.json, Codex → ~/.codex/config.toml, Gemini →
-    ~/.gemini/settings.json), so the command needs no --mcp-config flags."""
-    for config in RUNTIMES.values():
-        for mode in ("run", "continue"):
-            cmd = _build_turn_command(config, mode)
-            assert "--mcp-config" not in cmd
-            assert "--strict-mcp-config" not in cmd
+    assert runtimes.Runtime is Runtime
+    assert runtimes.RUNTIMES is RUNTIMES

--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -11,7 +11,13 @@ import pytest
 from django.contrib.auth.models import User
 from sprites import SpriteError
 
-from agent_on_demand.models import AgentSession, AgentSessionLog, Environment, UserSpritesKey
+from agent_on_demand.models import (
+    AgentSession,
+    AgentSessionLog,
+    Environment,
+    UserCredential,
+    UserSpritesKey,
+)
 from agent_on_demand.runtimes import RUNTIMES
 from agent_on_demand.session_service import (
     ProvisionError,
@@ -26,14 +32,18 @@ def user(db):
     usk = UserSpritesKey(user=u)
     usk.set_api_key("fake-sprites-token")
     usk.save()
+    cred = UserCredential(user=u, kind="provider:anthropic")
+    cred.set_value("sk-xxx")
+    cred.save()
     return u
 
 
-def _spec(**overrides) -> SessionSpec:
+def _spec(user, **overrides) -> SessionSpec:
     defaults = dict(
         name="sprite-x",
         runtime=RUNTIMES["claude"],
-        api_key="sk-xxx",
+        model="anthropic/claude-sonnet-4-6",
+        user=user,
         runtime_session_id="11111111-2222-3333-4444-555555555555",
         environment=None,
         repos=[],
@@ -46,31 +56,57 @@ def _spec(**overrides) -> SessionSpec:
 
 class TestProvisionSessionOrder:
     def test_env_file_chmod_is_in_provision_script(self, user, fake_sprites):
-        provision_session(user, _spec())
+        provision_session(user, _spec(user))
         sprite = fake_sprites.last_sprite()
-        # Provision script is the single bash invocation; chmod lives inside it.
         script = sprite.write_map()["/tmp/aod-provision.sh"]
         assert "chmod 600 /tmp/aod-env" in script
 
     def test_single_bash_command_invokes_provision_script(self, user, fake_sprites):
-        provision_session(user, _spec())
+        provision_session(user, _spec(user))
         sprite = fake_sprites.last_sprite()
         # The whole provisioning phase uses exactly one sprite.command —
         # invoking the provision script. No per-stage chmod / clone commands.
         assert sprite.command_strings() == ["bash -l /tmp/aod-provision.sh"]
 
-    def test_env_file_contains_api_key_and_session_id(self, user, fake_sprites):
-        provision_session(user, _spec())
+    def test_env_file_contains_credential_and_session_id(self, user, fake_sprites):
+        provision_session(user, _spec(user))
         env_file = fake_sprites.last_sprite().write_map()["/tmp/aod-env"]
-        # shlex.quote leaves simple tokens unquoted; values with special chars
-        # get wrapped in single quotes (see test_env_vars_sorted_and_quoted).
+        # Credentials come from UserCredential rows for this user.
         assert "ANTHROPIC_API_KEY=sk-xxx" in env_file
         assert "AOD_SESSION_ID=11111111-2222-3333-4444-555555555555" in env_file
+        # AOD_MODEL surfaces the canonical provider/model_id for meta-runtimes.
+        assert "AOD_MODEL=anthropic/claude-sonnet-4-6" in env_file
+
+    def test_env_file_includes_runtime_token_when_present(self, user, fake_sprites):
+        oauth = UserCredential(user=user, kind="runtime_token:claude-oauth")
+        oauth.set_value("oauth-token")
+        oauth.save()
+        provision_session(user, _spec(user))
+        env_file = fake_sprites.last_sprite().write_map()["/tmp/aod-env"]
+        assert "ANTHROPIC_API_KEY=sk-xxx" in env_file
+        assert "CLAUDE_CODE_OAUTH_TOKEN=oauth-token" in env_file
+
+    def test_env_vars_override_credentials(self, user, fake_sprites):
+        """Environment.env_vars land last in the file, so when the same KEY
+        appears in both a credential and an environment, the environment
+        wins on `source` because later assignments overwrite earlier ones."""
+        env = Environment.objects.create(
+            user=user,
+            name="override",
+            env_vars={"ANTHROPIC_API_KEY": "env-override"},
+            version=1,
+        )
+        provision_session(user, _spec(user, environment=env))
+        body = fake_sprites.last_sprite().write_map()["/tmp/aod-env"]
+        lines = body.strip().split("\n")
+        cred_idx = next(i for i, line in enumerate(lines) if line.startswith("ANTHROPIC_API_KEY=sk-xxx"))
+        override_idx = next(i for i, line in enumerate(lines) if line == "ANTHROPIC_API_KEY=env-override")
+        assert cred_idx < override_idx
 
     def test_no_run_agent_script_is_written(self, user, fake_sprites):
         """The per-turn runtime-CLI invocation is assembled inline in the
         worker task; nothing is written to /run-agent.sh."""
-        provision_session(user, _spec())
+        provision_session(user, _spec(user))
         writes = fake_sprites.last_sprite().writes
         assert all(w.path != "/run-agent.sh" for w in writes)
 
@@ -81,9 +117,8 @@ class TestProvisionSessionFailureHandling:
     ):
         fake_sprites.raise_on_create(SpriteError("boom"))
         with pytest.raises(ProvisionError) as ei:
-            provision_session(user, _spec())
+            provision_session(user, _spec(user))
         assert ei.value.stage == "create_sprite"
-        # Nothing was created, so nothing should be deleted.
         assert fake_sprites.deleted == []
 
     def test_provision_script_failure_tags_stage_and_triggers_cleanup(
@@ -95,7 +130,6 @@ class TestProvisionSessionFailureHandling:
             packages={"pip": ["pandas"]},
             version=1,
         )
-        # Fail the single bash invocation that runs the provision script.
         original_create = fake_sprites.create_sprite
 
         def wrapped(name):
@@ -106,7 +140,7 @@ class TestProvisionSessionFailureHandling:
         mocker.patch.object(fake_sprites, "create_sprite", side_effect=wrapped)
 
         with pytest.raises(ProvisionError) as ei:
-            provision_session(user, _spec(environment=env))
+            provision_session(user, _spec(user, environment=env))
         assert ei.value.stage == "provision_setup"
         assert fake_sprites.deleted == ["sprite-x"]
 
@@ -124,27 +158,31 @@ class TestProvisionStageEvents:
 
     def test_minimal_spec_emits_expected_stages(self, user, fake_sprites):
         session = self._make_session(user)
-        provision_session(user, _spec(), session_id=str(session.id))
+        provision_session(user, _spec(user), session_id=str(session.id))
         events = list(
             AgentSessionLog.objects.filter(session=session, kind="stage")
             .order_by("id")
             .values("stage", "state")
         )
-        # env_file always runs; provision_setup always runs (at minimum it
-        # chmods the env file). No tokens, packages, mcp, or skills in
-        # _spec(), so git_credentials / mcp_config / skills are skipped.
+        # install_runtime, env_file, provision_setup, and runtime_config all
+        # run unconditionally now. No tokens → git_credentials skipped. No
+        # skills → skills skipped. Environment is None → network_policy skipped.
         assert events == [
             {"stage": "create_sprite", "state": "started"},
             {"stage": "create_sprite", "state": "done"},
+            {"stage": "install_runtime", "state": "started"},
+            {"stage": "install_runtime", "state": "done"},
             {"stage": "env_file", "state": "started"},
             {"stage": "env_file", "state": "done"},
             {"stage": "provision_setup", "state": "started"},
             {"stage": "provision_setup", "state": "done"},
+            {"stage": "runtime_config", "state": "started"},
+            {"stage": "runtime_config", "state": "done"},
         ]
 
     def test_done_events_carry_duration_ms(self, user, fake_sprites):
         session = self._make_session(user)
-        provision_session(user, _spec(), session_id=str(session.id))
+        provision_session(user, _spec(user), session_id=str(session.id))
         done = AgentSessionLog.objects.filter(session=session, kind="stage", state="done").first()
         assert done.duration_ms is not None and done.duration_ms >= 0
 
@@ -152,7 +190,7 @@ class TestProvisionStageEvents:
         session = self._make_session(user)
         fake_sprites.raise_on_create(SpriteError("boom"))
         with pytest.raises(ProvisionError):
-            provision_session(user, _spec(), session_id=str(session.id))
+            provision_session(user, _spec(user), session_id=str(session.id))
         events = list(
             AgentSessionLog.objects.filter(session=session, kind="stage")
             .order_by("id")
@@ -165,9 +203,7 @@ class TestProvisionStageEvents:
 
     def test_no_session_id_emits_no_rows(self, user, fake_sprites):
         """Backwards-compat path: tests that don't pass session_id emit nothing."""
-        provision_session(user, _spec())
-        # Use the fake_sprites fixture's session handle to prove provisioning ran;
-        # the real assertion is that no logs were written anywhere.
+        provision_session(user, _spec(user))
         assert AgentSessionLog.objects.count() == 0
 
 
@@ -179,12 +215,14 @@ class TestProvisionSessionEnvFileShape:
             env_vars={"B_SECOND": "two", "A_FIRST": "one with space"},
             version=1,
         )
-        provision_session(user, _spec(environment=env))
+        provision_session(user, _spec(user, environment=env))
         body = fake_sprites.last_sprite().write_map()["/tmp/aod-env"]
         lines = body.strip().split("\n")
-        # API key and AOD_SESSION_ID come first, env vars follow in alpha order.
-        assert lines[0].startswith("ANTHROPIC_API_KEY=")
-        assert lines[1].startswith("AOD_SESSION_ID=")
-        assert lines[2].startswith("A_FIRST=")
-        assert lines[3].startswith("B_SECOND=")
-        assert "'one with space'" in lines[2]
+        # Credentials are dumped first (order depends on DB row id; one
+        # here), then AOD_SESSION_ID / AOD_MODEL, then env_vars alpha-sorted.
+        assert any(line.startswith("ANTHROPIC_API_KEY=") for line in lines)
+        assert any(line.startswith("AOD_SESSION_ID=") for line in lines)
+        a_idx = next(i for i, line in enumerate(lines) if line.startswith("A_FIRST="))
+        b_idx = next(i for i, line in enumerate(lines) if line.startswith("B_SECOND="))
+        assert a_idx < b_idx
+        assert "'one with space'" in lines[a_idx]

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,10 +1,16 @@
+"""HTTP-layer validation for the agent `skills` field.
+
+Per-runtime skills materialization onto the Sprite is exercised via the
+provision flow in `tests/test_session_service.py` and in per-runtime tests.
+"""
+
 import json
 
 import pytest
 from django.contrib.auth.models import User
 from django.test import Client
 
-from agent_on_demand.models import Agent, AgentVersion, APIKey, UserRuntimeKey, UserSpritesKey
+from agent_on_demand.models import Agent, AgentVersion, APIKey
 
 
 SAMPLE_CONTENT = (
@@ -24,9 +30,6 @@ def _skill(name: str = "web-search", content: str = SAMPLE_CONTENT) -> dict:
     }
 
 
-# --- Fixtures ---
-
-
 @pytest.fixture
 def user(db):
     return User.objects.create_user(username="testuser", password="testpass")
@@ -44,208 +47,6 @@ def auth_headers(api_key):
     return {"HTTP_AUTHORIZATION": f"Bearer {raw_key}"}
 
 
-@pytest.fixture
-def sprites_key(user):
-    usk = UserSpritesKey(user=user)
-    usk.set_api_key("fake-sprites-token")
-    usk.save()
-    return usk
-
-
-@pytest.fixture
-def runtime_key(user, sprites_key):
-    urk = UserRuntimeKey(user=user, runtime="claude")
-    urk.set_api_key("fake-anthropic-key")
-    urk.save()
-    return urk
-
-
-# --- Session + skills integration (via recording fake) ---
-
-
-def _last_sprite_writes(fake_sprites) -> dict[str, str]:
-    return fake_sprites.last_sprite().write_map()
-
-
-@pytest.mark.django_db
-class TestSessionSkillsIntegration:
-    def test_claude_skill_writes_skill_md_under_dot_claude(
-        self, client: Client, auth_headers, runtime_key, user, fake_sprites
-    ):
-        agent = Agent.objects.create(
-            user=user,
-            name="Skilled",
-            model="claude-sonnet-4-6",
-            runtime="claude",
-            version=1,
-            skills=[_skill()],
-        )
-        resp = client.post(
-            "/sessions",
-            data=json.dumps({"agent_id": str(agent.id), "prompt": "hello"}),
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert resp.status_code == 202
-        sprite = fake_sprites.last_sprite()
-        assert "/home/sprite/.claude/skills/web-search/SKILL.md" in sprite.write_map()
-        cmds = sprite.shell_strings()
-        assert "mkdir -p /home/sprite/.claude/skills/web-search" in cmds
-
-    def test_codex_skill_writes_under_dot_codex(
-        self, client: Client, auth_headers, user, sprites_key, fake_sprites
-    ):
-        urk = UserRuntimeKey(user=user, runtime="codex")
-        urk.set_api_key("k")
-        urk.save()
-        agent = Agent.objects.create(
-            user=user,
-            name="Codex Skilled",
-            model="gpt-4.1",
-            runtime="codex",
-            version=1,
-            skills=[_skill()],
-        )
-        resp = client.post(
-            "/sessions",
-            data=json.dumps({"agent_id": str(agent.id), "prompt": "hello"}),
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert resp.status_code == 202
-        writes = _last_sprite_writes(fake_sprites)
-        assert "/home/sprite/.codex/skills/web-search/SKILL.md" in writes
-        assert "/home/sprite/.claude/skills/web-search/SKILL.md" not in writes
-
-    def test_gemini_skill_writes_under_dot_gemini(
-        self, client: Client, auth_headers, user, sprites_key, fake_sprites
-    ):
-        urk = UserRuntimeKey(user=user, runtime="gemini")
-        urk.set_api_key("k")
-        urk.save()
-        agent = Agent.objects.create(
-            user=user,
-            name="Gemini Skilled",
-            model="gemini-2.5-pro",
-            runtime="gemini",
-            version=1,
-            skills=[_skill()],
-        )
-        resp = client.post(
-            "/sessions",
-            data=json.dumps({"agent_id": str(agent.id), "prompt": "hello"}),
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert resp.status_code == 202
-        writes = _last_sprite_writes(fake_sprites)
-        assert "/home/sprite/.gemini/skills/web-search/SKILL.md" in writes
-
-    def test_agent_without_skills_writes_none(
-        self, client: Client, auth_headers, runtime_key, user, fake_sprites
-    ):
-        agent = Agent.objects.create(
-            user=user,
-            name="Plain",
-            model="claude-sonnet-4-6",
-            runtime="claude",
-            version=1,
-        )
-        resp = client.post(
-            "/sessions",
-            data=json.dumps({"agent_id": str(agent.id), "prompt": "hello"}),
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert resp.status_code == 202
-        writes = _last_sprite_writes(fake_sprites)
-        assert not any("SKILL.md" in path for path in writes)
-
-    def test_multiple_skills_each_get_their_own_dir(
-        self, client: Client, auth_headers, runtime_key, user, fake_sprites
-    ):
-        agent = Agent.objects.create(
-            user=user,
-            name="Multi",
-            model="claude-sonnet-4-6",
-            runtime="claude",
-            version=1,
-            skills=[
-                _skill(name="one", content="---\nname: one\ndescription: d\n---\nbody\n"),
-                _skill(name="two", content="---\nname: two\ndescription: d\n---\nbody\n"),
-            ],
-        )
-        resp = client.post(
-            "/sessions",
-            data=json.dumps({"agent_id": str(agent.id), "prompt": "hello"}),
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert resp.status_code == 202
-        writes = _last_sprite_writes(fake_sprites)
-        assert "/home/sprite/.claude/skills/one/SKILL.md" in writes
-        assert "/home/sprite/.claude/skills/two/SKILL.md" in writes
-
-    def test_skill_content_written_verbatim(
-        self, client: Client, auth_headers, runtime_key, user, fake_sprites
-    ):
-        """Skills are written via the filesystem API now, so any shell-metachar
-        concerns from the old heredoc approach no longer apply — the content is
-        raw bytes from the Python side to the Sprite filesystem."""
-        content = "---\nname: sh\ndescription: d\n---\n$VAR `whoami` $(date)\n"
-        agent = Agent.objects.create(
-            user=user,
-            name="Raw",
-            model="claude-sonnet-4-6",
-            runtime="claude",
-            version=1,
-            skills=[_skill(name="sh", content=content)],
-        )
-        resp = client.post(
-            "/sessions",
-            data=json.dumps({"agent_id": str(agent.id), "prompt": "hello"}),
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert resp.status_code == 202
-        writes = _last_sprite_writes(fake_sprites)
-        assert writes["/home/sprite/.claude/skills/sh/SKILL.md"] == content
-
-    def test_continue_session_touches_no_filesystem(
-        self, client: Client, auth_headers, runtime_key, user, fake_sprites
-    ):
-        from agent_on_demand.models import AgentSession
-
-        agent = Agent.objects.create(
-            user=user,
-            name="Skilled",
-            model="claude-sonnet-4-6",
-            runtime="claude",
-            version=1,
-            skills=[_skill()],
-        )
-        session = AgentSession.objects.create(
-            user=user,
-            agent=agent,
-            runtime="claude",
-            prompt="first",
-            sprite_name="sprite-xyz",
-            status="completed",
-        )
-        resp = client.post(
-            f"/sessions/{session.id}/prompt",
-            data=json.dumps({"prompt": "follow-up"}),
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert resp.status_code == 202
-        sprite = fake_sprites.sprites["sprite-xyz"]
-        assert sprite.writes == []
-
-
-# --- Validator edges (HTTP layer, unchanged) ---
-
-
 @pytest.mark.django_db
 class TestCreateAgentWithSkills:
     def test_create_with_skill(self, client: Client, auth_headers):
@@ -254,7 +55,7 @@ class TestCreateAgentWithSkills:
             data=json.dumps(
                 {
                     "name": "Skill Agent",
-                    "model": "claude-sonnet-4-6",
+                    "model": "anthropic/claude-sonnet-4-6",
                     "runtime": "claude",
                     "skills": [_skill()],
                 }
@@ -273,7 +74,7 @@ class TestCreateAgentWithSkills:
             data=json.dumps(
                 {
                     "name": "Plain",
-                    "model": "claude-sonnet-4-6",
+                    "model": "anthropic/claude-sonnet-4-6",
                     "runtime": "claude",
                 }
             ),
@@ -292,7 +93,7 @@ class TestSkillsValidation:
             data=json.dumps(
                 {
                     "name": "Bad",
-                    "model": "claude-sonnet-4-6",
+                    "model": "anthropic/claude-sonnet-4-6",
                     "runtime": "claude",
                     "skills": skills,
                 }
@@ -375,7 +176,7 @@ class TestUpdateAgentSkills:
         agent = Agent.objects.create(
             user=user,
             name="Agent",
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
             version=1,
         )
@@ -403,7 +204,7 @@ class TestUpdateAgentSkills:
         agent = Agent.objects.create(
             user=user,
             name="Agent",
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
             version=1,
         )

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -21,7 +21,7 @@ from agent_on_demand.models import (
     AgentSessionLog,
     APIKey,
     SessionTurn,
-    UserRuntimeKey,
+    UserCredential,
     UserSpritesKey,
 )
 from agent_on_demand.session_service.tasks import (
@@ -140,7 +140,7 @@ def test_execute_turn_marks_failed_on_exec_error(user, mocker):
 
 
 @pytest.mark.django_db
-def test_execute_turn_builds_expected_bash_command(user, mocker):
+def test_execute_turn_builds_expected_argv(user, mocker):
     session, turn = _make_session_and_turn(user)
     mock_sprite, _ = _patch_sprite(mocker, "success")
 
@@ -153,11 +153,17 @@ def test_execute_turn_builds_expected_bash_command(user, mocker):
     )
 
     argv = mock_sprite.command.call_args.args
+    # Thin shim: bash -lc sourcing /tmp/aod-env, then exec "$@" ... argv.
     assert argv[0] == "bash"
-    assert argv[1] == "-c"
-    assert "/run-agent.sh" not in argv[2]
+    assert argv[1] == "-lc"
     assert "source /tmp/aod-env" in argv[2]
-    assert "PROMPT=$(cat)" in argv[2]
+    assert 'exec "$@"' in argv[2]
+    assert argv[3] == "--"
+    # First runtime-CLI token must be the claude binary for this session.
+    assert argv[4] == "claude"
+    # No shell template substitutions made it into argv.
+    assert "/run-agent.sh" not in " ".join(argv)
+    assert "PROMPT=$(cat)" not in " ".join(argv)
 
 
 @pytest.mark.django_db
@@ -267,15 +273,15 @@ def provision_user(db):
     usk = UserSpritesKey(user=u)
     usk.set_api_key("fake-sprites-token")
     usk.save()
-    urk = UserRuntimeKey(user=u, runtime="claude")
-    urk.set_api_key("fake-anthropic-key")
-    urk.save()
+    cred = UserCredential(user=u, kind="provider:anthropic")
+    cred.set_value("fake-anthropic-key")
+    cred.save()
     return u
 
 
 def _make_pending_session(user):
     agent = Agent.objects.create(
-        user=user, name="a", model="claude-sonnet-4-6", runtime="claude", version=1
+        user=user, name="a", model="anthropic/claude-sonnet-4-6", runtime="claude", version=1
     )
     session = AgentSession.objects.create(
         user=user,
@@ -366,11 +372,13 @@ def test_provision_task_skips_if_session_terminated(provision_user, fake_sprites
 
 
 @pytest.mark.django_db
-def test_provision_task_marks_failed_when_runtime_key_missing(provision_user, fake_sprites, mocker):
-    """If the user's runtime key was deleted between create and provision,
-    the task surfaces that as a failed session rather than raising."""
+def test_provision_task_runs_with_no_runtime_credential(provision_user, fake_sprites, mocker):
+    """Credentials are now dumped wholesale into /tmp/aod-env; provisioning
+    no longer short-circuits on missing creds (the session-create HTTP gate
+    is what prevents this from reaching the worker). This just confirms the
+    worker path succeeds with zero credentials."""
     session, turn = _make_pending_session(provision_user)
-    UserRuntimeKey.objects.filter(user=provision_user, runtime="claude").delete()
+    UserCredential.objects.filter(user=provision_user).delete()
     defer_spy = mocker.patch("agent_on_demand.session_service.tasks.execute_turn.defer")
 
     provision_session_task(
@@ -381,10 +389,8 @@ def test_provision_task_marks_failed_when_runtime_key_missing(provision_user, fa
         timeout=10.0,
     )
 
-    session.refresh_from_db()
-    assert session.status == "failed"
-    assert fake_sprites.created == []
-    assert defer_spy.call_count == 0
+    # Provisioning proceeded; turn execution is the worker's next step.
+    assert defer_spy.call_count == 1
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_tools_mcp.py
+++ b/tests/test_tools_mcp.py
@@ -1,10 +1,16 @@
+"""HTTP-layer validation for the agent `mcp_servers` field.
+
+Per-runtime MCP config rendering (the actual file contents on the Sprite) is
+covered in `tests/runtimes/test_{claude,codex,gemini}.py`.
+"""
+
 import json
 
 import pytest
 from django.contrib.auth.models import User
 from django.test import Client
 
-from agent_on_demand.models import Agent, AgentVersion, APIKey, UserRuntimeKey, UserSpritesKey
+from agent_on_demand.models import Agent, AgentVersion, APIKey
 
 
 # --- Fixtures ---
@@ -27,284 +33,7 @@ def auth_headers(api_key):
     return {"HTTP_AUTHORIZATION": f"Bearer {raw_key}"}
 
 
-@pytest.fixture
-def sprites_key(user):
-    usk = UserSpritesKey(user=user)
-    usk.set_api_key("fake-sprites-token")
-    usk.save()
-    return usk
-
-
-@pytest.fixture
-def runtime_key(user, sprites_key):
-    urk = UserRuntimeKey(user=user, runtime="claude")
-    urk.set_api_key("fake-anthropic-key")
-    urk.save()
-    return urk
-
-
-# --- Session + MCP integration (via recording fake) ---
-
-
-def _mcp_json(sprite) -> dict:
-    return json.loads(sprite.write_map()["/home/sprite/.claude.json"])
-
-
-@pytest.mark.django_db
-class TestSessionMcpIntegration:
-    def test_claude_mcp_url_server_writes_json(
-        self, client: Client, auth_headers, runtime_key, user, fake_sprites
-    ):
-        agent = Agent.objects.create(
-            user=user,
-            name="MCP Agent",
-            model="claude-sonnet-4-6",
-            runtime="claude",
-            version=1,
-            mcp_servers=[
-                {"type": "url", "name": "github", "url": "https://mcp.github.com/mcp"},
-            ],
-        )
-        resp = client.post(
-            "/sessions",
-            data=json.dumps({"agent_id": str(agent.id), "prompt": "hello"}),
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert resp.status_code == 202
-        sprite = fake_sprites.last_sprite()
-        cfg = _mcp_json(sprite)
-        assert cfg == {
-            "mcpServers": {"github": {"type": "http", "url": "https://mcp.github.com/mcp"}}
-        }
-
-    def test_claude_mcp_with_headers(
-        self, client: Client, auth_headers, runtime_key, user, fake_sprites
-    ):
-        agent = Agent.objects.create(
-            user=user,
-            name="Auth Agent",
-            model="claude-sonnet-4-6",
-            runtime="claude",
-            version=1,
-            mcp_servers=[
-                {
-                    "type": "url",
-                    "name": "private",
-                    "url": "https://mcp.example.com/mcp",
-                    "headers": {"Authorization": "Bearer ${SECRET}"},
-                },
-            ],
-        )
-        resp = client.post(
-            "/sessions",
-            data=json.dumps({"agent_id": str(agent.id), "prompt": "hello"}),
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert resp.status_code == 202
-        cfg = _mcp_json(fake_sprites.last_sprite())
-        assert cfg["mcpServers"]["private"]["headers"] == {"Authorization": "Bearer ${SECRET}"}
-
-    def test_claude_stdio_mcp(self, client: Client, auth_headers, runtime_key, user, fake_sprites):
-        agent = Agent.objects.create(
-            user=user,
-            name="Local MCP",
-            model="claude-sonnet-4-6",
-            runtime="claude",
-            version=1,
-            mcp_servers=[
-                {
-                    "type": "stdio",
-                    "name": "local",
-                    "command": "npx",
-                    "args": ["-y", "@some/mcp-server"],
-                    "env": {"API_KEY": "val"},
-                },
-            ],
-        )
-        resp = client.post(
-            "/sessions",
-            data=json.dumps({"agent_id": str(agent.id), "prompt": "hello"}),
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert resp.status_code == 202
-        cfg = _mcp_json(fake_sprites.last_sprite())
-        assert cfg["mcpServers"]["local"]["type"] == "stdio"
-        assert cfg["mcpServers"]["local"]["command"] == "npx"
-        assert cfg["mcpServers"]["local"]["args"] == ["-y", "@some/mcp-server"]
-
-    def test_codex_mcp_writes_toml(
-        self, client: Client, auth_headers, user, sprites_key, fake_sprites
-    ):
-        urk = UserRuntimeKey(user=user, runtime="codex")
-        urk.set_api_key("k")
-        urk.save()
-        agent = Agent.objects.create(
-            user=user,
-            name="Codex Agent",
-            model="gpt-4.1",
-            runtime="codex",
-            version=1,
-            mcp_servers=[
-                {"type": "url", "name": "github", "url": "https://mcp.github.com/mcp"},
-            ],
-        )
-        resp = client.post(
-            "/sessions",
-            data=json.dumps({"agent_id": str(agent.id), "prompt": "hello"}),
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert resp.status_code == 202
-        sprite = fake_sprites.last_sprite()
-        toml = sprite.write_map()["/home/sprite/.codex/config.toml"]
-        assert "[mcp_servers.github]" in toml
-        assert 'url = "https://mcp.github.com/mcp"' in toml
-
-    def test_codex_mcp_bearer_token_env_var(
-        self, client: Client, auth_headers, user, sprites_key, fake_sprites
-    ):
-        urk = UserRuntimeKey(user=user, runtime="codex")
-        urk.set_api_key("k")
-        urk.save()
-        agent = Agent.objects.create(
-            user=user,
-            name="Codex Auth",
-            model="gpt-4.1",
-            runtime="codex",
-            version=1,
-            mcp_servers=[
-                {
-                    "type": "url",
-                    "name": "api",
-                    "url": "https://mcp.example.com/mcp",
-                    "headers": {"Authorization": "Bearer ${MY_TOKEN}"},
-                },
-            ],
-        )
-        resp = client.post(
-            "/sessions",
-            data=json.dumps({"agent_id": str(agent.id), "prompt": "hello"}),
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert resp.status_code == 202
-        toml = fake_sprites.last_sprite().write_map()["/home/sprite/.codex/config.toml"]
-        assert 'bearer_token_env_var = "MY_TOKEN"' in toml
-
-    def test_gemini_mcp_writes_settings_json(
-        self, client: Client, auth_headers, user, sprites_key, fake_sprites
-    ):
-        urk = UserRuntimeKey(user=user, runtime="gemini")
-        urk.set_api_key("k")
-        urk.save()
-        agent = Agent.objects.create(
-            user=user,
-            name="Gemini Agent",
-            model="gemini-2.5-pro",
-            runtime="gemini",
-            version=1,
-            mcp_servers=[
-                {"type": "url", "name": "github", "url": "https://mcp.github.com/mcp"},
-            ],
-        )
-        resp = client.post(
-            "/sessions",
-            data=json.dumps({"agent_id": str(agent.id), "prompt": "hello"}),
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert resp.status_code == 202
-        settings = json.loads(
-            fake_sprites.last_sprite().write_map()["/home/sprite/.gemini/settings.json"]
-        )
-        assert settings["mcpServers"]["github"]["httpUrl"] == "https://mcp.github.com/mcp"
-        assert settings["mcpServers"]["github"]["trust"] is True
-
-    def test_agent_without_mcp_writes_no_config(
-        self, client: Client, auth_headers, runtime_key, user, fake_sprites
-    ):
-        agent = Agent.objects.create(
-            user=user,
-            name="Plain Agent",
-            model="claude-sonnet-4-6",
-            runtime="claude",
-            version=1,
-        )
-        resp = client.post(
-            "/sessions",
-            data=json.dumps({"agent_id": str(agent.id), "prompt": "hello"}),
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert resp.status_code == 202
-        writes = fake_sprites.last_sprite().write_map()
-        assert "/home/sprite/.claude.json" not in writes
-
-    def test_multiple_mcp_servers(
-        self, client: Client, auth_headers, runtime_key, user, fake_sprites
-    ):
-        agent = Agent.objects.create(
-            user=user,
-            name="Multi MCP",
-            model="claude-sonnet-4-6",
-            runtime="claude",
-            version=1,
-            mcp_servers=[
-                {"type": "url", "name": "github", "url": "https://mcp.github.com/mcp"},
-                {"type": "url", "name": "slack", "url": "https://mcp.slack.com/mcp"},
-            ],
-        )
-        resp = client.post(
-            "/sessions",
-            data=json.dumps({"agent_id": str(agent.id), "prompt": "hello"}),
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert resp.status_code == 202
-        cfg = _mcp_json(fake_sprites.last_sprite())
-        assert set(cfg["mcpServers"].keys()) == {"github", "slack"}
-
-    def test_continue_session_touches_no_filesystem(
-        self, client: Client, auth_headers, runtime_key, user, fake_sprites
-    ):
-        """Follow-up /prompt is fire-and-forget: no filesystem writes on the
-        Sprite. The prompt streams over stdin when the background thread runs
-        the dispatcher in `continue` mode."""
-        from agent_on_demand.models import AgentSession
-
-        agent = Agent.objects.create(
-            user=user,
-            name="MCP Agent",
-            model="claude-sonnet-4-6",
-            runtime="claude",
-            version=1,
-            mcp_servers=[
-                {"type": "url", "name": "github", "url": "https://mcp.github.com/mcp"},
-            ],
-        )
-        session = AgentSession.objects.create(
-            user=user,
-            agent=agent,
-            runtime="claude",
-            prompt="first",
-            sprite_name="sprite-xyz",
-            status="completed",
-        )
-        resp = client.post(
-            f"/sessions/{session.id}/prompt",
-            data=json.dumps({"prompt": "follow-up"}),
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert resp.status_code == 202
-        sprite = fake_sprites.sprites["sprite-xyz"]
-        assert sprite.writes == []
-
-
-# --- Agent CRUD with mcp_servers (HTTP layer only, unchanged) ---
+# --- Agent CRUD with mcp_servers (HTTP layer) ---
 
 
 @pytest.mark.django_db
@@ -315,7 +44,7 @@ class TestCreateAgentWithMcp:
             data=json.dumps(
                 {
                     "name": "MCP Agent",
-                    "model": "claude-sonnet-4-6",
+                    "model": "anthropic/claude-sonnet-4-6",
                     "runtime": "claude",
                     "mcp_servers": [
                         {
@@ -341,7 +70,7 @@ class TestCreateAgentWithMcp:
             data=json.dumps(
                 {
                     "name": "No MCP",
-                    "model": "claude-sonnet-4-6",
+                    "model": "anthropic/claude-sonnet-4-6",
                     "runtime": "claude",
                 }
             ),
@@ -359,7 +88,7 @@ class TestCreateAgentWithMcp:
             data=json.dumps(
                 {
                     "name": "Ignored Tools",
-                    "model": "claude-sonnet-4-6",
+                    "model": "anthropic/claude-sonnet-4-6",
                     "runtime": "claude",
                     "tools": [{"type": "agent_toolset_20260401"}],
                 }
@@ -379,7 +108,7 @@ class TestAgentMcpValidation:
             data=json.dumps(
                 {
                     "name": "Bad",
-                    "model": "claude-sonnet-4-6",
+                    "model": "anthropic/claude-sonnet-4-6",
                     "runtime": "claude",
                     "mcp_servers": [{"type": "url", "url": "https://example.com/mcp"}],
                 }
@@ -396,7 +125,7 @@ class TestAgentMcpValidation:
             data=json.dumps(
                 {
                     "name": "Bad",
-                    "model": "claude-sonnet-4-6",
+                    "model": "anthropic/claude-sonnet-4-6",
                     "runtime": "claude",
                     "mcp_servers": [{"type": "url", "name": "test"}],
                 }
@@ -413,7 +142,7 @@ class TestAgentMcpValidation:
             data=json.dumps(
                 {
                     "name": "Bad",
-                    "model": "claude-sonnet-4-6",
+                    "model": "anthropic/claude-sonnet-4-6",
                     "runtime": "claude",
                     "mcp_servers": [{"type": "stdio", "name": "test"}],
                 }
@@ -430,7 +159,7 @@ class TestAgentMcpValidation:
             data=json.dumps(
                 {
                     "name": "Bad",
-                    "model": "claude-sonnet-4-6",
+                    "model": "anthropic/claude-sonnet-4-6",
                     "runtime": "claude",
                     "mcp_servers": [
                         {"name": "github", "url": "https://a.com/mcp"},
@@ -450,7 +179,7 @@ class TestAgentMcpValidation:
             data=json.dumps(
                 {
                     "name": "Bad",
-                    "model": "claude-sonnet-4-6",
+                    "model": "anthropic/claude-sonnet-4-6",
                     "runtime": "claude",
                     "mcp_servers": [{"type": "grpc", "name": "test", "url": "https://a.com"}],
                 }
@@ -468,7 +197,7 @@ class TestAgentMcpValidation:
             data=json.dumps(
                 {
                     "name": "Bad",
-                    "model": "claude-sonnet-4-6",
+                    "model": "anthropic/claude-sonnet-4-6",
                     "runtime": "claude",
                     "mcp_servers": servers,
                 }
@@ -486,7 +215,7 @@ class TestUpdateAgentMcp:
         agent = Agent.objects.create(
             user=user,
             name="Agent",
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
             version=1,
         )
@@ -520,7 +249,7 @@ class TestUpdateAgentMcp:
         agent = Agent.objects.create(
             user=user,
             name="Agent",
-            model="claude-sonnet-4-6",
+            model="anthropic/claude-sonnet-4-6",
             runtime="claude",
             version=1,
         )

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -217,10 +217,10 @@ def test_api_key_revoke_scoped_to_owner(logged_in_client, other_user):
 @pytest.mark.django_db
 def test_agents_list_only_shows_owned(logged_in_client, user, other_user):
     mine = Agent.objects.create(
-        user=user, name="mine", model="claude-sonnet-4-6", runtime="claude", version=1
+        user=user, name="mine", model="anthropic/claude-sonnet-4-6", runtime="claude", version=1
     )
     theirs = Agent.objects.create(
-        user=other_user, name="theirs", model="claude-sonnet-4-6", runtime="claude", version=1
+        user=other_user, name="theirs", model="anthropic/claude-sonnet-4-6", runtime="claude", version=1
     )
     resp = logged_in_client.get("/ui/agents")
     assert resp.status_code == 200
@@ -231,7 +231,7 @@ def test_agents_list_only_shows_owned(logged_in_client, user, other_user):
 @pytest.mark.django_db
 def test_agent_detail_404_for_other_user(logged_in_client, other_user):
     theirs = Agent.objects.create(
-        user=other_user, name="theirs", model="claude-sonnet-4-6", runtime="claude", version=1
+        user=other_user, name="theirs", model="anthropic/claude-sonnet-4-6", runtime="claude", version=1
     )
     resp = logged_in_client.get(f"/ui/agents/{theirs.id}")
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Rewrite step of the runtime redesign (closes #85). Behavior-equivalent for the existing claude/codex/gemini runtimes.

- Port claude / codex / gemini to `Runtime` classes under `src/agent_on_demand/runtimes/{claude,codex,gemini}.py`. Fold the old `claude-oauth` runtime into `ClaudeRuntime` — `build_command` picks the OAuth command shape when the user has a `runtime_token:claude-oauth` `UserCredential` registered.
- Drop `AgentModel`, `RuntimeConfig`, and `MODEL_RUNTIME_MAP`. Validation keys off `models_catalog.MODELS` + `runtime.providers`.
- `SessionSpec` carries `model` (canonical `provider/model_id`) and `user` (Django User, for credential lookups). The per-turn command is argv now, not a shell template: a thin `bash -lc` shim sources `/tmp/aod-env` and execs `runtime.build_command(spec, mode)` verbatim; session id is baked in from the spec.
- `_write_env_file` dumps every `UserCredential` via `CREDENTIAL_ENV_VAR`, plus `AOD_SESSION_ID` / `AOD_MODEL`; `Environment.env_vars` land last so per-env overrides keep winning.
- New `_install_runtime` provisioning stage (no-op for the three pre-baked runtimes; meaningful for the meta-runtimes in step 3+). `_write_runtime_config` replaces the per-runtime `_write_mcp_*` helpers and always runs.
- Drop `UserRuntimeKey`; admin now manages `UserCredential` directly.
- Migration 0016 rewrites `Agent.model` / `AgentVersion.model` strings to `provider/model_id`, maps `claude-oauth` runtime → `claude`, copies `UserRuntimeKey` rows into `UserCredential`, and drops the legacy table.

Tests reorganize per-runtime cases into `tests/runtimes/test_{claude,codex,gemini}.py`. `test_tools_mcp.py` and `test_skills.py` are trimmed to HTTP-layer validation; the rest of the suite is adapted to the new `SessionSpec` / stage list / argv shape.

## Deploy notes

- This rewrite changes `SessionSpec`. The `web` and `worker` services must be deployed together (`render.yaml` already does this); if rolling, restart workers first then web.
- In-flight sessions during the cutover may fail with `DoesNotExist` / decode errors. Drain queues or accept failed in-flight sessions during the migration window.

## Test plan

- [ ] `make test` — full unit + integration suite (265 passing locally)
- [ ] `make lint` — ruff check clean
- [ ] Run `make test-e2e-fast` against a deployment with the new migration applied (fast path exercises claude/codex/gemini agent CRUD, session create, skills, MCP)
- [ ] Spot-check admin UI: create + edit a `UserCredential` row for each of `provider:anthropic`, `provider:openai`, `provider:google`, `runtime_token:claude-oauth`
- [ ] After migration, spot-check a pre-existing `Agent` row: `model` should read e.g. `anthropic/claude-sonnet-4-6`; any `claude-oauth` runtime rows now read `claude`

🤖 Generated with [Claude Code](https://claude.com/claude-code)