### PR TITLE
Handle deleted-session race in session worker tasks

### DIFF
--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -331,9 +331,7 @@ def _execute_turn_inner(
         )
         turn = SessionTurn.objects.get(pk=turn_id)
     except (AgentSession.DoesNotExist, SessionTurn.DoesNotExist):
-        logger.info(
-            "execute_turn: session=%s turn=%s gone, skipping", session_id, turn_id
-        )
+        logger.info("execute_turn: session=%s turn=%s gone, skipping", session_id, turn_id)
         return
     spec = _build_spec_for_session(session)
 
@@ -494,9 +492,7 @@ def _execute_turn_body(session, turn, spec, sprite, prompt, mode, timeout, span)
     except AgentSession.DoesNotExist:
         # Session was deleted mid-turn (e.g. client raced terminate + delete).
         # Turn + logs were cascade-deleted alongside it; nothing left to write.
-        logger.info(
-            "execute_turn: session %s deleted mid-turn, skipping finalization", session.id
-        )
+        logger.info("execute_turn: session %s deleted mid-turn, skipping finalization", session.id)
         return
     if session.status != "terminated":
         session.status = final_status

--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -161,7 +161,13 @@ def _provision_session_inner(
     mode: str,
     timeout: float,
 ) -> None:
-    session = AgentSession.objects.select_related("user", "agent", "environment").get(pk=session_id)
+    try:
+        session = AgentSession.objects.select_related("user", "agent", "environment").get(
+            pk=session_id
+        )
+    except AgentSession.DoesNotExist:
+        logger.info("provision_session_task: session %s gone, skipping", session_id)
+        return
     # If the client terminated before the worker picked this up, skip.
     if session.status == "terminated":
         return
@@ -319,8 +325,16 @@ def _execute_turn_inner(
     mode: str,
     timeout: float,
 ) -> None:
-    session = AgentSession.objects.select_related("user", "agent", "environment").get(pk=session_id)
-    turn = SessionTurn.objects.get(pk=turn_id)
+    try:
+        session = AgentSession.objects.select_related("user", "agent", "environment").get(
+            pk=session_id
+        )
+        turn = SessionTurn.objects.get(pk=turn_id)
+    except (AgentSession.DoesNotExist, SessionTurn.DoesNotExist):
+        logger.info(
+            "execute_turn: session=%s turn=%s gone, skipping", session_id, turn_id
+        )
+        return
     spec = _build_spec_for_session(session)
 
     tracer = get_tracer()
@@ -475,7 +489,15 @@ def _execute_turn_body(session, turn, spec, sprite, prompt, mode, timeout, span)
         exit_code = None
 
     ended = timezone.now()
-    session.refresh_from_db(fields=["status"])
+    try:
+        session.refresh_from_db(fields=["status"])
+    except AgentSession.DoesNotExist:
+        # Session was deleted mid-turn (e.g. client raced terminate + delete).
+        # Turn + logs were cascade-deleted alongside it; nothing left to write.
+        logger.info(
+            "execute_turn: session %s deleted mid-turn, skipping finalization", session.id
+        )
+        return
     if session.status != "terminated":
         session.status = final_status
         session.exit_code = exit_code

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -370,6 +370,92 @@ def test_provision_task_skips_if_session_terminated(provision_user, fake_sprites
 
 
 @pytest.mark.django_db
+def test_provision_task_skips_if_session_deleted(provision_user, fake_sprites, mocker):
+    """Race: user calls DELETE /sessions on a pending session after the
+    view enqueued provision_session_task but before the worker picks it up.
+    The task must swallow AgentSession.DoesNotExist and return cleanly."""
+    session, turn = _make_pending_session(provision_user)
+    session_id = str(session.id)
+    turn_id = turn.id
+    mocker.patch("agent_on_demand.session_service.tasks.destroy_session_task.defer")
+    session.delete()  # cascades to turn + logs
+    defer_spy = mocker.patch("agent_on_demand.session_service.tasks.execute_turn.defer")
+
+    # Does not raise.
+    provision_session_task(
+        session_id=session_id,
+        turn_id=turn_id,
+        prompt="hi",
+        mode="run",
+        timeout=10.0,
+    )
+
+    assert fake_sprites.created == []
+    assert defer_spy.call_count == 0
+
+
+@pytest.mark.django_db
+def test_execute_turn_skips_if_session_deleted(user, mocker):
+    """Race: DELETE /sessions fires between POST /prompt enqueueing execute_turn
+    and the worker picking it up. The task must no-op rather than raise."""
+    session, turn = _make_session_and_turn(user)
+    session_id = str(session.id)
+    turn_id = turn.id
+    mocker.patch("agent_on_demand.session_service.tasks.destroy_session_task.defer")
+    session.delete()
+    resume_spy = mocker.patch("agent_on_demand.session_service.tasks.resume_session")
+
+    # Does not raise.
+    execute_turn(
+        session_id=session_id,
+        turn_id=turn_id,
+        prompt="hi",
+        mode="run",
+        timeout=10.0,
+    )
+
+    # Sprite is never resumed — we bail before the runtime is touched.
+    assert resume_spy.call_count == 0
+
+
+@pytest.mark.django_db
+def test_execute_turn_skips_finalization_if_session_deleted_mid_turn(user, mocker):
+    """Race: user terminates then deletes a session while the turn body is
+    running. The sprite command returns (ExecError or clean), and the
+    post-run `session.refresh_from_db` sees the row gone. Skip the
+    finalization writes (they'd have been cascade-deleted anyway) and don't
+    let DoesNotExist bubble out to the task's error reporter."""
+    session, turn = _make_session_and_turn(user)
+    _patch_sprite(mocker, "success")
+    mocker.patch("agent_on_demand.session_service.tasks.destroy_session_task.defer")
+
+    # Delete the session on the very first refresh_from_db call (which is
+    # the finalization refresh — the sprite command has already returned).
+    original_refresh = AgentSession.refresh_from_db
+
+    def deleting_refresh(self, *args, **kwargs):
+        if self.pk == session.pk:
+            AgentSession.objects.filter(pk=self.pk).delete()
+            return original_refresh(self, *args, **kwargs)
+        return original_refresh(self, *args, **kwargs)
+
+    mocker.patch.object(AgentSession, "refresh_from_db", deleting_refresh)
+
+    # Does not raise.
+    execute_turn(
+        session_id=str(session.id),
+        turn_id=turn.id,
+        prompt="hi",
+        mode="run",
+        timeout=10.0,
+    )
+
+    # Session row + turn row are gone (cascade-deleted).
+    assert not AgentSession.objects.filter(pk=session.pk).exists()
+    assert not SessionTurn.objects.filter(pk=turn.pk).exists()
+
+
+@pytest.mark.django_db
 def test_provision_task_runs_with_no_runtime_credential(provision_user, fake_sprites, mocker):
     """Credentials are now dumped wholesale into /tmp/aod-env; provisioning
     no longer short-circuits on missing creds (the session-create HTTP gate


### PR DESCRIPTION
## Summary

Three call sites in `session_service.tasks` could raise `AgentSession.DoesNotExist` when the session row was gone by the time the worker picked up the job. Sentry has three open reports matching this — one per call site — all paging us for benign user-initiated deletes.

- **`provision_session_task`** (`_provision_session_inner`, `tasks.py:164`): session loaded at the top of the task. Race: `DELETE /sessions/{id}` fires between `POST /sessions` enqueuing the provision task and the worker picking it up. The DELETE view only blocks `running` sessions, so `pending` is deletable.
- **`execute_turn`** (`_execute_turn_inner`, `tasks.py:322`): same pattern. `DELETE /sessions/{id}` between `POST /prompt` enqueuing the turn and the worker starting it.
- **`_execute_turn_body`** (`tasks.py:478`): `session.refresh_from_db(fields=["status"])` after the sprite command returns. Race: client calls `POST /terminate` (flips status to `terminated`, making the session deletable) then `DELETE /sessions/{id}` while the turn is mid-flight; the refresh sees an empty row.

All three now log + return cleanly. `SessionTurn.session` and `AgentSessionLog.session` are both `on_delete=CASCADE`, so the finalization writes in `_execute_turn_body` were destined to be no-ops anyway.

## Test plan

- [x] `make test` — 303 passed (was 300, +3 regression tests in `test_tasks.py`):
  - `test_provision_task_skips_if_session_deleted`
  - `test_execute_turn_skips_if_session_deleted`
  - `test_execute_turn_skips_finalization_if_session_deleted_mid_turn`
- [x] `make lint` — clean
- [ ] Verify in Sentry after deploy that the three `AgentSession.DoesNotExist` signatures stop firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)