### PR TITLE
Fix unhandled exceptions in provision/execute tasks leaving sessions in "pending"

### DIFF
--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -48,7 +48,7 @@ from agent_on_demand.models import (
 from agent_on_demand.observability import get_tracer
 from agent_on_demand.runtimes import RUNTIMES, Runtime
 
-from .errors import NoSpritesKeyError, ProvisionError
+from .errors import NoSpritesKeyError, ProvisionError, SessionHandleNotFound
 from .provisioning import (
     STAGE_RUNTIME_START,
     destroy_session,
@@ -166,7 +166,12 @@ def _provision_session_inner(
     if session.status == "terminated":
         return
 
-    spec = _build_spec_for_session(session)
+    try:
+        spec = _build_spec_for_session(session)
+    except Exception as e:
+        logger.exception("failed to build SessionSpec for session %s", session_id)
+        _mark_provision_failed(session, turn_id, f"internal error: {e}")
+        return
 
     tracer = get_tracer()
     with tracer.start_as_current_span(
@@ -278,6 +283,28 @@ def _mark_provision_failed(session: AgentSession, turn_id: int, message: str) ->
         )
 
 
+def _fail_pending_turn(session: AgentSession, turn: SessionTurn, message: str) -> None:
+    """Mark a session and turn as failed when they are still in pending state
+    (before _execute_turn_body has set them to running).
+
+    Used when _build_spec_for_session or resume_session fail before
+    _execute_turn_body is entered."""
+    AgentSessionLog.objects.create(
+        session=session,
+        turn=turn,
+        stream="stderr",
+        data=f"turn failed: {message}\n",
+    )
+    now = timezone.now()
+    session.refresh_from_db(fields=["status"])
+    if session.status != "terminated":
+        session.status = "failed"
+        session.save(update_fields=["status", "updated_at"])
+    turn.status = "failed"
+    turn.ended_at = now
+    turn.save(update_fields=["status", "ended_at"])
+
+
 @procrastinate_app.task(queue="sessions", name="execute_turn", pass_context=False)
 def execute_turn(
     *,
@@ -321,7 +348,15 @@ def _execute_turn_inner(
 ) -> None:
     session = AgentSession.objects.select_related("user", "agent", "environment").get(pk=session_id)
     turn = SessionTurn.objects.get(pk=turn_id)
-    spec = _build_spec_for_session(session)
+
+    try:
+        spec = _build_spec_for_session(session)
+    except Exception as e:
+        logger.exception(
+            "failed to build SessionSpec for session %s turn %s", session_id, turn_id
+        )
+        _fail_pending_turn(session, turn, f"internal error: {e}")
+        return
 
     tracer = get_tracer()
     with tracer.start_as_current_span(
@@ -335,7 +370,15 @@ def _execute_turn_inner(
             "aod.timeout": timeout,
         },
     ) as span:
-        sprite = resume_session(session.user, session.sprite_name)
+        try:
+            sprite = resume_session(session.user, session.sprite_name)
+        except SessionHandleNotFound as e:
+            logger.warning(
+                "sprite not found for session %s turn %s: %s", session_id, turn_id, e
+            )
+            span.set_attribute("aod.failure_stage", "sprite_not_found")
+            _fail_pending_turn(session, turn, str(e))
+            return
         _execute_turn_body(session, turn, spec, sprite, prompt, mode, timeout, span)
 
 

--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -161,7 +161,13 @@ def _provision_session_inner(
     mode: str,
     timeout: float,
 ) -> None:
-    session = AgentSession.objects.select_related("user", "agent", "environment").get(pk=session_id)
+    try:
+        session = AgentSession.objects.select_related("user", "agent", "environment").get(
+            pk=session_id
+        )
+    except AgentSession.DoesNotExist:
+        logger.info("provision_session_task: session %s gone, skipping", session_id)
+        return
     # If the client terminated before the worker picked this up, skip.
     if session.status == "terminated":
         return
@@ -346,15 +352,19 @@ def _execute_turn_inner(
     mode: str,
     timeout: float,
 ) -> None:
-    session = AgentSession.objects.select_related("user", "agent", "environment").get(pk=session_id)
-    turn = SessionTurn.objects.get(pk=turn_id)
+    try:
+        session = AgentSession.objects.select_related("user", "agent", "environment").get(
+            pk=session_id
+        )
+        turn = SessionTurn.objects.get(pk=turn_id)
+    except (AgentSession.DoesNotExist, SessionTurn.DoesNotExist):
+        logger.info("execute_turn: session=%s turn=%s gone, skipping", session_id, turn_id)
+        return
 
     try:
         spec = _build_spec_for_session(session)
     except Exception as e:
-        logger.exception(
-            "failed to build SessionSpec for session %s turn %s", session_id, turn_id
-        )
+        logger.exception("failed to build SessionSpec for session %s turn %s", session_id, turn_id)
         _fail_pending_turn(session, turn, f"internal error: {e}")
         return
 
@@ -373,9 +383,7 @@ def _execute_turn_inner(
         try:
             sprite = resume_session(session.user, session.sprite_name)
         except SessionHandleNotFound as e:
-            logger.warning(
-                "sprite not found for session %s turn %s: %s", session_id, turn_id, e
-            )
+            logger.warning("sprite not found for session %s turn %s: %s", session_id, turn_id, e)
             span.set_attribute("aod.failure_stage", "sprite_not_found")
             _fail_pending_turn(session, turn, str(e))
             return
@@ -518,7 +526,13 @@ def _execute_turn_body(session, turn, spec, sprite, prompt, mode, timeout, span)
         exit_code = None
 
     ended = timezone.now()
-    session.refresh_from_db(fields=["status"])
+    try:
+        session.refresh_from_db(fields=["status"])
+    except AgentSession.DoesNotExist:
+        # Session was deleted mid-turn (e.g. client raced terminate + delete).
+        # Turn + logs were cascade-deleted alongside it; nothing left to write.
+        logger.info("execute_turn: session %s deleted mid-turn, skipping finalization", session.id)
+        return
     if session.status != "terminated":
         session.status = final_status
         session.exit_code = exit_code


### PR DESCRIPTION
## Summary

Two related bugs in `session_service/tasks.py` where unhandled exceptions crash the Procrastinate task and leave the session and/or turn permanently stuck in `"pending"`. These are distinct from PR #111 (which handles `AgentSession.DoesNotExist`) and are not covered by any open PR.

---

### Bug 1: `_build_spec_for_session` exceptions are unhandled in both tasks

`_build_spec_for_session` is called **before** any `try/except` in both `_provision_session_inner` and `_execute_turn_inner`. It can raise:

- **`ValueError`** from `SessionResource.get_token()` → `decrypt()` when a repo authorization token's ciphertext is corrupted or was encrypted with a different key (made more visible by the `InvalidToken → ValueError` hardening in PR #114)
- **`KeyError`** if `agent.mcp_servers` or `agent.skills` JSON is malformed (e.g. `s["name"]`, `s["source"]`, `s["content"]` with a missing key)

When either raises, neither `_mark_provision_failed` nor any cleanup runs. The task crashes, Procrastinate marks it failed, and the session is stuck in `"pending"` forever with no worker ever picking it up again.

**Fix:** Wrap `_build_spec_for_session` in a `try/except Exception` in both task inner functions. In `_provision_session_inner`, call the existing `_mark_provision_failed`. In `_execute_turn_inner`, call the new `_fail_pending_turn` helper (see below).

---

### Bug 2: `SessionHandleNotFound` from `resume_session` is unhandled in `_execute_turn_inner`

`resume_session` raises `SessionHandleNotFound` when the Sprite is no longer available (e.g. server-side eviction or timeout between provisioning and the `execute_turn` task being picked up). `SessionHandleNotFound` was not imported in `tasks.py` and was not caught anywhere in `_execute_turn_inner`, so:

1. The exception propagates out of the task
2. Procrastinate marks the task failed
3. The session stays `"pending"`, the turn stays `"pending"` — permanently

**Fix:** Import `SessionHandleNotFound` from `.errors`, catch it around `resume_session`, and call `_fail_pending_turn`.

---

### New helper: `_fail_pending_turn`

Mirrors `_mark_provision_failed` for the execute-turn path. Used when failures happen before `_execute_turn_body` has run (i.e. the session and turn are still `"pending"`, no Sprite command has started). Writes a `stderr` log chunk, respects the `"terminated"` guard on session status, and marks both session and turn `"failed"`.

## Test plan

- [ ] Corrupt a `SessionResource.encrypted_token` in the DB, start a new session referencing that resource → verify session ends up `"failed"` (not stuck `"pending"`)
- [ ] Manually break an `agent.mcp_servers` JSON entry (remove the `"name"` key), trigger a new session → verify session ends up `"failed"`
- [ ] Delete a Sprite server-side between provision and execute_turn (or mock `resume_session` to raise `SessionHandleNotFound`) → verify session and turn both end up `"failed"` (not stuck `"pending"`)

**Note:** This PR will have a minor conflict with PR #111 (both touch `_execute_turn_inner` and `_provision_session_inner`). The two fixes are independent and can be applied together with a straightforward rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)