### PR TITLE
Return 409 on duplicate active environment name

### DIFF
--- a/src/agent_on_demand/views/environments.py
+++ b/src/agent_on_demand/views/environments.py
@@ -1,6 +1,7 @@
 import json
 
 import posthog
+from django.db import IntegrityError, transaction
 from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
@@ -160,17 +161,24 @@ def environments_list_create(request):
         networking_type = req.networking.get("type", "unrestricted")
         networking_config = {k: v for k, v in req.networking.items() if k != "type"}
 
-        env = Environment.objects.create(
-            user=request.user,
-            name=req.name,
-            packages=req.packages,
-            env_vars=req.env_vars,
-            setup_script=req.setup_script,
-            networking_type=networking_type,
-            networking_config=networking_config,
-            version=1,
-        )
-        _snapshot_environment_version(env)
+        try:
+            with transaction.atomic():
+                env = Environment.objects.create(
+                    user=request.user,
+                    name=req.name,
+                    packages=req.packages,
+                    env_vars=req.env_vars,
+                    setup_script=req.setup_script,
+                    networking_type=networking_type,
+                    networking_config=networking_config,
+                    version=1,
+                )
+                _snapshot_environment_version(env)
+        except IntegrityError:
+            return JsonResponse(
+                {"detail": f"An active environment named {req.name!r} already exists"},
+                status=409,
+            )
 
         with posthog.new_context():
             posthog.identify_context(str(request.user.id))
@@ -246,8 +254,15 @@ def environment_detail(request, environment_id):
 
         if changed:
             env.version += 1
-            env.save()
-            _snapshot_environment_version(env)
+            try:
+                with transaction.atomic():
+                    env.save()
+                    _snapshot_environment_version(env)
+            except IntegrityError:
+                return JsonResponse(
+                    {"detail": f"An active environment named {env.name!r} already exists"},
+                    status=409,
+                )
             with posthog.new_context():
                 posthog.identify_context(str(request.user.id))
                 posthog.capture(

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -412,6 +412,32 @@ class TestCreateEnvironment:
         )
         assert resp.status_code == 400
 
+    def test_create_duplicate_active_name(self, client: Client, auth_headers, environment):
+        resp = client.post(
+            "/environments",
+            data=json.dumps({"name": environment.name}),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 409
+        assert environment.name in resp.json()["detail"]
+        assert Environment.objects.filter(user=environment.user, name=environment.name).count() == 1
+
+    def test_create_reuses_archived_name(self, client: Client, auth_headers, environment):
+        from django.utils import timezone
+
+        environment.archived_at = timezone.now()
+        environment.save()
+
+        resp = client.post(
+            "/environments",
+            data=json.dumps({"name": environment.name}),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 201
+        assert resp.json()["name"] == environment.name
+
 
 @pytest.mark.django_db
 class TestListEnvironments:
@@ -548,6 +574,44 @@ class TestUpdateEnvironment:
         assert resp.status_code == 200
         assert resp.json()["version"] == 1
         assert not EnvironmentVersion.objects.filter(environment=environment, version=2).exists()
+
+    def test_update_rename_to_existing_active_name(self, client: Client, auth_headers, environment):
+        other = Environment.objects.create(user=environment.user, name="other-env", version=1)
+
+        resp = client.put(
+            f"/environments/{environment.id}",
+            data=json.dumps({"version": 1, "name": other.name}),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 409
+        assert other.name in resp.json()["detail"]
+
+        environment.refresh_from_db()
+        assert environment.name == "test-env"
+        assert environment.version == 1
+        assert not EnvironmentVersion.objects.filter(environment=environment, version=2).exists()
+
+    def test_update_rename_to_archived_name_succeeds(
+        self, client: Client, auth_headers, environment
+    ):
+        from django.utils import timezone
+
+        Environment.objects.create(
+            user=environment.user,
+            name="taken-then-archived",
+            version=1,
+            archived_at=timezone.now(),
+        )
+
+        resp = client.put(
+            f"/environments/{environment.id}",
+            data=json.dumps({"version": 1, "name": "taken-then-archived"}),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "taken-then-archived"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- `POST /environments` and `PUT /environments/{id}` now return **409** with a clear `detail` when a name collides with an existing active environment for the same user, instead of bubbling the `unique_active_environment_name` `IntegrityError` up as a 500 (seen in PostHog exception reporting).
- Both code paths run inside `transaction.atomic()` so the snapshot row in `environment_versions` only lands when the parent write commits.

## Test plan
- [x] `make test` (278 passed)
- [x] New unit tests cover: duplicate active name on create → 409, reusing an archived env's name on create → 201, rename collision with another active env → 409 (and the original row is unchanged), rename to a name only held by an archived env → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)