### PR TITLE
Fix: agent environment_id cannot be cleared via PUT /agents/{id}

### DIFF
--- a/src/agent_on_demand/views/agents.py
+++ b/src/agent_on_demand/views/agents.py
@@ -417,14 +417,22 @@ def agent_detail(request, agent_id):
         # Detect changes
         changed = False
 
-        # Resolve environment_id if provided
-        if req.environment_id is not None:
-            try:
-                env_obj = Environment.objects.get(pk=req.environment_id, user=request.user)
-            except (Environment.DoesNotExist, ValueError):
-                return JsonResponse({"detail": "Environment not found"}, status=404)
-            if env_obj.id != agent.environment_id:
-                agent.environment = env_obj
+        # Resolve environment_id only when it was explicitly included in the
+        # request body. environment_id defaults to None in the schema, so we
+        # must consult model_fields_set to distinguish "absent from payload"
+        # from "explicitly set to null" (which clears the environment).
+        if "environment_id" in req.model_fields_set:
+            if req.environment_id is not None:
+                try:
+                    env_obj = Environment.objects.get(pk=req.environment_id, user=request.user)
+                except (Environment.DoesNotExist, ValueError):
+                    return JsonResponse({"detail": "Environment not found"}, status=404)
+                if env_obj.id != agent.environment_id:
+                    agent.environment = env_obj
+                    changed = True
+            elif agent.environment_id is not None:
+                # Explicit null — detach the environment.
+                agent.environment = None
                 changed = True
 
         for field in ("name", "model", "runtime", "system", "description", "skills", "mcp_servers"):


### PR DESCRIPTION
## Summary

`PUT /agents/{id}` with `"environment_id": null` was silently ignored — once an environment was attached to an agent, there was no way to detach it.

### Root cause

`UpdateAgentRequest.environment_id` has type `str | None` with a default of `None`. The update handler checks:

```python
if req.environment_id is not None:
    # resolve and set the environment
```

This condition is `False` for both:
- a request body that **omits** `environment_id` entirely (field takes its default of `None`)
- a request body that **explicitly sends** `"environment_id": null` (to clear it)

So the explicit-null case was indistinguishable from the absent case and was silently dropped.

### Fix

Use Pydantic v2's `model_fields_set` — the set of field names that were actually present in the input — to tell the two cases apart:

```python
if "environment_id" in req.model_fields_set:
    if req.environment_id is not None:
        # resolve and set the environment (existing behaviour)
    elif agent.environment_id is not None:
        agent.environment = None   # explicit null → detach
        changed = True
```

Fields absent from the request body never appear in `model_fields_set`, so omitting `environment_id` still has no effect.

## Test plan

- [ ] `PUT /agents/{id}` with body `{"version": N, "environment_id": null}` when agent has an environment → `environment_id` in response is `null`, version bumped
- [ ] `PUT /agents/{id}` with body `{"version": N, "environment_id": null}` when agent already has no environment → no change, version unchanged
- [ ] `PUT /agents/{id}` with body `{"version": N}` (no `environment_id` key) → environment unchanged (regression check)
- [ ] `PUT /agents/{id}` with body `{"version": N, "environment_id": "<valid-uuid>"}` → environment set as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)