### PR TITLE
Fix agent create/update not atomic with version snapshot

### DIFF
--- a/src/agent_on_demand/views/agents.py
+++ b/src/agent_on_demand/views/agents.py
@@ -2,6 +2,7 @@ import json
 import re
 
 import posthog
+from django.db import transaction
 from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
@@ -326,20 +327,21 @@ def agents_list_create(request):
             except (Environment.DoesNotExist, ValueError):
                 return JsonResponse({"detail": "Environment not found"}, status=404)
 
-        agent = Agent.objects.create(
-            user=request.user,
-            name=req.name,
-            description=req.description,
-            system=req.system,
-            model=req.model,
-            runtime=req.runtime,
-            environment=env_obj,
-            skills=req.skills,
-            mcp_servers=req.mcp_servers,
-            metadata=req.metadata,
-            version=1,
-        )
-        _snapshot_version(agent)
+        with transaction.atomic():
+            agent = Agent.objects.create(
+                user=request.user,
+                name=req.name,
+                description=req.description,
+                system=req.system,
+                model=req.model,
+                runtime=req.runtime,
+                environment=env_obj,
+                skills=req.skills,
+                mcp_servers=req.mcp_servers,
+                metadata=req.metadata,
+                version=1,
+            )
+            _snapshot_version(agent)
 
         with posthog.new_context():
             posthog.identify_context(str(request.user.id))
@@ -447,8 +449,9 @@ def agent_detail(request, agent_id):
 
         if changed:
             agent.version += 1
-            agent.save()
-            _snapshot_version(agent)
+            with transaction.atomic():
+                agent.save()
+                _snapshot_version(agent)
             with posthog.new_context():
                 posthog.identify_context(str(request.user.id))
                 posthog.capture(


### PR DESCRIPTION
## Bug

`agents.py` performs `Agent.objects.create()` + `_snapshot_version()` and `agent.save()` + `_snapshot_version()` as two separate, non-atomic DB operations. If `_snapshot_version()` raises after the first write succeeds (e.g. a DB error or the `unique_agent_version` constraint fires on a retry), the agent row exists at version N but has no `AgentVersion` row for that version. This permanently corrupts the version history and breaks the optimistic-concurrency invariant: the "current version" has no snapshot to roll back to.

The `environments.py` view already wraps both create and update in `transaction.atomic()`. This PR applies the same pattern to agents.

## Changes

**`src/agent_on_demand/views/agents.py`**

1. Add `from django.db import transaction` import.

2. Wrap agent creation in `transaction.atomic()`:
   ```python
   # Before
   agent = Agent.objects.create(...)
   _snapshot_version(agent)

   # After
   with transaction.atomic():
       agent = Agent.objects.create(...)
       _snapshot_version(agent)
   ```

3. Wrap agent update in `transaction.atomic()`:
   ```python
   # Before
   agent.version += 1
   agent.save()
   _snapshot_version(agent)

   # After
   agent.version += 1
   with transaction.atomic():
       agent.save()
       _snapshot_version(agent)
   ```

## Prior art

`environments.py` `environments_list_create` (create path) and `environment_detail` PUT (update path) both already use `transaction.atomic()` for the same reason.