### PR TITLE
Fix three lifecycle races: delete-pending session, environment-delete, execute-turn status overwrite

### DIFF
--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -398,6 +398,25 @@ def _execute_turn_body(session, turn, spec, sprite, prompt, mode, timeout, span)
             output_q.put(_SENTINEL)
 
     now = timezone.now()
+
+    # Guard against a concurrent terminate_session that committed
+    # status="terminated" after _execute_turn_inner fetched the session row.
+    # Without this check, the unconditional save below would overwrite the
+    # termination, leaving the session showing "running" for the whole turn.
+    session.refresh_from_db(fields=["status"])
+    if session.status == "terminated":
+        AgentSessionLog.objects.create(
+            session=session,
+            turn=turn,
+            stream="stderr",
+            data="turn aborted: session terminated before execution started\n",
+        )
+        turn.status = "failed"
+        turn.started_at = now
+        turn.ended_at = now
+        turn.save(update_fields=["status", "started_at", "ended_at"])
+        return
+
     session.status = "running"
     session.save(update_fields=["status", "updated_at"])
     turn.status = "running"

--- a/src/agent_on_demand/views/environments.py
+++ b/src/agent_on_demand/views/environments.py
@@ -310,9 +310,7 @@ def environment_delete(request, environment_id):
 
     try:
         with transaction.atomic():
-            env = Environment.objects.select_for_update().get(
-                pk=environment_id, user=request.user
-            )
+            env = Environment.objects.select_for_update().get(pk=environment_id, user=request.user)
             if env.sessions.exists():
                 return JsonResponse(
                     {"detail": "Cannot delete environment with existing sessions"},

--- a/src/agent_on_demand/views/environments.py
+++ b/src/agent_on_demand/views/environments.py
@@ -309,18 +309,19 @@ def environment_delete(request, environment_id):
         return JsonResponse({"detail": "Method not allowed"}, status=405)
 
     try:
-        env = Environment.objects.get(pk=environment_id, user=request.user)
+        with transaction.atomic():
+            env = Environment.objects.select_for_update().get(
+                pk=environment_id, user=request.user
+            )
+            if env.sessions.exists():
+                return JsonResponse(
+                    {"detail": "Cannot delete environment with existing sessions"},
+                    status=409,
+                )
+            env_id_str = str(env.id)
+            env.delete()
     except (Environment.DoesNotExist, ValueError):
         return JsonResponse({"detail": "Environment not found"}, status=404)
-
-    if env.sessions.exists():
-        return JsonResponse(
-            {"detail": "Cannot delete environment with existing sessions"},
-            status=409,
-        )
-
-    env_id_str = str(env.id)
-    env.delete()
 
     with posthog.new_context():
         posthog.identify_context(str(request.user.id))

--- a/src/agent_on_demand/views/sessions.py
+++ b/src/agent_on_demand/views/sessions.py
@@ -534,8 +534,8 @@ def delete_session(request, session_id):
     except (AgentSession.DoesNotExist, ValueError):
         return JsonResponse({"detail": "Session not found"}, status=404)
 
-    if session.status == "running":
-        return JsonResponse({"detail": "Cannot delete a running session"}, status=409)
+    if session.status in ("running", "pending"):
+        return JsonResponse({"detail": "Cannot delete an active session"}, status=409)
 
     session_id_str = str(session.id)
     session.delete()  # pre_delete signal handles Sprite cleanup


### PR DESCRIPTION
## Three bugs fixed

### 1. `delete_session` — allows deleting a `"pending"` session while provisioning is in flight (`views/sessions.py`)

```python
# Before
if session.status == "running":
    return JsonResponse({"detail": "Cannot delete a running session"}, status=409)

# After
if session.status in ("running", "pending"):
    return JsonResponse({"detail": "Cannot delete an active session"}, status=409)
```

A `"pending"` session has an active `provision_session_task` in the Procrastinate queue. If that task has already called `provision_session()`, deleting the session row causes either:
- The task's `AgentSession.objects.get(pk=session_id)` to raise `DoesNotExist` (unhandled — crashes the task), **or**
- The task to create the Sprite successfully but then silently fail on subsequent `session.save()` writes — leaving the Sprite orphaned permanently, since `pre_delete` fired before the Sprite existed.

### 2. `environment_delete` — `sessions.exists()` check and `env.delete()` not atomic (`views/environments.py`)

```python
# Before
if env.sessions.exists():
    return JsonResponse({"detail": "Cannot delete environment with existing sessions"}, status=409)
env.delete()

# After
with transaction.atomic():
    env = Environment.objects.select_for_update().get(pk=environment_id, user=request.user)
    if env.sessions.exists():
        return JsonResponse({"detail": "Cannot delete environment with existing sessions"}, status=409)
    env.delete()
```

Between `sessions.exists()` returning `False` and `env.delete()`, a concurrent `POST /sessions` can create a session referencing this environment. Django's `SET_NULL` cascade then silently clears `AgentSession.environment` on the active session. The `provision_session_task` runs with `environment=None` — no env vars, packages, setup script, or network policy — producing a silently misconfigured Sprite.

### 3. `_execute_turn_body` — unconditional `session.status = "running"` save overwrites a concurrent `terminate_session` (`session_service/tasks.py`)

```python
# Before
now = timezone.now()
session.status = "running"
session.save(update_fields=["status", "updated_at"])

# After
now = timezone.now()
session.refresh_from_db(fields=["status"])
if session.status == "terminated":
    # abort cleanly — log a stderr entry, mark turn failed, return
    ...
    return
session.status = "running"
session.save(update_fields=["status", "updated_at"])
```

`_execute_turn_inner` fetches the session row without a lock. A concurrent `terminate_session` can commit `status="terminated"` between that fetch and the `session.status = "running"` save inside `_execute_turn_body`. Without the guard, the task overwrites the termination, leaving the session showing `"running"` for the entire turn duration even though `sprite_name` has been cleared. The end-of-turn `refresh_from_db` eventually restores the correct terminal state, but the window can span the full turn (~10–600s).

The fix adds a `refresh_from_db` check at the start of turn execution. If terminated, the turn is marked `"failed"` with a log entry explaining the abort, and the task returns without touching the Sprite.