### PR TITLE
aod-sdk (TS): bump version to 0.1.1

### DIFF
--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ravi-hq/aod-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ravi-hq/aod-sdk",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ravi-hq/aod-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript SDK for the Agent on Demand API",
   "license": "Apache-2.0",
   "author": "Ravi",

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -50,4 +50,4 @@ export type {
   SessionStreamOptions,
 } from "./resources/index.js";
 
-export const VERSION = "0.1.0";
+export const VERSION = "0.1.1";


### PR DESCRIPTION
## Summary
- Bump `@ravi-hq/aod-sdk` to `0.1.1` in `package.json`, `package-lock.json`, and the `VERSION` export
- First release on the new trusted-publishing pipeline (#104); no SDK code changes since 0.1.0

After merge, cut a GitHub Release tagged `aod-sdk-ts-v0.1.1` on `main` and `sdk-release-npm.yml` will publish to npm.

## Test plan
- [ ] CI green
- [ ] After release, `npm install @ravi-hq/aod-sdk@0.1.1` resolves cleanly
- [ ] Published version has a provenance badge on npmjs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)