### PR TITLE
fix: archived env validation in agent create/update, turn_count semantics, SessionHandleNotFound status

### DIFF
--- a/src/agent_on_demand/views/agents.py
+++ b/src/agent_on_demand/views/agents.py
@@ -325,6 +325,10 @@ def agents_list_create(request):
                 env_obj = Environment.objects.get(pk=req.environment_id, user=request.user)
             except (Environment.DoesNotExist, ValueError):
                 return JsonResponse({"detail": "Environment not found"}, status=404)
+            if env_obj.is_archived:
+                return JsonResponse(
+                    {"detail": "Cannot assign an archived environment to an agent"}, status=409
+                )
 
         agent = Agent.objects.create(
             user=request.user,
@@ -423,6 +427,10 @@ def agent_detail(request, agent_id):
                 env_obj = Environment.objects.get(pk=req.environment_id, user=request.user)
             except (Environment.DoesNotExist, ValueError):
                 return JsonResponse({"detail": "Environment not found"}, status=404)
+            if env_obj.is_archived:
+                return JsonResponse(
+                    {"detail": "Cannot assign an archived environment to an agent"}, status=409
+                )
             if env_obj.id != agent.environment_id:
                 agent.environment = env_obj
                 changed = True

--- a/src/agent_on_demand/views/sessions.py
+++ b/src/agent_on_demand/views/sessions.py
@@ -43,7 +43,6 @@ def _serialize_resources(session: AgentSession) -> list[dict]:
 
 def _serialize_session(session: AgentSession) -> dict:
     latest = session.turns.order_by("-turn_number").first()
-    turn_count = latest.turn_number if latest else 0
     return {
         "id": str(session.id),
         "agent_id": str(session.agent_id) if session.agent_id else None,
@@ -54,7 +53,7 @@ def _serialize_session(session: AgentSession) -> dict:
         "created_at": session.created_at.isoformat(),
         "updated_at": session.updated_at.isoformat(),
         "resources": _serialize_resources(session),
-        "turn_count": turn_count,
+        "turn_count": session.turns.count(),
         "current_turn": latest.turn_number if latest else None,
     }
 
@@ -412,8 +411,15 @@ def send_prompt(request, session_id):
         sprite = session_service.resume_session(request.user, session.sprite_name)
     except session_service.NoSpritesKeyError as e:
         return JsonResponse({"detail": str(e)}, status=400)
-    except session_service.SessionHandleNotFound as e:
-        return JsonResponse({"detail": str(e)}, status=404)
+    except session_service.SessionHandleNotFound:
+        # The Sprite is gone (e.g. idle timeout on the Sprites platform). The
+        # session record still exists, so 404 would be misleading — callers
+        # cannot distinguish "session not found" from "Sprite no longer
+        # available". Return 409 with an actionable message instead.
+        return JsonResponse(
+            {"detail": "Session sprite is no longer available; start a new session."},
+            status=409,
+        )
 
     # Atomically lock the session row, re-check state, and allocate a turn
     # number. Prevents two concurrent POSTs from both creating turn N+1 or


### PR DESCRIPTION
## Summary

Four bugs, all in `views/agents.py` or `views/sessions.py`, none addressed by existing open PRs.

### Bug A — `POST /agents`: archived environment accepted silently (`agents.py`)

`agents_list_create` looks up the environment by ID and user, but never checks `env_obj.is_archived`. Supplying an archived `environment_id` creates the agent successfully. The agent then can't be used for any session — `_create_session` checks archived status and returns 409 — but the caller gets no feedback at agent-creation time and is left with a permanently unusable agent.

**Fix:** Add `if env_obj.is_archived: return 409` after the environment lookup in `agents_list_create`.

### Bug B — `PUT /agents/{id}`: same missing archived check on environment update (`agents.py`)

`agent_detail` PUT has the same gap: updating an agent's `environment_id` to point at an archived environment succeeds, storing the archived reference. Same downstream result: agent becomes unable to start sessions.

**Fix:** Add `if env_obj.is_archived: return 409` after the environment lookup in `agent_detail` PUT.

### Bug C — `POST /sessions/{id}/prompt`: `SessionHandleNotFound` returns 404 (`sessions.py`)

When the session's Sprite no longer exists (e.g., idle timeout on the Sprites platform), `resume_session` raises `SessionHandleNotFound`, which was propagated as a 404. Callers cannot distinguish:
- 404 = "session row doesn't exist" (the normal meaning of 404)
- 404 = "Sprite is gone but session exists"

The session resource is present; only the compute backing it is gone. The correct status is 409 with an actionable message.

**Fix:** Catch `SessionHandleNotFound` and return 409 `"Session sprite is no longer available; start a new session."` The real 404 (session row missing) remains a 404.

### Bug D — `_serialize_session`: `turn_count` is max turn number, not actual count (`sessions.py`)

```python
# before
turn_count = latest.turn_number if latest else 0   # max(turn_number), not COUNT(*)
```

`turn_count` and `current_turn` returned identical values — both `latest.turn_number`. The field name promises a count. Today they're equal because turns are sequentially numbered and never individually deleted, but the implementation will silently return a wrong value if that invariant changes (e.g., a future admin cleanup of orphaned turns).

**Fix:** Use `session.turns.count()`.

## Changes

| File | Change |
|------|--------|
| `views/agents.py` | Add `is_archived` guard after env lookup in both `agents_list_create` and `agent_detail` PUT |
| `views/sessions.py` | `SessionHandleNotFound` → 409; `turn_count` → `session.turns.count()` |

## Test plan

- [ ] `POST /agents` with an archived `environment_id` → 409 "Cannot assign an archived environment to an agent"
- [ ] `PUT /agents/{id}` with an archived `environment_id` → 409
- [ ] `POST /agents` with a non-archived environment still succeeds (201)
- [ ] `POST /sessions/{id}/prompt` when Sprite is gone → 409 (not 404), message mentions "sprite is no longer available"
- [ ] `POST /sessions/{id}/prompt` for a non-existent session → still 404
- [ ] `GET /sessions/{id}` — `turn_count` equals actual number of turns in the DB