### PR TITLE
Accept github skill references, install via skills.sh CLI

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -609,9 +609,40 @@ components:
     Skill:
       type: object
       description: >
-        Opaque skill definition — shape depends on the runtime. Validated
-        server-side; see `agent_on_demand/runtimes.py`.
+        A skill definition. Two shapes are accepted; presence of `type`
+        discriminates:
+
+        Inline (default — omit `type`): {name, description, content}. The
+        full SKILL.md text is shipped in `content` and is written directly
+        onto the Sprite at `<runtime-skills-root>/<name>/SKILL.md`. Subject
+        to MAX_SKILL_CONTENT_BYTES.
+
+        GitHub reference (type: "github"): {type, name, description, source}.
+        `source` is `owner/repo`. At session-provision time the Sprite runs
+        `npx -y skills@latest add <source> --global --agent <runtime-agent>
+        --yes` (the [skills.sh](https://skills.sh) CLI) to materialize every
+        SKILL.md from the repo into the runtime-appropriate global path. For
+        `networking_type: "limited"` Environments, the allowed-hosts list
+        must include `registry.npmjs.org`, `github.com`, and
+        `codeload.github.com`.
       additionalProperties: true
+      properties:
+        type:
+          type: string
+          enum: [github]
+          description: Omit for inline skills; "github" for github references.
+        name:
+          type: string
+          description: Directory slug. Matches [a-z0-9][a-z0-9-]{0,63}.
+        description:
+          type: string
+          description: Up to 1024 chars.
+        content:
+          type: string
+          description: Inline SKILL.md text. Required for inline skills, ignored for github skills.
+        source:
+          type: string
+          description: GitHub "owner/repo". Required for github skills.
 
     Agent:
       type: object

--- a/src/agent_on_demand/runtimes/base.py
+++ b/src/agent_on_demand/runtimes/base.py
@@ -12,6 +12,7 @@ class Runtime(Protocol):
     name: str
     providers: set[str]  # which providers this runtime can serve; non-empty
     skills_root: str | None  # absolute path on Sprite for SKILL.md files, or None to disable
+    skills_sh_agent: str | None  # `--agent` id for `npx skills add`, or None if unsupported
 
     def install(self, sprite: Sprite) -> None:
         """Install the runtime CLI on the Sprite. No-op if pre-installed in the base image."""

--- a/src/agent_on_demand/runtimes/claude.py
+++ b/src/agent_on_demand/runtimes/claude.py
@@ -20,6 +20,7 @@ class ClaudeRuntime:
     name = "claude"
     providers: set[str] = {"anthropic"}
     skills_root: str | None = "/home/sprite/.claude/skills"
+    skills_sh_agent: str | None = "claude-code"
 
     def install(self, sprite: Sprite) -> None:
         return None

--- a/src/agent_on_demand/runtimes/codex.py
+++ b/src/agent_on_demand/runtimes/codex.py
@@ -14,6 +14,7 @@ class CodexRuntime:
     name = "codex"
     providers: set[str] = {"openai"}
     skills_root: str | None = "/home/sprite/.codex/skills"
+    skills_sh_agent: str | None = "codex"
 
     def install(self, sprite: Sprite) -> None:
         return None

--- a/src/agent_on_demand/runtimes/gemini.py
+++ b/src/agent_on_demand/runtimes/gemini.py
@@ -15,6 +15,7 @@ class GeminiRuntime:
     name = "gemini"
     providers: set[str] = {"google"}
     skills_root: str | None = "/home/sprite/.gemini/skills"
+    skills_sh_agent: str | None = "gemini-cli"
 
     def install(self, sprite: Sprite) -> None:
         return None

--- a/src/agent_on_demand/runtimes/opencode.py
+++ b/src/agent_on_demand/runtimes/opencode.py
@@ -30,6 +30,7 @@ class OpencodeRuntime:
     name = "opencode"
     providers: set[str] = {"anthropic", "openai", "google"}
     skills_root: str | None = "/home/sprite/.config/opencode/skills"
+    skills_sh_agent: str | None = "opencode"
 
     def install(self, sprite: Sprite) -> None:
         sprite.command("bash", "-lc", f"npm install -g opencode-ai@{OPENCODE_VERSION}").run()

--- a/src/agent_on_demand/session_service/provisioning.py
+++ b/src/agent_on_demand/session_service/provisioning.py
@@ -374,9 +374,12 @@ def _directories_for_post_script_writes(spec: SessionSpec) -> list[str]:
         elif spec.runtime.name == "opencode":
             dirs.append("/home/sprite/.config/opencode")
         # claude writes to /home/sprite/.claude.json (no mkdir).
-    if spec.skills and spec.runtime.skills_root:
+    if spec.runtime.skills_root:
+        # Only inline skills need a pre-created target dir; github skills are
+        # installed by `npx skills add`, which makes its own directories.
         for s in spec.skills:
-            dirs.append(f"{spec.runtime.skills_root}/{s.name}")
+            if s.content is not None:
+                dirs.append(f"{spec.runtime.skills_root}/{s.name}")
     return dirs
 
 
@@ -423,16 +426,39 @@ def _write_skills(
     spec: SessionSpec,
     session_id: str | None,
 ) -> None:
+    """Materialize skills onto the Sprite.
+
+    Inline skills are written directly with ``sprite.filesystem()``.
+    Github-source skills are installed via the
+    `skills.sh <https://skills.sh>`_ CLI (``npx -y skills@latest add ...``)
+    which the Sprite has network access for at this point in provisioning.
+
+    Runtimes whose ``skills_root`` is ``None`` skip inline writes; runtimes
+    without a ``skills_sh_agent`` skip github installs.
+    """
     if not spec.skills:
         return
-    root = spec.runtime.skills_root
-    if root is None:
-        return
+    inline = [s for s in spec.skills if s.content is not None]
+    github = [s for s in spec.skills if s.source is not None]
+
     with stage_timer(session_id, STAGE_SKILLS):
         try:
-            fs = sprite.filesystem()
-            for s in spec.skills:
-                dir_path = f"{root}/{s.name}"
-                (fs / f"{dir_path.lstrip('/')}/SKILL.md").write_text(s.content)
+            root = spec.runtime.skills_root
+            if inline and root is not None:
+                fs = sprite.filesystem()
+                for s in inline:
+                    dir_path = f"{root}/{s.name}"
+                    # mypy narrows: s.content was the filter predicate.
+                    assert s.content is not None
+                    (fs / f"{dir_path.lstrip('/')}/SKILL.md").write_text(s.content)
+            agent_id = spec.runtime.skills_sh_agent
+            if github and agent_id is not None:
+                for s in github:
+                    assert s.source is not None
+                    cmd = (
+                        f"npx -y skills@latest add {shlex.quote(s.source)} "
+                        f"--global --agent {shlex.quote(agent_id)} --yes"
+                    )
+                    sprite.command("bash", "-lc", cmd).run()
         except SpriteError as e:
             raise ProvisionError(f"Failed to write skills: {e}", stage=STAGE_SKILLS) from e

--- a/src/agent_on_demand/session_service/specs.py
+++ b/src/agent_on_demand/session_service/specs.py
@@ -33,14 +33,26 @@ class McpServerSpec:
 
 @dataclass(frozen=True)
 class SkillSpec:
-    """A SKILL.md file to materialize onto the Sprite filesystem.
+    """A skill to materialize on the Sprite.
 
-    `content` is the full SKILL.md text including YAML frontmatter. `name`
-    is the directory slug, validated upstream to match [a-z0-9][a-z0-9-]{0,63}.
+    Exactly one of ``content`` / ``source`` is set:
+
+    - inline: ``content`` carries the full SKILL.md text (including YAML
+      frontmatter). Written directly to ``<skills_root>/<name>/SKILL.md``.
+    - github: ``source`` is an ``owner/repo`` identifier. Installed on the
+      Sprite during provisioning by invoking the
+      `skills.sh <https://skills.sh>`_ CLI
+      (``npx -y skills@latest add <source> -g -a <runtime-agent> -y``),
+      which handles discovery, symlinking and per-agent path layout.
+
+    ``name`` is the directory slug for inline skills, and a display/dedup
+    identifier for github skills (it is not passed to the skills.sh CLI —
+    the CLI discovers skill names from the repo itself).
     """
 
     name: str
-    content: str
+    content: str | None = None
+    source: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -218,7 +218,10 @@ def _build_spec_for_session(session: AgentSession) -> SessionSpec:
                 )
             )
         for s in agent.skills or []:
-            skills.append(SkillSpec(name=s["name"], content=s["content"]))
+            if s.get("type") == "github":
+                skills.append(SkillSpec(name=s["name"], source=s["source"]))
+            else:
+                skills.append(SkillSpec(name=s["name"], content=s["content"]))
 
     repos = [
         RepoSpec(url=r.url, mount_path=r.mount_path, token=r.get_token())

--- a/src/agent_on_demand/views/agents.py
+++ b/src/agent_on_demand/views/agents.py
@@ -36,8 +36,59 @@ MAX_SKILL_DESCRIPTION_LEN = 1024
 MAX_SKILL_CONTENT_BYTES = 64 * 1024
 
 _SKILL_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
-_SKILL_ALLOWED_KEYS = {"name", "description", "content"}
+# `owner/repo` — same character class GitHub allows for both segments.
+_GITHUB_SOURCE_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
+
+# Two skill shapes:
+#   inline: {name, description, content}          ← content shipped in-band
+#   github: {type: "github", name, description, source}
+#                                                 ← installed on the Sprite at
+#                                                   provision time via the
+#                                                   skills.sh CLI
+#                                                   (`npx skills add ...`).
+# Detection: presence of `type` field. Inline shape omits it.
+_INLINE_SKILL_KEYS = {"name", "description", "content"}
+_GITHUB_SKILL_KEYS = {"type", "name", "description", "source"}
+_GITHUB_REQUIRED_KEYS = {"type", "name", "description", "source"}
+
 _SKILL_HEREDOC_DELIMITER = "SKILL_EOF"
+
+
+def _validate_skill_inline(skill: dict, i: int) -> None:
+    extra = set(skill) - _INLINE_SKILL_KEYS
+    if extra:
+        raise ValueError(
+            f"skills[{i}]: unknown keys {sorted(extra)!r}. "
+            f"Allowed for inline skills: {sorted(_INLINE_SKILL_KEYS)}"
+        )
+    for field_name in ("name", "description", "content"):
+        if field_name not in skill:
+            raise ValueError(f"skills[{i}] missing required field: {field_name}")
+        if not isinstance(skill[field_name], str):
+            raise ValueError(f"skills[{i}].{field_name} must be a string")
+    content = skill["content"]
+    if len(content.encode("utf-8")) > MAX_SKILL_CONTENT_BYTES:
+        raise ValueError(f"skills[{i}].content exceeds {MAX_SKILL_CONTENT_BYTES} bytes")
+    if _SKILL_HEREDOC_DELIMITER in content:
+        raise ValueError(f"skills[{i}].content must not contain {_SKILL_HEREDOC_DELIMITER!r}")
+
+
+def _validate_skill_github(skill: dict, i: int) -> None:
+    extra = set(skill) - _GITHUB_SKILL_KEYS
+    if extra:
+        raise ValueError(
+            f"skills[{i}]: unknown keys {sorted(extra)!r}. "
+            f"Allowed for github skills: {sorted(_GITHUB_SKILL_KEYS)}"
+        )
+    for field_name in _GITHUB_REQUIRED_KEYS:
+        if field_name not in skill:
+            raise ValueError(f"skills[{i}] missing required field: {field_name}")
+        if not isinstance(skill[field_name], str):
+            raise ValueError(f"skills[{i}].{field_name} must be a string")
+    if skill["type"] != "github":
+        raise ValueError(f"skills[{i}].type {skill['type']!r} unsupported (only 'github')")
+    if not _GITHUB_SOURCE_RE.match(skill["source"]):
+        raise ValueError(f"skills[{i}].source {skill['source']!r} must be 'owner/repo'")
 
 
 def _validate_skills(skills: list) -> list:
@@ -48,18 +99,13 @@ def _validate_skills(skills: list) -> list:
         if not isinstance(skill, dict):
             raise ValueError(f"skills[{i}] must be an object")
 
-        extra = set(skill) - _SKILL_ALLOWED_KEYS
-        if extra:
-            raise ValueError(
-                f"skills[{i}]: unknown keys {sorted(extra)!r}. "
-                f"Allowed: {sorted(_SKILL_ALLOWED_KEYS)}"
-            )
-        for field_name in ("name", "description", "content"):
-            if field_name not in skill:
-                raise ValueError(f"skills[{i}] missing required field: {field_name}")
-            if not isinstance(skill[field_name], str):
-                raise ValueError(f"skills[{i}].{field_name} must be a string")
+        # Discriminate by presence of `type`. Inline skills omit it.
+        if "type" in skill:
+            _validate_skill_github(skill, i)
+        else:
+            _validate_skill_inline(skill, i)
 
+        # Common per-skill checks (name + description) regardless of type.
         name = skill["name"]
         if not _SKILL_NAME_RE.match(name):
             raise ValueError(f"skills[{i}].name {name!r} must match [a-z0-9][a-z0-9-]{{0,63}}")
@@ -69,12 +115,6 @@ def _validate_skills(skills: list) -> list:
 
         if len(skill["description"]) > MAX_SKILL_DESCRIPTION_LEN:
             raise ValueError(f"skills[{i}].description exceeds {MAX_SKILL_DESCRIPTION_LEN} chars")
-
-        content = skill["content"]
-        if len(content.encode("utf-8")) > MAX_SKILL_CONTENT_BYTES:
-            raise ValueError(f"skills[{i}].content exceeds {MAX_SKILL_CONTENT_BYTES} bytes")
-        if _SKILL_HEREDOC_DELIMITER in content:
-            raise ValueError(f"skills[{i}].content must not contain {_SKILL_HEREDOC_DELIMITER!r}")
     return skills
 
 

--- a/tests/test_runtime_protocol.py
+++ b/tests/test_runtime_protocol.py
@@ -40,7 +40,7 @@ def test_stub_satisfies_runtime_protocol():
 
 
 def test_runtime_protocol_has_required_annotations():
-    required_attrs = {"name", "providers", "skills_root"}
+    required_attrs = {"name", "providers", "skills_root", "skills_sh_agent"}
     annotations = Runtime.__annotations__
     assert required_attrs == set(annotations.keys())
 

--- a/tests/test_runtimes.py
+++ b/tests/test_runtimes.py
@@ -21,7 +21,7 @@ def test_every_runtime_implements_the_protocol():
     """Runtime is a Protocol — instances don't inherit from it, but must
     still expose `name`, `providers`, `skills_root`, `install`, `build_command`,
     and `write_config`."""
-    required_attrs = ("name", "providers", "skills_root")
+    required_attrs = ("name", "providers", "skills_root", "skills_sh_agent")
     required_methods = ("install", "build_command", "write_config")
     for runtime in RUNTIMES.values():
         for attr in required_attrs:

--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -24,6 +24,7 @@ from agent_on_demand.session_service import (
     SessionSpec,
     provision_session,
 )
+from agent_on_demand.session_service.specs import SkillSpec
 
 
 @pytest.fixture
@@ -230,3 +231,102 @@ class TestProvisionSessionEnvFileShape:
         b_idx = next(i for i, line in enumerate(lines) if line.startswith("B_SECOND="))
         assert a_idx < b_idx
         assert "'one with space'" in lines[a_idx]
+
+
+class TestProvisionSkills:
+    """_write_skills materializes both inline and github skills on the Sprite.
+
+    Inline skills are written verbatim to
+    `<skills_root>/<name>/SKILL.md`. Github skills shell out to
+    `npx -y skills@latest add <source> --global --agent <runtime-agent> --yes`
+    — the `skills.sh <https://skills.sh>`_ CLI handles discovery + install.
+    """
+
+    SAMPLE_CONTENT = "---\nname: inline-skill\ndescription: Local inline skill.\n---\n\nBody.\n"
+
+    def test_inline_skill_written_to_runtime_skills_root(self, user, fake_sprites):
+        spec = _spec(
+            user,
+            skills=[SkillSpec(name="inline-skill", content=self.SAMPLE_CONTENT)],
+        )
+        provision_session(user, spec)
+        writes = fake_sprites.last_sprite().write_map()
+        assert writes["/home/sprite/.claude/skills/inline-skill/SKILL.md"] == self.SAMPLE_CONTENT
+
+    def test_github_skill_invokes_skills_sh_cli(self, user, fake_sprites):
+        spec = _spec(
+            user,
+            skills=[SkillSpec(name="aod", source="ravi-hq/agent-on-demand")],
+        )
+        provision_session(user, spec)
+        shell_lines = fake_sprites.last_sprite().shell_strings()
+        assert any(
+            "npx -y skills@latest add ravi-hq/agent-on-demand "
+            "--global --agent claude-code --yes" in line
+            for line in shell_lines
+        ), f"no skills.sh install command recorded; got: {shell_lines!r}"
+
+    @pytest.mark.parametrize(
+        "runtime_name,expected_agent",
+        [
+            ("claude", "claude-code"),
+            ("codex", "codex"),
+            ("gemini", "gemini-cli"),
+            ("opencode", "opencode"),
+        ],
+    )
+    def test_github_skill_uses_runtime_specific_agent_identifier(
+        self, user, fake_sprites, runtime_name, expected_agent
+    ):
+        # _write_skills only reads `runtime.skills_sh_agent` and the skill
+        # source; no credentials or env setup are needed, so call it directly
+        # instead of running full provision_session.
+        from agent_on_demand.session_service.provisioning import _write_skills
+        from tests.fakes.sprite import RecordingSprite
+
+        sprite = RecordingSprite("s")
+        spec = _spec(
+            user,
+            runtime=RUNTIMES[runtime_name],
+            skills=[SkillSpec(name="aod", source="ravi-hq/agent-on-demand")],
+        )
+        _write_skills(sprite, spec, session_id=None)
+        shell_lines = sprite.shell_strings()
+        assert any(f"--agent {expected_agent} --yes" in line for line in shell_lines), shell_lines
+
+    def test_github_skill_source_is_shell_quoted(self, user, fake_sprites):
+        # `source` is validated to be owner/repo, so no shell metacharacters
+        # can sneak in — but the call site still quotes it for defense in
+        # depth. Assert that no command substitutions appear in the output.
+        spec = _spec(
+            user,
+            skills=[SkillSpec(name="aod", source="ravi-hq/agent-on-demand")],
+        )
+        provision_session(user, spec)
+        for line in fake_sprites.last_sprite().shell_strings():
+            assert "`" not in line
+            assert "$(" not in line
+
+    def test_mixed_inline_and_github_skills(self, user, fake_sprites):
+        spec = _spec(
+            user,
+            skills=[
+                SkillSpec(name="inline-skill", content=self.SAMPLE_CONTENT),
+                SkillSpec(name="from-gh", source="ravi-hq/agent-on-demand"),
+            ],
+        )
+        provision_session(user, spec)
+        sprite = fake_sprites.last_sprite()
+        assert (
+            sprite.write_map()["/home/sprite/.claude/skills/inline-skill/SKILL.md"]
+            == self.SAMPLE_CONTENT
+        )
+        assert any(
+            "npx -y skills@latest add ravi-hq/agent-on-demand" in line
+            for line in sprite.shell_strings()
+        )
+
+    def test_no_skills_no_install_command(self, user, fake_sprites):
+        provision_session(user, _spec(user, skills=[]))
+        shell_lines = fake_sprites.last_sprite().shell_strings()
+        assert not any("npx -y skills@latest add" in line for line in shell_lines)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -227,3 +227,100 @@ class TestUpdateAgentSkills:
             **auth_headers,
         )
         assert resp.status_code == 422
+
+
+def _github_skill(
+    name: str = "aod-sdk-python",
+    source: str = "ravi-hq/agent-on-demand",
+) -> dict:
+    return {
+        "type": "github",
+        "name": name,
+        "description": "Install aod-sdk-python skill from the AoD repo.",
+        "source": source,
+    }
+
+
+@pytest.mark.django_db
+class TestGithubSkillValidation:
+    """Validation for the github skill reference shape.
+
+    Github references are installed on the Sprite at provision time via the
+    skills.sh CLI (`npx skills add <source> -g -a <runtime-agent> -y`), so
+    the API only needs to validate the shape — not resolve any content.
+    """
+
+    def _post(self, client, auth_headers, skills):
+        return client.post(
+            "/agents",
+            data=json.dumps(
+                {
+                    "name": "GH Agent",
+                    "model": "anthropic/claude-sonnet-4-6",
+                    "runtime": "claude",
+                    "skills": skills,
+                }
+            ),
+            content_type="application/json",
+            **auth_headers,
+        )
+
+    def test_create_with_github_skill(self, client: Client, auth_headers):
+        resp = self._post(client, auth_headers, [_github_skill()])
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["skills"] == [_github_skill()]
+
+    def test_inline_and_github_skill_together(self, client: Client, auth_headers):
+        resp = self._post(client, auth_headers, [_skill(), _github_skill()])
+        assert resp.status_code == 201
+        assert len(resp.json()["skills"]) == 2
+
+    def test_rejects_unknown_type(self, client: Client, auth_headers):
+        skill = _github_skill()
+        skill["type"] = "gitlab"
+        resp = self._post(client, auth_headers, [skill])
+        assert resp.status_code == 422
+        assert "github" in str(resp.json()["detail"]).lower()
+
+    def test_missing_source(self, client: Client, auth_headers):
+        skill = _github_skill()
+        del skill["source"]
+        resp = self._post(client, auth_headers, [skill])
+        assert resp.status_code == 422
+        assert "source" in str(resp.json()["detail"]).lower()
+
+    def test_invalid_source_format(self, client: Client, auth_headers):
+        skill = _github_skill(source="not-a-valid-source")
+        resp = self._post(client, auth_headers, [skill])
+        assert resp.status_code == 422
+        assert "owner/repo" in str(resp.json()["detail"])
+
+    def test_rejects_content_field(self, client: Client, auth_headers):
+        skill = _github_skill()
+        skill["content"] = "body"
+        resp = self._post(client, auth_headers, [skill])
+        assert resp.status_code == 422
+        assert "unknown" in str(resp.json()["detail"]).lower()
+
+    def test_rejects_ref_field_in_v1(self, client: Client, auth_headers):
+        # v1 does not support ref pinning — the skills.sh shorthand doesn't
+        # either. Accepting `ref` silently would mislead callers.
+        skill = _github_skill()
+        skill["ref"] = "main"
+        resp = self._post(client, auth_headers, [skill])
+        assert resp.status_code == 422
+        assert "unknown" in str(resp.json()["detail"]).lower()
+
+    def test_name_still_validated(self, client: Client, auth_headers):
+        skill = _github_skill(name="Bad Name")
+        resp = self._post(client, auth_headers, [skill])
+        assert resp.status_code == 422
+
+    def test_duplicate_names_across_shapes(self, client: Client, auth_headers):
+        # Name is the dedup key regardless of inline vs github shape.
+        inline = _skill(name="shared")
+        github = _github_skill(name="shared")
+        resp = self._post(client, auth_headers, [inline, github])
+        assert resp.status_code == 422
+        assert "duplicate" in str(resp.json()["detail"]).lower()


### PR DESCRIPTION
## Summary
- Add a second skill shape (`{type: "github", name, description, source}`) to agent create/update, alongside the existing inline shape.
- At session provision time, install github skills by shelling out to the skills.sh CLI: `npx -y skills@latest add <source> --global --agent <runtime-agent> --yes`.
- Add `skills_sh_agent` to each runtime (claude→`claude-code`, codex→`codex`, gemini→`gemini-cli`, opencode→`opencode`) so installs land at each runtime's canonical user-level path.

## Why
Nebula (and other callers) want to reference curated skills by repo without copying content into every agent. Delegating install to skills.sh means we get the canonical ecosystem layout for free — and we don't have to re-implement discovery, per-agent path routing, or symlinking.

## v1 limits
- Public repos only.
- No ref pinning (the skills.sh shorthand doesn't support it; we reject `ref` up front rather than silently ignoring it).
- For Environments with `networking_type: "limited"`, the allowed-hosts list must include `registry.npmjs.org`, `github.com`, and `codeload.github.com`.

## Test plan
- [x] `make lint` / `ruff format --check` pass
- [x] `make typecheck` (mypy) passes — 44 files
- [x] `make test` (SQLite) passes — 296 passed
- [x] New shape validation in `tests/test_skills.py::TestGithubSkillValidation`
- [x] Provisioning materialization in `tests/test_session_service.py::TestProvisionSkills` (parametrized across all four runtimes)
- [ ] Manual smoke: create an agent with a github skill, launch a session on each runtime, confirm `npx skills add` runs and the expected path contains SKILL.md files
- [ ] Optional: extend `tests/e2e/test_skills.py` to cover the github shape once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)