### PR TITLE
Refresh AoD API skill; add Python + TypeScript SDK skills

### DIFF
--- a/.claude/skills/agent-on-demand-api.md
+++ b/.claude/skills/agent-on-demand-api.md
@@ -1,6 +1,6 @@
 ---
 name: agent-on-demand-api
-description: Use when driving the Agent on Demand REST API — creating agents, environments, or sessions; writing/maintaining `tests/e2e/`; adding new endpoints; or debugging 4xx responses. Covers auth, the route table, the `detail`-is-a-list quirk for 422, optimistic concurrency (`version`), agent-metadata-merge vs env_vars-full-replacement divergence, the session state machine with 409 edges, SSE stream consumption, and multi-turn session semantics. Canonical full reference is `docs/API.md`.
+description: Use when driving the Agent on Demand REST API — creating agents, environments, or sessions; writing/maintaining `tests/e2e/`; adding new endpoints; or debugging 4xx responses. Covers auth, the route table, the `detail`-is-a-list quirk for 422, optimistic concurrency (`version`), agent-metadata-merge vs env_vars-full-replacement divergence, the session state machine (failed is terminal), session resources (GitHub repo clone), concurrent-session quota (429), SSE stream with stage events, and multi-turn session semantics. Canonical spec is `docs/openapi.yaml`.
 ---
 
 # Agent on Demand API Skill
@@ -13,15 +13,16 @@ Use this skill when:
 - Calling the Agent on Demand API from code, tests, or curl (creating agents, environments, or sessions)
 - Writing or maintaining e2e tests in `tests/e2e/`
 - Adding new endpoints — keep the conventions here consistent
-- Debugging 4xx responses (especially 409, 422, or the `detail`-is-a-list edge case)
+- Debugging 4xx responses (especially 409, 422, 429, or the `detail`-is-a-list edge case)
 
-Canonical full-depth reference: `docs/API.md`. This skill is the shorter operator view with the gotchas front-loaded.
+Canonical spec: `docs/openapi.yaml`. The operator site is rendered at `https://ravi-hq.github.io/agent-on-demand`. This skill is the shorter operator view with the gotchas front-loaded.
 
 ## Base URL & Auth
 
 - Dev: `http://localhost:8777` (what `make dev` serves)
 - E2E default when invoking through `make`: same `http://localhost:8777`; raw `pytest` defaults to `http://localhost:8000`
 - Every endpoint except `GET /health` requires `Authorization: Bearer aod_<token>`. Tokens are created server-side via `APIKey.create_key(user, name)` (Django shell/management command).
+- Runtime auth (provider keys, OAuth tokens) is a separate concept — stored as `UserCredential` rows keyed by `kind` (e.g. `provider:anthropic`, `runtime_token:claude-oauth`). Missing credentials for a session's runtime → `400 "No API key configured for runtime: <name>"`.
 
 ## Route Table
 
@@ -44,6 +45,7 @@ POST   /sessions                            # 202  ← not 201; execution is asy
 GET    /sessions                            # 200 {"data":[...]}  (all statuses, newest first)
 GET    /sessions/{uuid}                     # 200
 POST   /sessions/{uuid}/prompt              # 202  (multi-turn)
+GET    /sessions/{uuid}/turns               # 200 {"data":[...]}  turn history
 POST   /sessions/{uuid}/terminate           # 200
 DELETE /sessions/{uuid}/delete              # 200
 GET    /sessions/{uuid}/stream              # 200 text/event-stream
@@ -58,7 +60,8 @@ GET    /sessions/{uuid}/stream              # 200 text/event-stream
 - List: `{"data":[<resource>,...]}` — no pagination, no query params.
 - Single: resource object, no envelope.
 - Error: `{"detail": ...}` for every status, including successful deletes (`{"detail":"Session deleted"}`).
-- `GET /sessions` and `GET /sessions/{id}` return the same per-session shape (no `prompt`, no `version`, no `archived_at`).
+- `GET /sessions` and `GET /sessions/{id}` return the same per-session shape: `id`, `agent_id`, `environment_id`, `runtime`, `status`, `exit_code`, `created_at`, `updated_at`, `resources`, `turn_count`, `current_turn`. No `prompt`, no `version`, no `archived_at`.
+- `POST /sessions` and `POST /sessions/{id}/prompt` return a trimmed ack (`id`, `status`, `stream_url`, `current_turn`, plus `environment_id`/`resources` on create). To get the full session, `GET /sessions/{id}` after.
 
 ### The 422 quirk
 
@@ -93,24 +96,26 @@ The two resources handle bag-of-key-values fields **differently**:
 
 ### 2. env_vars is never returned in responses
 
-`env_vars` can be set on create/update but is always omitted from `_serialize_environment`. To verify a value, check it from inside a running session (`echo $VAR`) — you cannot GET it back from the API.
+`env_vars` can be set on create/update but is always omitted from `_serialize_environment` (also encrypted at rest). To verify a value, check it from inside a running session (`echo $VAR`) — you cannot GET it back from the API.
 
 ### 3. Session create is 202, not 201
 
-Execution starts in a background thread. The caller must consume the stream (or poll GET) to observe completion. Don't assume a session with status `pending` has done anything yet.
+Execution is enqueued as a Procrastinate task and runs in the worker process. The caller must consume the stream (or poll `GET /sessions/{id}`) to observe completion. Don't assume a session with status `pending` has done anything yet. The 202 ack carries `stream_url` and `current_turn` — use those instead of guessing paths.
 
-### 4. Multi-turn does NOT re-apply setup
+### 4. Multi-turn does NOT re-apply setup; `failed` is terminal
 
 On `POST /sessions/{id}/prompt`:
-- The agent's `system` prompt is **not** re-prepended (the runtime session history already has it from turn 1).
-- Environment `setup_script`, `packages`, `env_vars`, MCP servers — **none** re-run/re-apply on turn 2+.
+- The agent's `system` prompt is **not** re-prepended (the runtime CLI's own `--continue`/`--resume` carries conversation state from turn 1).
+- Environment `setup_script`, `packages`, `env_vars`, MCP servers, skills — **none** re-run/re-apply on turn 2+.
 - The Sprite filesystem persists between turns.
+- Allowed only on `pending` or `completed`. Both `running` (409 "already running") **and `failed` (409 "has failed and cannot be resumed")** are blocked. `failed` used to be resumable — it isn't anymore; a failed turn may have left the Sprite in a bad state, so start a new session instead.
 
 If you need new packages or env vars mid-conversation, start a new session.
 
 ### 5. 409 edges on sessions
 
 - `POST /prompt` on `running` → `"Session is already running"`
+- `POST /prompt` on `failed` → `"Session has failed and cannot be resumed. Start a new session."`
 - `POST /prompt` on `terminated` → `"Session has been terminated"`
 - `POST /terminate` on `terminated` → `"Session is already terminated"`
 - `DELETE /delete` on `running` → `"Cannot delete a running session"`
@@ -118,32 +123,44 @@ If you need new packages or env vars mid-conversation, start a new session.
 
 Terminate is idempotent-error (409), not idempotent-OK.
 
-### 6. Runtime/model pairing is NOT cross-validated
+### 6. Runtime/model pairing IS cross-validated
 
-You can save `runtime="gemini"` with `model="claude-opus-4-6"` — the API will 201. The session will fail at exec time with a less obvious error. Always pair correctly from the matrix below.
+The API enforces that the agent's `model` is servable by the agent's `runtime` (provider of the model must be in the runtime's `providers` set). Enforced on `POST /agents`, `PUT /agents/{id}`, and again at session create — returns **422** with `"Runtime X cannot serve model Y: provider Z not in [...]"`. Pair correctly from the matrix below; the validator will reject mismatches before a Sprite is created.
 
 ### 7. Archive vs delete on environments
 
-- Archive (`POST /environments/{id}/archive`) → soft, reversible-ish (no un-archive endpoint), but rows stay. Second archive → 409.
+- Archive (`POST /environments/{id}/archive`) → soft, reversible-ish (no un-archive endpoint), rows stay. Second archive → 409.
 - Delete (`DELETE /environments/{id}/delete`) → hard, cascades versions. **Blocked by 409 if any session — even terminated ones — references this environment.** Does not require prior archive.
 - Practical pattern: **prefer archive**. The e2e fixtures use archive for cleanup to avoid the sessions-exist 409.
 
 ### 8. Agents cannot disable individual tools
 
-Each runtime runs with its full default tool set (bash/read/write/edit/glob/grep/web_fetch/web_search). MCP servers on the agent are additive. There is no tool allowlist or per-tool disable switch.
+Each runtime runs with its full default tool set (bash/read/write/edit/glob/grep/web_fetch/web_search). MCP servers and skills on the agent are additive. There is no tool allowlist or per-tool disable switch.
+
+### 9. Concurrent-session quota returns 429
+
+`POST /sessions` counts the caller's `pending` + `running` sessions against their quota (`UserQuota.max_concurrent_sessions`, default from `settings.DEFAULT_MAX_CONCURRENT_SESSIONS`). Exceeded → `429` with `{"detail": "...", "limit": N, "active": M}` — the only endpoint that surfaces extra keys alongside `detail`.
+
+### 10. Session `resources` (GitHub repos)
+
+`POST /sessions` accepts up to 10 `resources[]` entries of `{"type":"github_repository","url":"https://github.com/<owner>/<repo>"[,"mount_path":"/absolute/path"][,"authorization_token":"<PAT>"]}`. The repo is cloned inside the Sprite during provisioning. `mount_path` defaults to `/workspace/<repo-name>`, must be absolute, cannot be `/` or `/home/sprite`, and must be unique across the request. `authorization_token` (for private repos) is encrypted at rest and **never echoed back** on any response.
 
 ## Runtime & Model Matrix
 
-| Runtime        | Valid models                                                                              |
-| -------------- | ----------------------------------------------------------------------------------------- |
-| `claude`       | `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`, plus pinned variants in `runtimes.py` |
-| `claude-oauth` | same as `claude` (OAuth auth path)                                                        |
-| `codex`        | `gpt-4.1`, `o3`, `o4-mini`                                                                |
-| `gemini`       | `gemini-2.5-pro`, `gemini-2.5-flash`                                                      |
+Model IDs are canonical `provider/model_id` strings. Agent create/update rejects any ID not in `MODELS`.
 
-Source of truth: `src/agent_on_demand/runtimes.py` — `AgentModel` + `RUNTIMES` + `MODEL_RUNTIME_MAP`.
+| Runtime    | Providers                       | Valid models                                                                                                                                                                        |
+| ---------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `claude`   | `anthropic`                     | `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5`, plus pinned variants (`claude-opus-4-0-20250514`, `claude-sonnet-4-0-20250514`, `claude-sonnet-4-5-20250514`, `claude-3-5-haiku-20241022`) |
+| `codex`    | `openai`                        | `openai/gpt-4.1`, `openai/o3`, `openai/o4-mini`                                                                                                                                     |
+| `gemini`   | `google`                        | `google/gemini-2.5-pro`, `google/gemini-2.5-flash`                                                                                                                                  |
+| `opencode` | `anthropic`, `openai`, `google` | any of the above (meta-runtime; picks provider+model per invocation via `--model`)                                                                                                  |
 
-If you see `400 {"detail":"No API key configured for runtime: <name>"}` at session create, the user hasn't added a `UserRuntimeKey` for that runtime.
+Source of truth: `src/agent_on_demand/models_catalog.py` (`MODELS`) and `src/agent_on_demand/runtimes/` (per-runtime `Runtime.providers`).
+
+Claude accepts either a `provider:anthropic` credential (ANTHROPIC_API_KEY) or a `runtime_token:claude-oauth` credential (CLAUDE_CODE_OAUTH_TOKEN) — both authenticate the same `claude` runtime. There is no separate `claude-oauth` runtime anymore.
+
+If you see `400 {"detail":"No API key configured for runtime: <name>"}` at session create, the user hasn't registered a `UserCredential` of an accepted `kind` for that runtime.
 
 ## Session State Machine
 
@@ -154,8 +171,8 @@ If you see `400 {"detail":"No API key configured for runtime: <name>"}` at sessi
                    ┌─────────┐
                    │ pending │◄────────────────────────────────┐
                    └────┬────┘                                 │
-                        │ background execution                 │ POST /sessions/{id}/prompt
-                        ▼                                      │ (allowed on pending/completed/failed)
+                        │ worker picks up task                 │ POST /sessions/{id}/prompt
+                        ▼                                      │ (allowed only on pending/completed)
                    ┌─────────┐                                 │
                    │ running │─────────────────────────────────┘
                    └────┬────┘
@@ -164,27 +181,32 @@ If you see `400 {"detail":"No API key configured for runtime: <name>"}` at sessi
     ┌──────────┐  ┌────────┐  ┌──────────────┐
     │completed │  │ failed │  │  terminated  │◄── POST /sessions/{id}/terminate
     └──────────┘  └────────┘  └──────────────┘
+                      │
+                      └─ terminal: /prompt returns 409. Start a new session.
 ```
 
 - `completed`: exit_code == 0
-- `failed`: non-zero exit OR unhandled exception (exit_code may be null)
+- `failed`: non-zero exit OR unhandled exception (exit_code may be null). Terminal — no resume.
 - `terminated`: explicit terminate; Sprite deleted best-effort; record kept
 
 ## SSE Stream
 
 `GET /sessions/{id}/stream` — `Content-Type: text/event-stream`, `X-Accel-Buffering: no`.
 
-Event types (`data: <json>\n\n`). Every event except `start` includes an `"id": <log_row_id>` field in the JSON payload and an SSE `id:` line.
+Event types (`data: <json>\n\n`). Every event except `start` includes an `"id": <log_row_id>` field in the JSON payload and an matching SSE `id:` line.
 
-| Type         | Payload                                                                          |
-| ------------ | -------------------------------------------------------------------------------- |
-| `start`      | `{"type":"start","runtime":"claude","session_id":"<uuid>"}` (always first, no `id`) |
-| `turn_start` | `{"type":"turn_start","id":<int>,"turn":<int>}` — before first output of each turn |
-| `output`     | `{"type":"output","id":<int>,"stream":"stdout"\|"stderr","data":"...","turn":<int>}` |
-| `exit`       | `{"type":"exit","id":<int>,"code":0}` — terminal                                |
-| `error`      | `{"type":"error","id":<int>,"message":"..."}` — terminal (exception path)       |
-| `terminated` | `{"type":"terminated","id":<int>,"message":"Session terminated"}` — terminal    |
-| `stale`      | `{"type":"stale","id":<int>,"message":"No output for 600s"}` — terminal; session may still be `running` |
+| Type         | Payload                                                                                                    |
+| ------------ | ---------------------------------------------------------------------------------------------------------- |
+| `start`      | `{"type":"start","runtime":"claude","session_id":"<uuid>"}` (always first, no `id`)                        |
+| `stage`      | `{"type":"stage","id":<int>,"stage":"<name>","state":"started"\|"completed"\|"failed"[,"duration_ms":N][,"message":"..."]}` — provisioning progress |
+| `turn_start` | `{"type":"turn_start","id":<int>,"turn":<int>}` — before first output of each turn                         |
+| `output`     | `{"type":"output","id":<int>,"stream":"stdout"\|"stderr","data":"...","turn":<int>}`                       |
+| `exit`       | `{"type":"exit","id":<int>,"code":0}` — terminal                                                           |
+| `error`      | `{"type":"error","id":<int>,"message":"..."}` — terminal (exception path; `failed` with no exit_code)      |
+| `terminated` | `{"type":"terminated","id":<int>,"message":"Session terminated"}` — terminal                              |
+| `stale`      | `{"type":"stale","id":<int>,"message":"No output for 600s"}` — terminal; session may still be `running`   |
+
+Stage names (emitted in order during provisioning): `create_sprite`, `install_runtime`, `network_policy`, `env_file`, `git_credentials`, `provision_setup`, `runtime_config`, `skills`, `runtime_start`.
 
 Heartbeats are lines starting with `: ` (skip them). Stream replays everything from the start by default; supply the last received `id` via `Last-Event-ID` header or `?since=<id>` query param to resume without re-receiving old events. If both are supplied, the header wins. `since=0` or omitting it gives a full replay. Non-integer `since` returns `400`.
 
@@ -220,11 +242,11 @@ BASE=http://localhost:8777
 AUTH="Authorization: Bearer $TOKEN"
 JSON="Content-Type: application/json"
 
-# Create agent
+# Create agent (note provider/model_id canonical form)
 curl -X POST "$BASE/agents" -H "$AUTH" -H "$JSON" \
-  -d '{"name":"demo","model":"claude-sonnet-4-6","runtime":"claude","system":"You are terse."}'
+  -d '{"name":"demo","model":"anthropic/claude-sonnet-4-6","runtime":"claude","system":"You are terse."}'
 
-# Update agent (stale version → 409)
+# Update agent (stale version → 409; incompatible runtime/model → 422)
 curl -X PUT "$BASE/agents/<id>" -H "$AUTH" -H "$JSON" \
   -d '{"version":1,"metadata":{"key-to-delete":"","keep":"val"}}'
 
@@ -236,16 +258,23 @@ curl -X POST "$BASE/environments" -H "$AUTH" -H "$JSON" -d '{
   "networking":{"type":"limited","allowed_hosts":["pypi.org","files.pythonhosted.org"]}
 }'
 
-# Create session (202)
-curl -X POST "$BASE/sessions" -H "$AUTH" -H "$JSON" \
-  -d '{"agent_id":"<id>","prompt":"hello","timeout":120}'
+# Create session (202) — optionally with GitHub repo resources
+curl -X POST "$BASE/sessions" -H "$AUTH" -H "$JSON" -d '{
+  "agent_id":"<id>",
+  "prompt":"summarize the README",
+  "timeout":120,
+  "resources":[{"type":"github_repository","url":"https://github.com/org/repo"}]
+}'
 
 # Stream until exit
 curl -N -H "$AUTH" "$BASE/sessions/<id>/stream"
 
-# Multi-turn (reuses same session row + Sprite)
+# Multi-turn (only valid on pending/completed; 409 on running/failed/terminated)
 curl -X POST "$BASE/sessions/<id>/prompt" -H "$AUTH" -H "$JSON" \
   -d '{"prompt":"follow up"}'
+
+# List turn history
+curl -H "$AUTH" "$BASE/sessions/<id>/turns"
 
 # Terminate (best-effort Sprite delete, record kept)
 curl -X POST -H "$AUTH" "$BASE/sessions/<id>/terminate"
@@ -256,24 +285,26 @@ curl -X DELETE -H "$AUTH" "$BASE/sessions/<id>/delete"
 
 ## Error Code Reference
 
-| Code | `detail` type | Common causes                                                                 |
-| ---- | ------------- | ----------------------------------------------------------------------------- |
-| 400  | string        | Invalid JSON, unknown runtime, no runtime API key configured                  |
-| 401  | string        | Missing/invalid/inactive/expired bearer token                                 |
-| 404  | string        | Resource not found or not owned by this token's user                          |
-| 405  | string        | Method not allowed on that route                                              |
-| 409  | string        | Version mismatch, already archived/terminated, running-session delete, etc.   |
-| 422  | **list**      | Pydantic validation failure — `detail` is an array of error dicts             |
-| 502  | string        | Sprites upstream error (create/policy/exec)                                   |
+| Code | `detail` type | Common causes                                                                                      |
+| ---- | ------------- | -------------------------------------------------------------------------------------------------- |
+| 400  | string        | Invalid JSON, unknown runtime, no Sprites key, no runtime credential configured, `since` not int   |
+| 401  | string        | Missing/invalid/inactive/expired bearer token                                                      |
+| 404  | string        | Resource not found or not owned by this token's user                                               |
+| 405  | string        | Method not allowed on that route                                                                   |
+| 409  | string        | Version mismatch, archived-already, terminated-already, running-session delete, failed-resume, etc.|
+| 422  | **list**      | Pydantic validation failure — `detail` is an array of error dicts. Also used for runtime/model incompat. |
+| 429  | string        | Per-user concurrent-session quota exceeded. Body also carries numeric `limit` and `active` keys.   |
+| 502  | string        | Sprites upstream error (create/policy/exec)                                                        |
 
 ## Related Files
 
 - `src/agent_on_demand/urls.py` — authoritative route table
-- `src/agent_on_demand/views.py` — request models, validation, serializers, all endpoints
-- `src/agent_on_demand/models.py` — `Agent`, `Environment`, `AgentSession`, version history, `APIKey`
-- `src/agent_on_demand/runtimes.py` — `AgentModel`, `RUNTIMES`, `MODEL_RUNTIME_MAP`
-- `src/agent_on_demand/stream.py` — background runner + SSE event emission
-- `src/agent_on_demand/sprites_exec.py` — `build_wrapper_script` (sets order of env → packages → clone → setup → exec)
-- `tests/e2e/conftest.py` — canonical fixtures (`create_agent`, `create_environment`, `create_session`)
-- `docs/API.md` — full reference with worked end-to-end examples
+- `src/agent_on_demand/views/` — request models, validation, serializers, per-resource endpoints
+- `src/agent_on_demand/models/` — `Agent`, `Environment`, `AgentSession`, `SessionTurn`, `SessionResource`, version history, `APIKey`, `UserCredential`, `UserQuota`
+- `src/agent_on_demand/models_catalog.py` — `MODELS` (canonical `provider/model_id` catalog)
+- `src/agent_on_demand/runtimes/` — per-runtime `Runtime` classes (`claude.py`, `codex.py`, `gemini.py`, `opencode.py`) and the `RUNTIMES` registry
+- `src/agent_on_demand/stream.py` — SSE replay generator (tails `AgentSessionLog`)
+- `src/agent_on_demand/session_service/` — Sprites orchestration (`provisioning.py`, `tasks.py`, `turn.py`)
+- `tests/e2e/conftest.py` — canonical fixtures (`create_agent`, `create_environment`, `create_session`) and the `AgentOnDemandAPI` test client
+- `docs/openapi.yaml` — full OpenAPI 3.1 spec (canonical machine-readable reference)
 - `thoughts/research/2026-04-17-fairy-api-docs.md` — research synthesis behind this skill

--- a/.claude/skills/aod-sdk-python.md
+++ b/.claude/skills/aod-sdk-python.md
@@ -1,0 +1,196 @@
+---
+name: aod-sdk-python
+description: Use when writing Python code that calls the Agent on Demand API via `aod-sdk` (package `aod` — `Client`/`AsyncClient`, `client.agents`/`environments`/`sessions`, `client.sessions.stream(...)`). Covers install, `AOD_API_URL`/`AOD_API_TOKEN` env fallbacks, typed pydantic models, sync-vs-async method parity, the `StreamEvent` SSE iterator (context manager + `.extra` dict), typed `AodHTTPError` subclasses (`ConflictError`/`ValidationError`/`RateLimitError.limit`/`active`), and the runtime-scoped `aod.pretty` formatters. Defers to the `agent-on-demand-api` skill for HTTP semantics, status codes, and state-machine edges.
+---
+
+# Agent on Demand Python SDK Skill
+
+The `aod-sdk` Python package (import name `aod`) wraps every endpoint in `docs/openapi.yaml` with typed pydantic models, sync + async clients, and a typed SSE event stream. Package source lives at `clients/python/` in this repo.
+
+## When This Skill Applies
+
+Use this skill when:
+- Writing Python that calls the AoD API via `from aod import Client` / `AsyncClient`
+- Extending `clients/python/` itself (new resources, new models, new stream helpers)
+- Debugging a traceback from `aod.errors.AodHTTPError` or its subclasses
+
+For HTTP-level questions (route table, state machine, 409/422/429 semantics), defer to the `agent-on-demand-api` skill. For TypeScript, use `aod-sdk-typescript`.
+
+## Install & Configure
+
+```bash
+pip install aod-sdk
+# or, in-tree development:
+cd clients/python && uv pip install -e ".[dev]"
+```
+
+`Client` / `AsyncClient` read these in order of precedence:
+1. Constructor kwargs: `base_url=...`, `token=...`
+2. Env vars: `AOD_API_URL`, `AOD_API_TOKEN`
+3. `base_url` default: `http://localhost:8777`. `token` is **required** — missing raises `ValueError`, not a 401.
+
+Both clients are context managers. Use them as such — they own an `httpx.Client`/`AsyncClient`.
+
+```python
+from aod import Client, AsyncClient
+
+with Client(token="aod_...") as client:
+    ...
+
+async with AsyncClient() as client:  # reads AOD_API_TOKEN from env
+    ...
+```
+
+## Resources Shape
+
+Every client exposes three resource namespaces with identical method names on both sync and async variants:
+
+| Namespace             | Methods                                                                                                                          |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `client.agents`       | `list()`, `create(...)`, `get(id)`, `update(id, version=..., **fields)`, `archive(id)`, `versions(id)`                            |
+| `client.environments` | `list()`, `create(...)`, `get(id)`, `update(id, version=..., **fields)`, `archive(id)`, `delete(id)`, `versions(id)`              |
+| `client.sessions`     | `list()`, `create(agent_id=..., prompt=..., [environment_id=], [timeout=], [resources=])`, `get(id)`, `prompt(id, prompt=...)`, `turns(id)`, `terminate(id)`, `delete(id)`, `stream(id, since=None)` |
+
+- Every method accepts `str | UUID` for IDs; they're stringified on the wire.
+- Return types are pydantic models from `aod.models` (`Agent`, `Environment`, `Session`, `SessionAck`, `SessionTurn`, `AgentVersion`, `EnvironmentVersion`). Unknown fields are **ignored** (`extra="ignore"`), so new server fields don't blow up old clients.
+- `sessions.create` and `sessions.prompt` and `sessions.terminate` return `SessionAck` — a **trimmed** payload, not a full `Session`. Only `id` + `status` are guaranteed; `stream_url`/`environment_id`/`resources`/`current_turn` are populated when the server provides them. Fetch `client.sessions.get(id)` for the full record.
+
+## Streaming
+
+`client.sessions.stream(session_id, since=None)` is a **context manager** that yields a **`StreamEvent` iterator**. The nesting matters — it owns an HTTP connection:
+
+```python
+with client.sessions.stream(session_id) as events:
+    for event in events:
+        if event.type == "output":
+            print(event.extra["data"], end="")
+        elif event.type in ("exit", "error", "terminated", "stale"):
+            break
+```
+
+Async:
+
+```python
+async with client.sessions.stream(session_id) as events:
+    async for event in events:
+        ...
+```
+
+`StreamEvent` shape: `type: StreamEventType` + `id: int | None` + `extra: dict[str, Any]`. Every server-side field except `type` and `id` lands in `extra`. This is deliberate — the event schema is still evolving, and keeping the raw payload accessible avoids breakage.
+
+Event types: `start`, `turn_start`, `output`, `stage`, `exit`, `error`, `terminated`, `stale`. Terminal types are `exit`/`error`/`terminated`/`stale` — break the loop when you see one.
+
+To resume after a disconnect, pass `since=<last event id>`. `since=None` / omitted = full replay.
+
+## Errors
+
+All non-2xx responses raise a typed subclass of `AodError`:
+
+| Status | Exception         | Common trigger                                                |
+| ------ | ----------------- | ------------------------------------------------------------- |
+| 401/3  | `AuthError`       | Missing/invalid token                                         |
+| 404    | `NotFoundError`   | Resource missing or not owned by the token's user             |
+| 409    | `ConflictError`   | Archive-already, terminal session, stale `version`, failed-resume |
+| 422    | `ValidationError` | Pydantic validation on the server — `detail` is a **list**    |
+| 429    | `RateLimitError`  | Concurrent-session quota. Has `.limit` and `.active` attrs    |
+| 5xx    | `ServerError`     | Sprites upstream error or unhandled exception                 |
+
+All share `.status_code`, `.detail`, `.method`, `.url`. `detail` is whatever the server sent — a string for most codes, a **list of error dicts** for 422 (Pydantic). Match with `isinstance` rather than on `status_code`.
+
+```python
+from aod import ConflictError, RateLimitError
+
+try:
+    client.agents.update(agent.id, version=agent.version, name="renamed")
+except ConflictError as e:
+    # stale version — refetch and retry
+    latest = client.agents.get(agent.id)
+    client.agents.update(latest.id, version=latest.version, name="renamed")
+except RateLimitError as e:
+    print(f"quota: {e.active}/{e.limit}")
+```
+
+## Optimistic Concurrency Idiom
+
+Agents and environments require `version=<current>` on every update. Stale → `ConflictError`. Standard pattern is read-then-write:
+
+```python
+agent = client.agents.get(agent_id)
+client.agents.update(agent.id, version=agent.version, system="...")
+```
+
+Merge/replace semantics match the HTTP API (covered in `agent-on-demand-api`):
+- `metadata` is **merged per-key**; empty string deletes the key.
+- `env_vars` is **fully replaced** — re-send every key you want to keep.
+
+## Runtime-Scoped Pretty Printing
+
+`aod.pretty` holds optional formatters that turn raw agent stdout into display lines. These are **runtime-specific** (runtime output formats are not part of the AoD API contract), so they live under a separate namespace and don't ship as part of the core `Client`.
+
+```python
+from aod.pretty.claude import ClaudeFormatter
+
+fmt = ClaudeFormatter()
+with client.sessions.stream(session_id) as events:
+    for event in events:
+        for line in fmt.consume(event):  # filters to output+stdout internally
+            print(line)
+    for line in fmt.flush():              # drain any half-buffered line
+        print(line)
+```
+
+Currently shipped: `ClaudeFormatter` (consumes the Claude CLI `stream-json` output format). Other runtimes have no formatter yet — iterate `event.extra["data"]` yourself for `output` events.
+
+## Common Gotchas
+
+1. **Missing token is a `ValueError` at construction, not an `AuthError`.** You won't hit the network to discover the config is broken.
+2. **`Session` response has no `prompt`.** `prompt` lives on `SessionTurn` — fetch it via `client.sessions.turns(session_id)`.
+3. **`SessionAck.environment_id` is `None` on `prompt` / `terminate` acks.** It's only set on `create` because that's the only ack where the server knows it needs to echo it.
+4. **The stream context manager must be exited for the connection to close.** Breaking out of the inner `for` is fine; don't hold the `events` iterator past the `with` block.
+5. **`extra["data"]` on `output` events is a string.** `stream`/`turn` also live in `extra`. Don't assume a fixed schema — consult `agent-on-demand-api` for the per-event payload shape.
+6. **Sync vs async symmetry is strict.** Every `Client` method has an `AsyncClient` counterpart with the same name and signature — except `close()` → `aclose()` and context manager forms.
+
+## End-to-End Example
+
+```python
+from aod import Client
+
+with Client(token="aod_...") as client:
+    env = client.environments.create(
+        name="demo",
+        packages={"pip": ["requests"]},
+        env_vars={"DEMO": "1"},
+        networking={"type": "limited", "allowed_hosts": ["pypi.org"]},
+    )
+    agent = client.agents.create(
+        name="demo",
+        model="anthropic/claude-sonnet-4-6",
+        runtime="claude",
+        system="You are terse.",
+        environment_id=env.id,
+    )
+    ack = client.sessions.create(
+        agent_id=agent.id,
+        prompt="summarize README.md",
+        resources=[{"type": "github_repository", "url": "https://github.com/me/repo"}],
+    )
+    with client.sessions.stream(ack.id) as events:
+        for event in events:
+            if event.type == "output":
+                print(event.extra["data"], end="")
+            elif event.type in ("exit", "error", "terminated", "stale"):
+                break
+    final = client.sessions.get(ack.id)
+    print(f"status={final.status} exit_code={final.exit_code}")
+```
+
+## Related Files
+
+- `clients/python/src/aod/client.py` — `Client` / `AsyncClient`; config resolution
+- `clients/python/src/aod/resources/` — `agents.py`, `environments.py`, `sessions.py`
+- `clients/python/src/aod/models.py` — pydantic models (`Agent`, `Session`, `StreamEvent`, etc.)
+- `clients/python/src/aod/errors.py` — exception hierarchy + `raise_for_status`
+- `clients/python/src/aod/stream.py` — sync/async SSE iterators
+- `clients/python/src/aod/pretty/` — runtime-scoped formatters (`claude.py`)
+- `clients/python/README.md` — user-facing docs
+- Sibling skill `agent-on-demand-api` — HTTP semantics, status codes, state machine

--- a/.claude/skills/aod-sdk-typescript.md
+++ b/.claude/skills/aod-sdk-typescript.md
@@ -1,0 +1,211 @@
+---
+name: aod-sdk-typescript
+description: Use when writing TypeScript or JavaScript that calls the Agent on Demand API via `@ravi-hq/aod-sdk` — `new Client({...})`, `client.agents`/`environments`/`sessions`, `client.sessions.stream(...)`. Covers install, `AOD_API_URL`/`AOD_API_TOKEN` env fallbacks (Node only), the single async client (no sync variant), the `StreamHandle` async iterable with `.close()`, `AbortSignal` cancellation, typed `AodHTTPError` subclasses (`ConflictError`/`ValidationError`/`RateLimitError.limit`/`active`), and Node-vs-browser differences. Defers to the `agent-on-demand-api` skill for HTTP semantics, status codes, and state-machine edges.
+---
+
+# Agent on Demand TypeScript SDK Skill
+
+The `@ravi-hq/aod-sdk` package wraps every endpoint in `docs/openapi.yaml` with typed interfaces, a single async `Client`, and an `AsyncIterable` SSE event stream. Zero runtime dependencies — uses built-in `fetch` / `ReadableStream` / `AbortController`. Node 18+ and modern browsers. Package source lives at `clients/typescript/` in this repo.
+
+## When This Skill Applies
+
+Use this skill when:
+- Writing TS/JS that calls the AoD API via `import { Client } from "@ravi-hq/aod-sdk"`
+- Extending `clients/typescript/` itself (new resources, new types, new stream helpers)
+- Debugging a thrown `AodHTTPError` (or `ConflictError` / `ValidationError` / `RateLimitError`)
+
+For HTTP-level questions (route table, state machine, 409/422/429 semantics), defer to the `agent-on-demand-api` skill. For Python, use `aod-sdk-python`.
+
+## Install & Configure
+
+```bash
+npm install @ravi-hq/aod-sdk
+# or, in-tree development:
+cd clients/typescript && npm install && npm test
+```
+
+`new Client({...})` resolves config in this order:
+1. Constructor options: `baseUrl`, `token`
+2. Env vars: `AOD_API_URL`, `AOD_API_TOKEN` — **Node only**. In the browser they're undefined.
+3. `baseUrl` default: `http://localhost:8777`. `token` is **required** — missing throws immediately (before any network call).
+
+`Client` is not a `Disposable` — it holds no open connections between requests, so you don't need to close it. Streams are the exception (see below).
+
+```ts
+import { Client } from "@ravi-hq/aod-sdk";
+
+const client = new Client({ baseUrl: "https://aod.example", token: "aod_..." });
+// or just: new Client()  — reads both from env in Node
+```
+
+Other constructor options:
+
+| Option       | Default            | Notes                                                          |
+| ------------ | ------------------ | -------------------------------------------------------------- |
+| `fetch`      | `globalThis.fetch` | Inject for tests/proxies. Must match the standard `fetch` shape. |
+| `timeoutMs`  | `30000`            | Per non-streaming request. Streams use the caller's `AbortSignal` instead. |
+
+## Resources Shape
+
+Single async `Client`, three resource namespaces. Every non-stream method accepts an optional trailing `{ signal }` for `AbortSignal` cancellation.
+
+| Namespace             | Methods                                                                                                                         |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `client.agents`       | `list()`, `create(params)`, `get(id)`, `update(id, params)`, `archive(id)`, `versions(id)`                                       |
+| `client.environments` | `list()`, `create(params)`, `get(id)`, `update(id, params)`, `archive(id)`, `delete(id)`, `versions(id)`                         |
+| `client.sessions`     | `list()`, `create(params)`, `get(id)`, `prompt(id, params)`, `turns(id)`, `terminate(id)`, `delete(id)`, `stream(id, options?)` |
+
+- Return types are interfaces exported from `@ravi-hq/aod-sdk`: `Agent`, `Environment`, `Session`, `SessionAck`, `SessionTurn`, `AgentVersion`, `EnvironmentVersion`, plus param interfaces (`AgentCreateParams`, `SessionCreateParams`, etc.). Interfaces are **structural** — extra server fields don't break consumers; missing ones are typed `undefined | null`.
+- IDs are plain `string`s (UUIDs on the wire). No helper type.
+- `sessions.create` / `sessions.prompt` / `sessions.terminate` return `SessionAck`, **not** `Session`. Only `id` + `status` are guaranteed; `stream_url` / `environment_id` / `resources` / `current_turn` are populated when the server provides them. Call `client.sessions.get(id)` for the full record.
+- Request params are `stripUndefined`d before being serialized — omitted fields aren't sent, preserving server-side defaults.
+
+## Streaming
+
+`client.sessions.stream(sessionId, options?)` returns a **`StreamHandle`** — an `AsyncIterable<StreamEvent>` with a `close()` method. **Always wrap in try/finally** so the underlying connection closes if you break early.
+
+```ts
+const stream = await client.sessions.stream(ack.id);
+try {
+  for await (const event of stream) {
+    if (event.type === "output") process.stdout.write(event.extra.data as string);
+    if (event.type === "exit" || event.type === "error"
+        || event.type === "terminated" || event.type === "stale") break;
+  }
+} finally {
+  await stream.close();
+}
+```
+
+`StreamEvent` shape: `{ type: StreamEventType; id: number | null; extra: Record<string, unknown> }`. Everything except `type` and `id` lands in `extra`. Event schema is still evolving server-side; the SDK deliberately keeps the raw payload accessible instead of typing every field.
+
+Event types: `start`, `turn_start`, `output`, `stage`, `exit`, `error`, `terminated`, `stale`. Terminal types are `exit`/`error`/`terminated`/`stale`.
+
+Resume after disconnect with `{ since: lastEventId }`. Cancel with an external `AbortSignal`:
+
+```ts
+const controller = new AbortController();
+const stream = await client.sessions.stream(sid, { signal: controller.signal });
+// ...later:
+controller.abort();          // OR
+await stream.close();        // either works — both abort the underlying connection
+```
+
+The stream's internal `AbortController` is linked to whatever signal you pass — aborting the external signal aborts the stream, and `stream.close()` aborts both.
+
+## Errors
+
+All non-2xx responses **throw** a typed subclass of `AodError`:
+
+| Status | Class             | Common trigger                                                |
+| ------ | ----------------- | ------------------------------------------------------------- |
+| 401/3  | `AuthError`       | Missing/invalid token                                         |
+| 404    | `NotFoundError`   | Resource missing or not owned by the token's user             |
+| 409    | `ConflictError`   | Archive-already, terminal session, stale `version`, failed-resume |
+| 422    | `ValidationError` | Pydantic validation on the server — `detail` is a **list**    |
+| 429    | `RateLimitError`  | Concurrent-session quota. Has `.limit` and `.active` props (may be `null`) |
+| 5xx    | `ServerError`     | Sprites upstream error or unhandled exception                 |
+
+All share `.statusCode`, `.detail`, `.method`, `.url`. `detail` is `unknown` in the TS types — it's a `string` for most codes and an **array of error objects** for 422. Narrow with `instanceof` rather than branching on `statusCode`, and on 422 check `Array.isArray(err.detail)` before reading.
+
+```ts
+import { ConflictError, RateLimitError } from "@ravi-hq/aod-sdk";
+
+try {
+  await client.agents.update(agent.id, { version: agent.version, name: "renamed" });
+} catch (e) {
+  if (e instanceof ConflictError) {
+    const latest = await client.agents.get(agent.id);
+    await client.agents.update(latest.id, { version: latest.version, name: "renamed" });
+  } else if (e instanceof RateLimitError) {
+    console.warn(`quota: ${e.active}/${e.limit}`);
+  } else {
+    throw e;
+  }
+}
+```
+
+## Optimistic Concurrency Idiom
+
+Agents and environments require `version` on every update. Stale → `ConflictError`.
+
+```ts
+const agent = await client.agents.get(agentId);
+await client.agents.update(agent.id, { version: agent.version, system: "..." });
+```
+
+Merge/replace semantics match the HTTP API (see `agent-on-demand-api`):
+- `metadata` is **merged per-key**; empty string deletes the key.
+- `env_vars` is **fully replaced** — re-send every key you want to keep.
+
+## Node vs Browser
+
+The SDK is isomorphic with a few caveats:
+
+- **Env var fallbacks are Node-only.** In a browser pass `baseUrl` and `token` explicitly.
+- **CORS**: calling the AoD API from a browser on a different origin requires the server to send CORS headers. The SDK itself does nothing special.
+- **No `process.env` leaks**: config resolution guards `typeof process !== "undefined"` so bundlers/Deno/browsers don't choke.
+- **Dependencies: zero.** If you see anything imported outside the `@ravi-hq/aod-sdk` tree, it's a bug.
+
+## Common Gotchas
+
+1. **Missing token throws synchronously from `new Client({})`.** No network roundtrip to discover the config is broken.
+2. **`Session` has no `prompt`.** `prompt` lives on `SessionTurn` — fetch with `client.sessions.turns(sessionId)`.
+3. **`SessionAck.environment_id` is absent on `prompt` / `terminate` acks.** Only populated on `create`. Don't rely on it after a resume.
+4. **`for await` of a `StreamHandle` leaks the connection if you don't `await stream.close()` in `finally`.** The `close()` aborts the fetch; without it the reader can outlive your function.
+5. **`event.extra.data` (for `output`) is typed `unknown`.** You know from the server that it's a `string`, but the SDK types it `unknown` because the payload shape is evolving. Cast at the boundary.
+6. **There's no sync client.** Node's `fetch` is async — use top-level `await` in modules or wrap in an `async` function.
+7. **`VERSION` exported from the package is a plain `const`** (`"0.1.1"` at time of writing). Keep it in sync with `package.json` when releasing (release script enforces this).
+
+## End-to-End Example
+
+```ts
+import { Client } from "@ravi-hq/aod-sdk";
+
+const client = new Client({ token: "aod_..." });
+
+const env = await client.environments.create({
+  name: "demo",
+  packages: { pip: ["requests"] },
+  env_vars: { DEMO: "1" },
+  networking: { type: "limited", allowed_hosts: ["pypi.org"] },
+});
+
+const agent = await client.agents.create({
+  name: "demo",
+  model: "anthropic/claude-sonnet-4-6",
+  runtime: "claude",
+  system: "You are terse.",
+  environment_id: env.id,
+});
+
+const ack = await client.sessions.create({
+  agent_id: agent.id,
+  prompt: "summarize README.md",
+  resources: [{ type: "github_repository", url: "https://github.com/me/repo" }],
+});
+
+const stream = await client.sessions.stream(ack.id);
+try {
+  for await (const event of stream) {
+    if (event.type === "output") process.stdout.write(event.extra.data as string);
+    if (["exit", "error", "terminated", "stale"].includes(event.type)) break;
+  }
+} finally {
+  await stream.close();
+}
+
+const final = await client.sessions.get(ack.id);
+console.log(`status=${final.status} exit_code=${final.exit_code}`);
+```
+
+## Related Files
+
+- `clients/typescript/src/client.ts` — `Client` + config resolution
+- `clients/typescript/src/resources/` — `agents.ts`, `environments.ts`, `sessions.ts`, barrel `index.ts`
+- `clients/typescript/src/types.ts` — interfaces (`Agent`, `Session`, `StreamEvent`, ...) and `streamEventFromPayload`
+- `clients/typescript/src/errors.ts` — error classes + `raiseForStatus`
+- `clients/typescript/src/stream.ts` — `createStreamHandle` + SSE reader
+- `clients/typescript/src/index.ts` — public exports barrel
+- `clients/typescript/README.md` — user-facing docs
+- Sibling skill `agent-on-demand-api` — HTTP semantics, status codes, state machine


### PR DESCRIPTION
## Summary

- Update `.claude/skills/agent-on-demand-api.md` to match the current API surface: new `/sessions/{id}/turns` endpoint, `opencode` runtime, canonical `provider/model_id` model catalog, cross-validated runtime/model pairing (422), 429 concurrent-session quota, `stage` SSE event, `failed`-as-terminal on `/prompt`, session `resources` + `SessionAck` shape, and repoint the canonical reference at `docs/openapi.yaml`.
- Add `.claude/skills/aod-sdk-python.md` — fires on `aod-sdk` / `from aod import`; covers install, `AOD_API_*` env fallbacks, sync+async parity, the `StreamEvent` context-manager iterator, typed error hierarchy (incl. `RateLimitError.limit`/`.active`), optimistic-concurrency idiom, and the runtime-scoped `aod.pretty.claude.ClaudeFormatter`.
- Add `.claude/skills/aod-sdk-typescript.md` — fires on `@ravi-hq/aod-sdk` / `new Client`; covers install, Node-only env fallbacks, single async client, `StreamHandle` `AsyncIterable` + `.close()` in `finally`, `AbortSignal` linking, `instanceof` error narrowing, and Node-vs-browser caveats.

The two SDK skills defer to `agent-on-demand-api` for HTTP semantics, status codes, and state-machine edges, so the three form a clean hierarchy: one shared API truth, two narrow client surfaces that only load when the relevant SDK is in use.

## Test plan

- [ ] Spot-check: Claude Code sees the three skills at `.claude/skills/*.md` and their frontmatter `description` fields look right.
- [ ] Trigger `aod-sdk-python` by asking a Python-SDK question in a fresh session; confirm it loads (and `aod-sdk-typescript` does not).
- [ ] Trigger `aod-sdk-typescript` by asking a TS-SDK question in a fresh session; confirm the reverse.
- [ ] Ask an HTTP-level question (e.g. "what status does a stale version update return?") and confirm `agent-on-demand-api` loads.
- [ ] Skim the updated `agent-on-demand-api` against `docs/openapi.yaml` for any remaining drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)