### PR TITLE
Fix delete/terminate session missing row-level lock

### DIFF
--- a/src/agent_on_demand/views/sessions.py
+++ b/src/agent_on_demand/views/sessions.py
@@ -492,17 +492,18 @@ def list_session_turns(request, session_id):
 def terminate_session(request, session_id):
     """Terminate a session's Sprite without deleting the session record."""
     try:
-        session = AgentSession.objects.get(pk=session_id, user=request.user)
+        with transaction.atomic():
+            session = AgentSession.objects.select_for_update().get(
+                pk=session_id, user=request.user
+            )
+            if session.status == "terminated":
+                return JsonResponse({"detail": "Session is already terminated"}, status=409)
+            sprite_name = session.sprite_name
+            session.status = "terminated"
+            session.sprite_name = ""
+            session.save(update_fields=["status", "sprite_name", "updated_at"])
     except (AgentSession.DoesNotExist, ValueError):
         return JsonResponse({"detail": "Session not found"}, status=404)
-
-    if session.status == "terminated":
-        return JsonResponse({"detail": "Session is already terminated"}, status=409)
-
-    sprite_name = session.sprite_name
-    session.status = "terminated"
-    session.sprite_name = ""
-    session.save(update_fields=["status", "sprite_name", "updated_at"])
 
     if sprite_name:
         session_service.destroy_session_task.defer(user_id=request.user.id, sprite_name=sprite_name)
@@ -530,15 +531,16 @@ def delete_session(request, session_id):
         return JsonResponse({"detail": "Method not allowed"}, status=405)
 
     try:
-        session = AgentSession.objects.get(pk=session_id, user=request.user)
+        with transaction.atomic():
+            session = AgentSession.objects.select_for_update().get(
+                pk=session_id, user=request.user
+            )
+            if session.status == "running":
+                return JsonResponse({"detail": "Cannot delete a running session"}, status=409)
+            session_id_str = str(session.id)
+            session.delete()  # pre_delete signal handles Sprite cleanup
     except (AgentSession.DoesNotExist, ValueError):
         return JsonResponse({"detail": "Session not found"}, status=404)
-
-    if session.status == "running":
-        return JsonResponse({"detail": "Cannot delete a running session"}, status=409)
-
-    session_id_str = str(session.id)
-    session.delete()  # pre_delete signal handles Sprite cleanup
 
     with posthog.new_context():
         posthog.identify_context(str(request.user.id))

--- a/src/agent_on_demand/views/sessions.py
+++ b/src/agent_on_demand/views/sessions.py
@@ -517,9 +517,7 @@ def terminate_session(request, session_id):
     """Terminate a session's Sprite without deleting the session record."""
     try:
         with transaction.atomic():
-            session = AgentSession.objects.select_for_update().get(
-                pk=session_id, user=request.user
-            )
+            session = AgentSession.objects.select_for_update().get(pk=session_id, user=request.user)
             if session.status == "terminated":
                 return JsonResponse({"detail": "Session is already terminated"}, status=409)
             sprite_name = session.sprite_name
@@ -556,9 +554,7 @@ def delete_session(request, session_id):
 
     try:
         with transaction.atomic():
-            session = AgentSession.objects.select_for_update().get(
-                pk=session_id, user=request.user
-            )
+            session = AgentSession.objects.select_for_update().get(pk=session_id, user=request.user)
             if session.status == "running":
                 return JsonResponse({"detail": "Cannot delete a running session"}, status=409)
             session_id_str = str(session.id)


### PR DESCRIPTION
## Bugs

### 1. `delete_session` — status check not under a lock

```python
# Before (buggy)
session = AgentSession.objects.get(pk=session_id, user=request.user)
if session.status == "running":
    return JsonResponse({"detail": "Cannot delete a running session"}, status=409)
session.delete()
```

`session.status` is a stale snapshot. A concurrent `POST /sessions/{id}/prompt` can transition the session from `completed` → `running` between the `get()` and the `delete()`. The running session gets deleted out from under the worker. The `execute_turn` task then hits `AgentSession.DoesNotExist` and crashes, leaving the turn stuck in `"running"` and the Sprite orphaned.

### 2. `terminate_session` — double-terminate race

```python
# Before (buggy)
session = AgentSession.objects.get(pk=session_id, user=request.user)
if session.status == "terminated":
    return JsonResponse({"detail": "Session is already terminated"}, status=409)
session.status = "terminated"
session.save(...)
if sprite_name:
    session_service.destroy_session_task.defer(...)
```

Two concurrent `POST /sessions/{id}/terminate` requests both read `status != "terminated"`, both write `status = "terminated"`, and both enqueue `destroy_session_task`. The Sprite is destroyed twice and two worker tasks are queued for it.

## Fix

Wrap the read → check → mutate sequence in `transaction.atomic()` + `select_for_update()` for both endpoints, matching the locking pattern already used in `send_prompt`.

```python
# delete_session (after)
with transaction.atomic():
    session = AgentSession.objects.select_for_update().get(pk=session_id, user=request.user)
    if session.status == "running":
        return JsonResponse({"detail": "Cannot delete a running session"}, status=409)
    session_id_str = str(session.id)
    session.delete()

# terminate_session (after)
with transaction.atomic():
    session = AgentSession.objects.select_for_update().get(pk=session_id, user=request.user)
    if session.status == "terminated":
        return JsonResponse({"detail": "Session is already terminated"}, status=409)
    sprite_name = session.sprite_name
    session.status = "terminated"
    session.sprite_name = ""
    session.save(update_fields=["status", "sprite_name", "updated_at"])
# defer outside the transaction so the task is enqueued only after the commit
if sprite_name:
    session_service.destroy_session_task.defer(...)
```

Note: `destroy_session_task.defer()` is intentionally kept **outside** the `transaction.atomic()` block so the Procrastinate task is only enqueued after the `"terminated"` status is committed — otherwise a worker could pick up the task before the status write is visible.