### PR TITLE
CI: add format-check, typecheck, and security gates + dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,33 @@ jobs:
           enable-cache: true
       - run: uv sync --all-extras
       - run: make lint
+      - run: make fmt-check
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      - run: uv sync --all-extras
+      - run: make typecheck
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      - run: uv sync --all-extras
+      - run: make security
 
   test:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,16 @@ test-all:
 lint:
 	uv run ruff check src/ tests/
 
+fmt-check:
+	uv run ruff format --check src/ tests/
+
+typecheck:
+	uv run mypy
+
+security:
+	uv run pip-audit
+	uv run bandit -r src/ -ll
+
 fmt:
 	uv run ruff format && ruff check --fix
 

--- a/src/agent_on_demand/admin.py
+++ b/src/agent_on_demand/admin.py
@@ -234,7 +234,7 @@ class AgentSessionAdmin(admin.ModelAdmin):
     def terminate_sessions(self, request, queryset):
         from django.conf import settings
 
-        clients: dict[int, SpritesClient] = {}
+        clients: dict[int, SpritesClient | None] = {}
 
         def client_for(user) -> SpritesClient | None:
             if user.pk in clients:

--- a/src/agent_on_demand/migrations/0013_userquota.py
+++ b/src/agent_on_demand/migrations/0013_userquota.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("fairy", "0012_add_runtime_session_id"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),

--- a/src/agent_on_demand/migrations/0015_usercredential.py
+++ b/src/agent_on_demand/migrations/0015_usercredential.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("fairy", "0014_agentsessionlog_stage_fields"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),

--- a/src/agent_on_demand/migrations/0016_runtime_redesign.py
+++ b/src/agent_on_demand/migrations/0016_runtime_redesign.py
@@ -91,7 +91,6 @@ def unmigrate_data(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("fairy", "0015_usercredential"),
     ]

--- a/src/agent_on_demand/models/auth.py
+++ b/src/agent_on_demand/models/auth.py
@@ -58,7 +58,9 @@ class UserCredential(models.Model):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="credentials"
     )
-    kind = models.CharField(max_length=64)  # e.g. "provider:anthropic", "runtime_token:claude-oauth"
+    kind = models.CharField(
+        max_length=64
+    )  # e.g. "provider:anthropic", "runtime_token:claude-oauth"
     value_encrypted = models.BinaryField()
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/src/agent_on_demand/models/quota.py
+++ b/src/agent_on_demand/models/quota.py
@@ -37,6 +37,4 @@ class UserQuota(models.Model):
 
     @classmethod
     def active_session_count_for(cls, user) -> int:
-        return AgentSession.objects.filter(
-            user=user, status__in=ACTIVE_SESSION_STATUSES
-        ).count()
+        return AgentSession.objects.filter(user=user, status__in=ACTIVE_SESSION_STATUSES).count()

--- a/src/agent_on_demand/models_catalog.py
+++ b/src/agent_on_demand/models_catalog.py
@@ -5,20 +5,30 @@ from dataclasses import dataclass
 class ModelDef:
     id: str  # canonical "provider/model_id" string
     provider: str  # "anthropic", "openai", "google"
-    runtimes: frozenset[str] | None = None  # optional restriction; None = any runtime whose providers includes this provider
+    runtimes: frozenset[str] | None = (
+        None  # optional restriction; None = any runtime whose providers includes this provider
+    )
 
 
 MODELS: dict[str, ModelDef] = {
-    "anthropic/claude-opus-4-6":            ModelDef(id="anthropic/claude-opus-4-6",            provider="anthropic"),
-    "anthropic/claude-sonnet-4-6":          ModelDef(id="anthropic/claude-sonnet-4-6",          provider="anthropic"),
-    "anthropic/claude-haiku-4-5":           ModelDef(id="anthropic/claude-haiku-4-5",           provider="anthropic"),
-    "anthropic/claude-opus-4-0-20250514":   ModelDef(id="anthropic/claude-opus-4-0-20250514",   provider="anthropic"),
-    "anthropic/claude-sonnet-4-0-20250514": ModelDef(id="anthropic/claude-sonnet-4-0-20250514", provider="anthropic"),
-    "anthropic/claude-sonnet-4-5-20250514": ModelDef(id="anthropic/claude-sonnet-4-5-20250514", provider="anthropic"),
-    "anthropic/claude-3-5-haiku-20241022":  ModelDef(id="anthropic/claude-3-5-haiku-20241022",  provider="anthropic"),
-    "openai/gpt-4.1":                       ModelDef(id="openai/gpt-4.1",                       provider="openai"),
-    "openai/o3":                            ModelDef(id="openai/o3",                            provider="openai"),
-    "openai/o4-mini":                       ModelDef(id="openai/o4-mini",                       provider="openai"),
-    "google/gemini-2.5-pro":               ModelDef(id="google/gemini-2.5-pro",               provider="google"),
-    "google/gemini-2.5-flash":             ModelDef(id="google/gemini-2.5-flash",             provider="google"),
+    "anthropic/claude-opus-4-6": ModelDef(id="anthropic/claude-opus-4-6", provider="anthropic"),
+    "anthropic/claude-sonnet-4-6": ModelDef(id="anthropic/claude-sonnet-4-6", provider="anthropic"),
+    "anthropic/claude-haiku-4-5": ModelDef(id="anthropic/claude-haiku-4-5", provider="anthropic"),
+    "anthropic/claude-opus-4-0-20250514": ModelDef(
+        id="anthropic/claude-opus-4-0-20250514", provider="anthropic"
+    ),
+    "anthropic/claude-sonnet-4-0-20250514": ModelDef(
+        id="anthropic/claude-sonnet-4-0-20250514", provider="anthropic"
+    ),
+    "anthropic/claude-sonnet-4-5-20250514": ModelDef(
+        id="anthropic/claude-sonnet-4-5-20250514", provider="anthropic"
+    ),
+    "anthropic/claude-3-5-haiku-20241022": ModelDef(
+        id="anthropic/claude-3-5-haiku-20241022", provider="anthropic"
+    ),
+    "openai/gpt-4.1": ModelDef(id="openai/gpt-4.1", provider="openai"),
+    "openai/o3": ModelDef(id="openai/o3", provider="openai"),
+    "openai/o4-mini": ModelDef(id="openai/o4-mini", provider="openai"),
+    "google/gemini-2.5-pro": ModelDef(id="google/gemini-2.5-pro", provider="google"),
+    "google/gemini-2.5-flash": ModelDef(id="google/gemini-2.5-flash", provider="google"),
 }

--- a/src/agent_on_demand/runtimes/claude.py
+++ b/src/agent_on_demand/runtimes/claude.py
@@ -24,9 +24,7 @@ class ClaudeRuntime:
     def install(self, sprite: Sprite) -> None:
         return None
 
-    def build_command(
-        self, spec: "SessionSpec", mode: Literal["run", "continue"]
-    ) -> list[str]:
+    def build_command(self, spec: "SessionSpec", mode: Literal["run", "continue"]) -> list[str]:
         session_id = spec.runtime_session_id or ""
         return [
             "claude",
@@ -60,6 +58,4 @@ class ClaudeRuntime:
         if not config:
             return
         fs = sprite.filesystem()
-        (fs / "home/sprite/.claude.json").write_text(
-            json.dumps({"mcpServers": config}, indent=2)
-        )
+        (fs / "home/sprite/.claude.json").write_text(json.dumps({"mcpServers": config}, indent=2))

--- a/src/agent_on_demand/runtimes/codex.py
+++ b/src/agent_on_demand/runtimes/codex.py
@@ -18,9 +18,7 @@ class CodexRuntime:
     def install(self, sprite: Sprite) -> None:
         return None
 
-    def build_command(
-        self, spec: "SessionSpec", mode: Literal["run", "continue"]
-    ) -> list[str]:
+    def build_command(self, spec: "SessionSpec", mode: Literal["run", "continue"]) -> list[str]:
         if mode == "continue":
             return [
                 "codex",

--- a/src/agent_on_demand/runtimes/gemini.py
+++ b/src/agent_on_demand/runtimes/gemini.py
@@ -19,9 +19,7 @@ class GeminiRuntime:
     def install(self, sprite: Sprite) -> None:
         return None
 
-    def build_command(
-        self, spec: "SessionSpec", mode: Literal["run", "continue"]
-    ) -> list[str]:
+    def build_command(self, spec: "SessionSpec", mode: Literal["run", "continue"]) -> list[str]:
         if mode == "continue":
             return ["gemini", "--resume", "--output-format", "stream-json"]
         return ["gemini", "--output-format", "stream-json"]

--- a/src/agent_on_demand/runtimes/opencode.py
+++ b/src/agent_on_demand/runtimes/opencode.py
@@ -32,13 +32,9 @@ class OpencodeRuntime:
     skills_root: str | None = "/home/sprite/.config/opencode/skills"
 
     def install(self, sprite: Sprite) -> None:
-        sprite.command(
-            "bash", "-lc", f"npm install -g opencode-ai@{OPENCODE_VERSION}"
-        ).run()
+        sprite.command("bash", "-lc", f"npm install -g opencode-ai@{OPENCODE_VERSION}").run()
 
-    def build_command(
-        self, spec: "SessionSpec", mode: Literal["run", "continue"]
-    ) -> list[str]:
+    def build_command(self, spec: "SessionSpec", mode: Literal["run", "continue"]) -> list[str]:
         argv = ["opencode", "run", "--model", spec.model, "--format", "json"]
         if mode == "continue":
             argv.append("--continue")

--- a/src/agent_on_demand/session_service/provisioning.py
+++ b/src/agent_on_demand/session_service/provisioning.py
@@ -34,9 +34,10 @@ from .client import best_effort_delete, require_client
 from .errors import ProvisionError
 from .specs import RepoSpec, SessionSpec
 
-ENV_FILE_PATH = "/tmp/aod-env"
-GIT_CREDS_PATH = "/tmp/.git-credentials"
-PROVISION_SCRIPT_PATH = "/tmp/aod-provision.sh"
+# Paths inside the single-tenant Sprite VM, not the host — B108 doesn't apply.
+ENV_FILE_PATH = "/tmp/aod-env"  # nosec B108
+GIT_CREDS_PATH = "/tmp/.git-credentials"  # nosec B108
+PROVISION_SCRIPT_PATH = "/tmp/aod-provision.sh"  # nosec B108
 
 logger = logging.getLogger(__name__)
 

--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -31,6 +31,7 @@ import logging
 import queue
 import threading
 import time
+from typing import Literal, cast
 
 import posthog
 from django.contrib.auth import get_user_model
@@ -115,7 +116,7 @@ def build_turn_argv(runtime: Runtime, spec, mode: str) -> list[str]:
     Prompt delivery is out of band: callers attach `cmd.stdin` with the
     prompt bytes so it flows through the bash shim into the runtime CLI.
     """
-    argv = runtime.build_command(spec, mode)
+    argv = runtime.build_command(spec, cast(Literal["run", "continue"], mode))
     return ["bash", "-lc", _ENV_SOURCE_SHIM, "--", *argv]
 
 

--- a/tests/runtimes/test_claude.py
+++ b/tests/runtimes/test_claude.py
@@ -83,9 +83,7 @@ def test_write_config_url_server(user):
         [McpServerSpec(name="github", type="url", url="https://mcp.github.com/mcp")],
     )
     cfg = json.loads(sprite.write_map()["/home/sprite/.claude.json"])
-    assert cfg == {
-        "mcpServers": {"github": {"type": "http", "url": "https://mcp.github.com/mcp"}}
-    }
+    assert cfg == {"mcpServers": {"github": {"type": "http", "url": "https://mcp.github.com/mcp"}}}
 
 
 @pytest.mark.django_db

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -117,7 +117,9 @@ def test_create_agent(client: Client, auth_headers):
 def test_create_agent_minimal(client: Client, auth_headers):
     resp = client.post(
         "/agents",
-        data=json.dumps({"name": "Minimal", "model": "anthropic/claude-sonnet-4-6", "runtime": "claude"}),
+        data=json.dumps(
+            {"name": "Minimal", "model": "anthropic/claude-sonnet-4-6", "runtime": "claude"}
+        ),
         content_type="application/json",
         **auth_headers,
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -707,8 +707,7 @@ async def test_stream_emits_turn_start_boundaries(async_client: AsyncClient):
     turn_start_events = [
         json.loads(line[6:])
         for line in content.splitlines()
-        if line.startswith("data: ")
-        and json.loads(line[6:]).get("type") == "turn_start"
+        if line.startswith("data: ") and json.loads(line[6:]).get("type") == "turn_start"
     ]
     turns = [e["turn"] for e in turn_start_events]
     assert turns == [1, 2]

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -192,9 +192,7 @@ def test_session_created_event_excludes_prompt_and_repo_url(
             {
                 "agent_id": agent_id,
                 "prompt": SENSITIVE_PROMPT,
-                "resources": [
-                    {"type": "github_repository", "url": SENSITIVE_REPO_URL}
-                ],
+                "resources": [{"type": "github_repository", "url": SENSITIVE_REPO_URL}],
             }
         ),
         content_type="application/json",

--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -99,8 +99,12 @@ class TestProvisionSessionOrder:
         provision_session(user, _spec(user, environment=env))
         body = fake_sprites.last_sprite().write_map()["/tmp/aod-env"]
         lines = body.strip().split("\n")
-        cred_idx = next(i for i, line in enumerate(lines) if line.startswith("ANTHROPIC_API_KEY=sk-xxx"))
-        override_idx = next(i for i, line in enumerate(lines) if line == "ANTHROPIC_API_KEY=env-override")
+        cred_idx = next(
+            i for i, line in enumerate(lines) if line.startswith("ANTHROPIC_API_KEY=sk-xxx")
+        )
+        override_idx = next(
+            i for i, line in enumerate(lines) if line == "ANTHROPIC_API_KEY=env-override"
+        )
         assert cred_idx < override_idx
 
     def test_no_run_agent_script_is_written(self, user, fake_sprites):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -253,9 +253,7 @@ def test_execute_turn_writes_log_chunks_via_tagging_writer(user, mocker):
     )
 
     # Scope to output rows: stage rows (e.g. runtime_start) have turn_id=None by design.
-    logs = list(
-        AgentSessionLog.objects.filter(session=session, kind="output").order_by("id")
-    )
+    logs = list(AgentSessionLog.objects.filter(session=session, kind="output").order_by("id"))
     assert any("first chunk" in log.data for log in logs)
     assert any("second chunk" in log.data for log in logs)
     assert all(log.turn_id == turn.id for log in logs)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -220,7 +220,11 @@ def test_agents_list_only_shows_owned(logged_in_client, user, other_user):
         user=user, name="mine", model="anthropic/claude-sonnet-4-6", runtime="claude", version=1
     )
     theirs = Agent.objects.create(
-        user=other_user, name="theirs", model="anthropic/claude-sonnet-4-6", runtime="claude", version=1
+        user=other_user,
+        name="theirs",
+        model="anthropic/claude-sonnet-4-6",
+        runtime="claude",
+        version=1,
     )
     resp = logged_in_client.get("/ui/agents")
     assert resp.status_code == 200
@@ -231,7 +235,11 @@ def test_agents_list_only_shows_owned(logged_in_client, user, other_user):
 @pytest.mark.django_db
 def test_agent_detail_404_for_other_user(logged_in_client, other_user):
     theirs = Agent.objects.create(
-        user=other_user, name="theirs", model="anthropic/claude-sonnet-4-6", runtime="claude", version=1
+        user=other_user,
+        name="theirs",
+        model="anthropic/claude-sonnet-4-6",
+        runtime="claude",
+        version=1,
     )
     resp = logged_in_client.get(f"/ui/agents/{theirs.id}")
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- Wire up four quality gates already present in `[dev]` deps but never gated in CI: `ruff format --check`, `mypy`, `pip-audit`, and `bandit`. Each gets a `make` target and a CI job.
- Add `.github/dependabot.yml` for weekly pip + github-actions bumps (limits 5 / 3).

## Commits
1. **Format pass** — `ruff format src/ tests/` across 17 drifted files so the new `ruff format --check` gate starts green. Pure formatting, no semantic changes.
2. **Gates + dependabot + small fixes** to get the new gates passing:
   - `admin.py`: widen `clients: dict[int, SpritesClient]` → `SpritesClient | None`; the cache already stores the missing-key sentinel.
   - `tasks.py`: cast `mode` to `Literal["run", "continue"]` at the `runtime.build_command` call site. `mode` crosses the Procrastinate task boundary as a plain string so narrowing happens at the consumer.
   - `provisioning.py`: three `# nosec B108` annotations on `/tmp/*` constants. Those paths resolve **inside** the single-tenant Sprite VM, not on the host — the shared-tmp-dir threat model B108 is built for doesn't apply.

## What's not in scope
- Coverage gate (`--cov-fail-under=85`) — need to measure current coverage before picking a floor.
- `pylint --enable=duplicate-code` — the original config ran it with `--exit-zero` so it was informational only. Low value; skip.

## Test plan
- [x] `make lint` — passes (ruff check clean).
- [x] `make fmt-check` — passes (93 files formatted).
- [x] `make typecheck` — passes (44 files, 0 errors).
- [x] `make security` — `pip-audit` clean, `bandit -ll` 0 findings (3 `# nosec` annotated).
- [ ] CI run on PR reports all four jobs (`lint`, `typecheck`, `security`, `test`) green.
- [ ] Dependabot config picked up — first PRs should land within a week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)