### PR TITLE
Pass --skill <name> to skills.sh; allow github refs without a name

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -615,15 +615,16 @@ components:
         Inline (default — omit `type`): {name, description, content}. The
         full SKILL.md text is shipped in `content` and is written directly
         onto the Sprite at `<runtime-skills-root>/<name>/SKILL.md`. Subject
-        to MAX_SKILL_CONTENT_BYTES.
+        to MAX_SKILL_CONTENT_BYTES. `name` is required.
 
-        GitHub reference (type: "github"): {type, name, description, source}.
+        GitHub reference (type: "github"): {type, description, source, name?}.
         `source` is `owner/repo`. At session-provision time the Sprite runs
         `npx -y skills@latest add <source> --global --agent <runtime-agent>
-        --yes` (the [skills.sh](https://skills.sh) CLI) to materialize every
-        SKILL.md from the repo into the runtime-appropriate global path. For
-        `networking_type: "limited"` Environments, the allowed-hosts list
-        must include `registry.npmjs.org`, `github.com`, and
+        --yes` (the [skills.sh](https://skills.sh) CLI). When `name` is set,
+        `--skill <name>` is appended so only that one SKILL.md from the repo
+        is installed; omit `name` to install every skill the repo exposes.
+        For `networking_type: "limited"` Environments, the allowed-hosts
+        list must include `registry.npmjs.org`, `github.com`, and
         `codeload.github.com`.
       additionalProperties: true
       properties:
@@ -633,7 +634,11 @@ components:
           description: Omit for inline skills; "github" for github references.
         name:
           type: string
-          description: Directory slug. Matches [a-z0-9][a-z0-9-]{0,63}.
+          description: >
+            Directory slug. Matches [a-z0-9][a-z0-9-]{0,63}. Required for
+            inline skills. Optional for github skills — present means
+            "install only this skill from the repo"; absent means "install
+            every skill the repo exposes".
         description:
           type: string
           description: Up to 1024 chars.

--- a/src/agent_on_demand/session_service/provisioning.py
+++ b/src/agent_on_demand/session_service/provisioning.py
@@ -379,6 +379,8 @@ def _directories_for_post_script_writes(spec: SessionSpec) -> list[str]:
         # installed by `npx skills add`, which makes its own directories.
         for s in spec.skills:
             if s.content is not None:
+                # Inline skills always carry a name (validator enforces it).
+                assert s.name is not None
                 dirs.append(f"{spec.runtime.skills_root}/{s.name}")
     return dirs
 
@@ -447,9 +449,10 @@ def _write_skills(
             if inline and root is not None:
                 fs = sprite.filesystem()
                 for s in inline:
-                    dir_path = f"{root}/{s.name}"
-                    # mypy narrows: s.content was the filter predicate.
+                    # Inline skills must have a name (validated upstream).
+                    assert s.name is not None
                     assert s.content is not None
+                    dir_path = f"{root}/{s.name}"
                     (fs / f"{dir_path.lstrip('/')}/SKILL.md").write_text(s.content)
             agent_id = spec.runtime.skills_sh_agent
             if github and agent_id is not None:
@@ -459,6 +462,10 @@ def _write_skills(
                         f"npx -y skills@latest add {shlex.quote(s.source)} "
                         f"--global --agent {shlex.quote(agent_id)} --yes"
                     )
+                    if s.name:
+                        # Pin to a single skill from the repo. Without --skill,
+                        # the CLI installs every SKILL.md it finds.
+                        cmd += f" --skill {shlex.quote(s.name)}"
                     sprite.command("bash", "-lc", cmd).run()
         except SpriteError as e:
             raise ProvisionError(f"Failed to write skills: {e}", stage=STAGE_SKILLS) from e

--- a/src/agent_on_demand/session_service/specs.py
+++ b/src/agent_on_demand/session_service/specs.py
@@ -38,19 +38,18 @@ class SkillSpec:
     Exactly one of ``content`` / ``source`` is set:
 
     - inline: ``content`` carries the full SKILL.md text (including YAML
-      frontmatter). Written directly to ``<skills_root>/<name>/SKILL.md``.
+      frontmatter). Written directly to ``<skills_root>/<name>/SKILL.md`` —
+      ``name`` is required for this shape.
     - github: ``source`` is an ``owner/repo`` identifier. Installed on the
       Sprite during provisioning by invoking the
       `skills.sh <https://skills.sh>`_ CLI
-      (``npx -y skills@latest add <source> -g -a <runtime-agent> -y``),
-      which handles discovery, symlinking and per-agent path layout.
-
-    ``name`` is the directory slug for inline skills, and a display/dedup
-    identifier for github skills (it is not passed to the skills.sh CLI —
-    the CLI discovers skill names from the repo itself).
+      (``npx -y skills@latest add <source> -g -a <runtime-agent> -y``).
+      ``name`` is optional: when set, it is forwarded to the CLI as
+      ``--skill <name>`` to install a single SKILL.md from the repo; when
+      omitted, every skill in the repo is installed.
     """
 
-    name: str
+    name: str | None = None
     content: str | None = None
     source: str | None = None
 

--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -219,7 +219,9 @@ def _build_spec_for_session(session: AgentSession) -> SessionSpec:
             )
         for s in agent.skills or []:
             if s.get("type") == "github":
-                skills.append(SkillSpec(name=s["name"], source=s["source"]))
+                # name is optional for github refs (omit → install all skills
+                # from the repo); pass it through verbatim, including absent.
+                skills.append(SkillSpec(name=s.get("name"), source=s["source"]))
             else:
                 skills.append(SkillSpec(name=s["name"], content=s["content"]))
 

--- a/src/agent_on_demand/views/agents.py
+++ b/src/agent_on_demand/views/agents.py
@@ -41,15 +41,20 @@ _GITHUB_SOURCE_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
 
 # Two skill shapes:
 #   inline: {name, description, content}          ← content shipped in-band
-#   github: {type: "github", name, description, source}
+#   github: {type: "github", description, source, name?}
 #                                                 ← installed on the Sprite at
 #                                                   provision time via the
 #                                                   skills.sh CLI
 #                                                   (`npx skills add ...`).
+#                                                   `name` selects a single skill
+#                                                   from the repo via the CLI's
+#                                                   `--skill` flag; omit it to
+#                                                   install every SKILL.md the
+#                                                   repo exposes.
 # Detection: presence of `type` field. Inline shape omits it.
 _INLINE_SKILL_KEYS = {"name", "description", "content"}
 _GITHUB_SKILL_KEYS = {"type", "name", "description", "source"}
-_GITHUB_REQUIRED_KEYS = {"type", "name", "description", "source"}
+_GITHUB_REQUIRED_KEYS = {"type", "description", "source"}
 
 _SKILL_HEREDOC_DELIMITER = "SKILL_EOF"
 
@@ -85,6 +90,9 @@ def _validate_skill_github(skill: dict, i: int) -> None:
             raise ValueError(f"skills[{i}] missing required field: {field_name}")
         if not isinstance(skill[field_name], str):
             raise ValueError(f"skills[{i}].{field_name} must be a string")
+    # `name` is optional for github; if present, must still be a string.
+    if "name" in skill and not isinstance(skill["name"], str):
+        raise ValueError(f"skills[{i}].name must be a string")
     if skill["type"] != "github":
         raise ValueError(f"skills[{i}].type {skill['type']!r} unsupported (only 'github')")
     if not _GITHUB_SOURCE_RE.match(skill["source"]):
@@ -94,24 +102,36 @@ def _validate_skill_github(skill: dict, i: int) -> None:
 def _validate_skills(skills: list) -> list:
     if len(skills) > MAX_SKILLS_PER_AGENT:
         raise ValueError(f"Maximum {MAX_SKILLS_PER_AGENT} skills per agent")
-    seen_names: set[str] = set()
+    seen_dedup_keys: set[str] = set()
     for i, skill in enumerate(skills):
         if not isinstance(skill, dict):
             raise ValueError(f"skills[{i}] must be an object")
 
         # Discriminate by presence of `type`. Inline skills omit it.
-        if "type" in skill:
+        is_github = "type" in skill
+        if is_github:
             _validate_skill_github(skill, i)
         else:
             _validate_skill_inline(skill, i)
 
-        # Common per-skill checks (name + description) regardless of type.
-        name = skill["name"]
-        if not _SKILL_NAME_RE.match(name):
-            raise ValueError(f"skills[{i}].name {name!r} must match [a-z0-9][a-z0-9-]{{0,63}}")
-        if name in seen_names:
-            raise ValueError(f"skills[{i}]: duplicate name {name!r}")
-        seen_names.add(name)
+        # Name regex applies whenever `name` is present. Github skills may
+        # omit it (means: install every SKILL.md from the repo); inline
+        # validation above already required it.
+        if "name" in skill:
+            name = skill["name"]
+            if not _SKILL_NAME_RE.match(name):
+                raise ValueError(f"skills[{i}].name {name!r} must match [a-z0-9][a-z0-9-]{{0,63}}")
+            dedup_key = name
+        else:
+            # Whole-repo github install. Dedup on source so two "all skills
+            # from owner/repo" entries collide, but a per-skill entry from
+            # the same source can coexist (different dedup key).
+            dedup_key = f"@github:{skill['source']}"
+
+        if dedup_key in seen_dedup_keys:
+            label = "name" if "name" in skill else "source"
+            raise ValueError(f"skills[{i}]: duplicate {label} {dedup_key!r}")
+        seen_dedup_keys.add(dedup_key)
 
         if len(skill["description"]) > MAX_SKILL_DESCRIPTION_LEN:
             raise ValueError(f"skills[{i}].description exceeds {MAX_SKILL_DESCRIPTION_LEN} chars")

--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -253,18 +253,36 @@ class TestProvisionSkills:
         writes = fake_sprites.last_sprite().write_map()
         assert writes["/home/sprite/.claude/skills/inline-skill/SKILL.md"] == self.SAMPLE_CONTENT
 
-    def test_github_skill_invokes_skills_sh_cli(self, user, fake_sprites):
+    def test_github_skill_invokes_skills_sh_cli_with_skill_flag(self, user, fake_sprites):
         spec = _spec(
             user,
-            skills=[SkillSpec(name="aod", source="ravi-hq/agent-on-demand")],
+            skills=[SkillSpec(name="aod-sdk-python", source="ravi-hq/agent-on-demand")],
         )
         provision_session(user, spec)
         shell_lines = fake_sprites.last_sprite().shell_strings()
+        # When a name is provided we MUST pass --skill so only that one
+        # SKILL.md from the repo is installed (not every skill in the repo).
         assert any(
             "npx -y skills@latest add ravi-hq/agent-on-demand "
-            "--global --agent claude-code --yes" in line
+            "--global --agent claude-code --yes --skill aod-sdk-python" in line
             for line in shell_lines
         ), f"no skills.sh install command recorded; got: {shell_lines!r}"
+
+    def test_github_skill_without_name_installs_whole_repo(self, user, fake_sprites):
+        # Omitting `name` is the explicit signal "install every skill from
+        # this repo" — no `--skill` flag should appear.
+        spec = _spec(
+            user,
+            skills=[SkillSpec(source="ravi-hq/agent-on-demand")],
+        )
+        provision_session(user, spec)
+        shell_lines = fake_sprites.last_sprite().shell_strings()
+        install_lines = [line for line in shell_lines if "npx -y skills@latest add" in line]
+        assert len(install_lines) == 1, install_lines
+        assert "--skill" not in install_lines[0]
+        assert (
+            "npx -y skills@latest add ravi-hq/agent-on-demand --global --agent claude-code --yes"
+        ) in install_lines[0]
 
     @pytest.mark.parametrize(
         "runtime_name,expected_agent",

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -230,15 +230,17 @@ class TestUpdateAgentSkills:
 
 
 def _github_skill(
-    name: str = "aod-sdk-python",
+    name: str | None = "aod-sdk-python",
     source: str = "ravi-hq/agent-on-demand",
 ) -> dict:
-    return {
+    payload: dict = {
         "type": "github",
-        "name": name,
         "description": "Install aod-sdk-python skill from the AoD repo.",
         "source": source,
     }
+    if name is not None:
+        payload["name"] = name
+    return payload
 
 
 @pytest.mark.django_db
@@ -324,3 +326,30 @@ class TestGithubSkillValidation:
         resp = self._post(client, auth_headers, [inline, github])
         assert resp.status_code == 422
         assert "duplicate" in str(resp.json()["detail"]).lower()
+
+    def test_github_skill_without_name_is_accepted(self, client: Client, auth_headers):
+        # Omitting name == "install every SKILL.md from the repo".
+        resp = self._post(client, auth_headers, [_github_skill(name=None)])
+        assert resp.status_code == 201, resp.json()
+        assert resp.json()["skills"][0] == {
+            "type": "github",
+            "description": "Install aod-sdk-python skill from the AoD repo.",
+            "source": "ravi-hq/agent-on-demand",
+        }
+
+    def test_two_whole_repo_entries_for_same_source_collide(self, client: Client, auth_headers):
+        skill = _github_skill(name=None)
+        resp = self._post(client, auth_headers, [skill, skill])
+        assert resp.status_code == 422
+        assert "duplicate" in str(resp.json()["detail"]).lower()
+
+    def test_named_and_whole_repo_entries_for_same_source_coexist(
+        self, client: Client, auth_headers
+    ):
+        # `--skill foo` install and a `--all from same repo` install have
+        # different dedup keys; both should be accepted on one agent.
+        named = _github_skill(name="aod-sdk-python")
+        whole = _github_skill(name=None)
+        resp = self._post(client, auth_headers, [named, whole])
+        assert resp.status_code == 201, resp.json()
+        assert len(resp.json()["skills"]) == 2


### PR DESCRIPTION
## Summary
- Forward `--skill <name>` to `npx skills add` when a github ref has a name, so only that one SKILL.md lands on the Sprite (today every skill in the repo gets installed).
- Make `name` optional on the github skill shape — omitting it is now the explicit "install every skill from this repo" signal.
- Dedup keys on `name` when present, else on `@github:<source>`, so two whole-repo entries for the same source still collide while a per-skill entry can coexist with a whole-repo entry from the same source.

## Why
ravi-hq/nebula reported a `ravi-hq/deepthink-skills` + `name: "think"` ref pulled in the whole skill bundle. The CLI is doing what we asked; we just need to ask for less.

## Test plan
- [x] `make lint` / `ruff format --check` clean
- [x] `make typecheck` clean (44 source files)
- [x] `make test` (SQLite) — 300 passing
- [x] New tests cover: `--skill` appended when name set, no `--skill` when name omitted, validator accepts shape without name, two whole-repo entries collide, named + whole-repo for same source coexist
- [ ] Manual: re-publish the deepthink-skills agent in nebula, launch a session, confirm only `~/.claude/skills/think/SKILL.md` exists (not the whole repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)