### PR TITLE
Fix environment_delete TOCTOU race and missing env_var key validation

### DIFF
--- a/src/agent_on_demand/views/environments.py
+++ b/src/agent_on_demand/views/environments.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 import posthog
 from django.db import IntegrityError, transaction
@@ -29,6 +30,10 @@ def _env_safe_props(env: Environment) -> dict:
 
 VALID_PACKAGE_MANAGERS = {"apt", "cargo", "gem", "go", "npm", "pip"}
 
+# Valid POSIX shell variable names. Keys that don't match this will corrupt
+# /tmp/aod-env when written as `KEY=value` shell assignments.
+_ENV_VAR_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
 
 class CreateEnvironmentRequest(BaseModel):
     name: str = Field(max_length=200)
@@ -48,6 +53,16 @@ class CreateEnvironmentRequest(BaseModel):
                 )
             if not isinstance(pkgs, list) or not all(isinstance(p, str) for p in pkgs):
                 raise ValueError(f"packages.{manager} must be a list of strings")
+        return v
+
+    @field_validator("env_vars")
+    @classmethod
+    def validate_env_vars(cls, v: dict) -> dict:
+        for key in v:
+            if not _ENV_VAR_KEY_RE.match(key):
+                raise ValueError(
+                    f"Invalid env_var key {key!r}: must match [A-Za-z_][A-Za-z0-9_]*"
+                )
         return v
 
     @field_validator("networking")
@@ -83,6 +98,17 @@ class UpdateEnvironmentRequest(BaseModel):
                     )
                 if not isinstance(pkgs, list) or not all(isinstance(p, str) for p in pkgs):
                     raise ValueError(f"packages.{manager} must be a list of strings")
+        return v
+
+    @field_validator("env_vars")
+    @classmethod
+    def validate_env_vars(cls, v: dict | None) -> dict | None:
+        if v is not None:
+            for key in v:
+                if not _ENV_VAR_KEY_RE.match(key):
+                    raise ValueError(
+                        f"Invalid env_var key {key!r}: must match [A-Za-z_][A-Za-z0-9_]*"
+                    )
         return v
 
     @field_validator("networking")
@@ -309,18 +335,23 @@ def environment_delete(request, environment_id):
         return JsonResponse({"detail": "Method not allowed"}, status=405)
 
     try:
-        env = Environment.objects.get(pk=environment_id, user=request.user)
+        with transaction.atomic():
+            # Lock the row so a concurrent POST /sessions cannot create a
+            # session referencing this environment between the existence check
+            # and the delete. Without the lock, the cascade would silently
+            # NULL-out the new session's environment FK.
+            env = Environment.objects.select_for_update().get(
+                pk=environment_id, user=request.user
+            )
+            if env.sessions.exists():
+                return JsonResponse(
+                    {"detail": "Cannot delete environment with existing sessions"},
+                    status=409,
+                )
+            env_id_str = str(env.id)
+            env.delete()
     except (Environment.DoesNotExist, ValueError):
         return JsonResponse({"detail": "Environment not found"}, status=404)
-
-    if env.sessions.exists():
-        return JsonResponse(
-            {"detail": "Cannot delete environment with existing sessions"},
-            status=409,
-        )
-
-    env_id_str = str(env.id)
-    env.delete()
 
     with posthog.new_context():
         posthog.identify_context(str(request.user.id))

--- a/src/agent_on_demand/views/environments.py
+++ b/src/agent_on_demand/views/environments.py
@@ -60,9 +60,7 @@ class CreateEnvironmentRequest(BaseModel):
     def validate_env_vars(cls, v: dict) -> dict:
         for key in v:
             if not _ENV_VAR_KEY_RE.match(key):
-                raise ValueError(
-                    f"Invalid env_var key {key!r}: must match [A-Za-z_][A-Za-z0-9_]*"
-                )
+                raise ValueError(f"Invalid env_var key {key!r}: must match [A-Za-z_][A-Za-z0-9_]*")
         return v
 
     @field_validator("networking")
@@ -340,9 +338,7 @@ def environment_delete(request, environment_id):
             # session referencing this environment between the existence check
             # and the delete. Without the lock, the cascade would silently
             # NULL-out the new session's environment FK.
-            env = Environment.objects.select_for_update().get(
-                pk=environment_id, user=request.user
-            )
+            env = Environment.objects.select_for_update().get(pk=environment_id, user=request.user)
             if env.sessions.exists():
                 return JsonResponse(
                     {"detail": "Cannot delete environment with existing sessions"},


### PR DESCRIPTION
## Bugs fixed

### Bug A — `environment_delete` TOCTOU race (`views/environments.py`)

`DELETE /environments/{id}` checked `env.sessions.exists()` and then called `env.delete()` with no lock and no transaction wrapping the two steps. Between the check and the delete, a concurrent `POST /sessions` (for an agent whose default environment is this one) could create a new session. Django's `SET_NULL` cascade then silently strips the environment FK from the new session before provision starts — the session runs without its env_vars, packages, or network policy, with no error surfaced to the caller.

**Fix:** Wrap the fetch, existence check, and delete in a single `transaction.atomic()` with `select_for_update()` on the environment row. The row lock prevents `_create_session` from attaching a new session to the environment until the delete transaction commits.

### Bug B — Missing `env_vars` key validation in both Create and Update (`views/environments.py`)

`CreateEnvironmentRequest` and `UpdateEnvironmentRequest` accepted `env_vars` as `dict[str, str]` with no constraint on key names. The env file writer in `provisioning._write_env_file` emits each key verbatim as a shell assignment:

```python
lines.append(f"{key}={shlex.quote(env.env_vars[key])}")
```

A key containing `\n` splits into two lines, injecting arbitrary content into `/tmp/aod-env` (which is `source`d with `set -a` on every turn). A key containing `=` silently truncates the variable name at the first `=`. Either case corrupts the env file and causes all subsequent turns to fail with a confusing shell error rather than a 422 at write time.

**Fix:** Add `validate_env_vars` field validators to both `CreateEnvironmentRequest` and `UpdateEnvironmentRequest` enforcing the POSIX shell variable name pattern `[A-Za-z_][A-Za-z0-9_]*`. Invalid keys now return a `422` at the API boundary before any data is persisted.