### PR TITLE
CI: publish aod-sdk (TS) to npm via trusted publishing

### DIFF
--- a/.github/workflows/sdk-release-npm.yml
+++ b/.github/workflows/sdk-release-npm.yml
@@ -15,7 +15,7 @@ jobs:
       name: npm
       url: https://www.npmjs.com/package/@ravi-hq/aod-sdk
     permissions:
-      id-token: write   # npm provenance
+      id-token: write   # OIDC for npm Trusted Publishing (also enables provenance)
       contents: read
     defaults:
       run:
@@ -26,6 +26,9 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+
+      # Trusted Publishing requires npm CLI >= 11.5.1; Node 20 ships with 10.x.
+      - run: npm install -g npm@latest
 
       - name: Verify tag matches package.json version
         run: |
@@ -44,5 +47,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -138,19 +138,31 @@ npm run build
 
 ## Releases (maintainers)
 
-Published to npm via GitHub Actions using npm provenance + an npm automation
-token stored as the `NPM_TOKEN` repository secret. The workflow lives at
-`.github/workflows/sdk-release-npm.yml` and fires on a GitHub Release tagged
-`aod-sdk-ts-v<version>`.
+Published to npm via GitHub Actions using [Trusted
+Publishing](https://docs.npmjs.com/trusted-publishers) — no API tokens to
+manage. The workflow lives at `.github/workflows/sdk-release-npm.yml` and
+fires on a GitHub Release tagged `aod-sdk-ts-v<version>`. Provenance is
+enabled automatically.
 
 ### One-time setup
 
-1. Reserve `@ravi-hq/aod-sdk` on [npm](https://www.npmjs.com/) (the `ravi-hq`
-   org must exist and your account must be a member).
-2. Create an npm automation token with publish access and add it as
-   `NPM_TOKEN` in the repo's Actions secrets.
+1. **Reserve the name on npm**. The `ravi-hq` org must exist and your account
+   must be a member. The first publish has to happen outside OIDC (npm has no
+   "create package" UI), so publish once from a laptop with `npm publish
+   --access public`, or from CI with a temporary automation token.
+2. **Add the trusted publisher**. On
+   [npmjs.com](https://www.npmjs.com/package/@ravi-hq/aod-sdk/access) go to
+   the package's *Settings → Trusted Publisher* and add:
+
+   | Field | Value |
+   | ----- | ----- |
+   | Publisher | GitHub Actions |
+   | Organization / repo | `ravi-hq/agent-on-demand` |
+   | Workflow filename | `sdk-release-npm.yml` |
+   | Environment | `npm` |
+
 3. (Recommended) Create a protected GitHub environment `npm` with required
-   reviewers.
+   reviewers (must match the Environment field above).
 
 ### Cutting a release
 


### PR DESCRIPTION
## Summary
- Drop `NPM_TOKEN` from `sdk-release-npm.yml`; npm trusted publishing uses OIDC
- Upgrade npm on the runner to >=11.5.1 (Node 20 still ships npm 10.x, which predates trusted-publishing support)
- Rewrite the TS SDK README release section to match the Python SDK's trusted-publishing wording, and document the bootstrap (npm has no "create package" UI — first publish has to happen manually)

Matches what's already set up for PyPI in `sdk-release.yml`. The `environment: npm` block is preserved and must line up with the Environment configured on the npm trusted publisher.

## Test plan
- [ ] Merge and cut a patch release tag (`aod-sdk-ts-v0.x.y`) to confirm the workflow publishes without a token
- [ ] Check the published version's provenance badge on npmjs.com
- [ ] Once the `NPM_TOKEN` secret is no longer referenced anywhere, delete it from the repo's Actions secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)