### PR TITLE
Extend mutation testing to session state machine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,8 +104,8 @@ follow_imports = "silent"
 exclude_dirs = ["tests", ".venv", "src/agent_on_demand/migrations"]
 
 [tool.mutmut]
-# Mutation testing for the highest-blast-radius modules. Currently scoped to
-# auth + crypto + versioning; planned expansion: session state machine.
+# Mutation testing for the highest-blast-radius modules: auth, crypto,
+# optimistic-concurrency check, and the session state machine.
 # Run with `make mutation-test`.
 #
 # IMPORTANT: tests under tests_dir must be sync-only. mutmut runs tests via
@@ -119,11 +119,13 @@ paths_to_mutate = [
     "src/agent_on_demand/crypto.py",
     "src/agent_on_demand/auth.py",
     "src/agent_on_demand/versioning.py",
+    "src/agent_on_demand/session_state.py",
 ]
 tests_dir = [
     "tests/test_auth.py",
     "tests/test_crypto.py",
     "tests/test_versioning.py",
+    "tests/test_session_state.py",
 ]
 # mutmut copies its working tree to ./mutants/ and runs pytest from there;
 # without these, the rest of the src/ tree isn't available to the test runner.

--- a/src/agent_on_demand/session_state.py
+++ b/src/agent_on_demand/session_state.py
@@ -1,0 +1,53 @@
+"""Session state-machine predicates: which operations each status allows.
+
+Sessions move `pending → running → {completed, failed, terminated}`. The
+helpers below return a 409 JsonResponse when an operation is not legal in
+the session's current state, or None to proceed.
+
+The exact `detail` strings are part of the API contract — clients/SDKs
+read them to decide whether to retry, refetch, or surface to the user.
+Don't change the wording without coordinating with SDK consumers; tests
+in tests/test_session_state.py pin them exactly.
+"""
+
+from __future__ import annotations
+
+from django.http import JsonResponse
+
+
+def check_can_accept_prompt(status: str) -> JsonResponse | None:
+    """Reject a new prompt if the session is not in an accepting state.
+
+    Accepts: ``pending`` and ``completed``.
+    Rejects: ``running``, ``terminated``, ``failed`` (each with its own message).
+
+    The same check runs twice on send_prompt: once before acquiring the row
+    lock (fast-fail) and once after (race-safe). Using one function for
+    both keeps the rejection messages identical between the two paths.
+    """
+    if status == "running":
+        return JsonResponse({"detail": "Session is already running"}, status=409)
+    if status == "terminated":
+        return JsonResponse({"detail": "Session has been terminated"}, status=409)
+    if status == "failed":
+        return JsonResponse(
+            {"detail": "Session has failed and cannot be resumed. Start a new session."},
+            status=409,
+        )
+    return None
+
+
+def check_can_terminate(status: str) -> JsonResponse | None:
+    """Reject termination only if already terminated (idempotent-error)."""
+    if status == "terminated":
+        return JsonResponse({"detail": "Session is already terminated"}, status=409)
+    return None
+
+
+def check_can_delete(status: str) -> JsonResponse | None:
+    """Reject delete while running (would leave an orphaned Sprite). All
+    other states — including terminated — are deletable.
+    """
+    if status == "running":
+        return JsonResponse({"detail": "Cannot delete a running session"}, status=409)
+    return None

--- a/src/agent_on_demand/views/sessions.py
+++ b/src/agent_on_demand/views/sessions.py
@@ -26,6 +26,11 @@ from agent_on_demand.models import (
 from agent_on_demand.models.auth import CREDENTIAL_ENV_VAR, UserCredential
 from agent_on_demand.models_catalog import MODELS
 from agent_on_demand.runtimes import RUNTIMES
+from agent_on_demand.session_state import (
+    check_can_accept_prompt,
+    check_can_delete,
+    check_can_terminate,
+)
 from agent_on_demand.stream import stream_session_from_db
 
 
@@ -407,20 +412,12 @@ def send_prompt(request, session_id):
     except (AgentSession.DoesNotExist, ValueError):
         return JsonResponse({"detail": "Session not found"}, status=404)
 
-    if session.status == "running":
-        return JsonResponse({"detail": "Session is already running"}, status=409)
-
-    if session.status == "terminated":
-        return JsonResponse({"detail": "Session has been terminated"}, status=409)
-
     # A `failed` session may have left its Sprite mid-execution (see Muddy
     # Zone 8 in thoughts/research/2026-04-18-sprites-script-setup.md). Making
     # `failed` terminal prevents a resume from colliding with a runaway turn.
-    if session.status == "failed":
-        return JsonResponse(
-            {"detail": "Session has failed and cannot be resumed. Start a new session."},
-            status=409,
-        )
+    err = check_can_accept_prompt(session.status)
+    if err is not None:
+        return err
 
     try:
         body = json.loads(request.body)
@@ -445,15 +442,9 @@ def send_prompt(request, session_id):
     try:
         with transaction.atomic():
             locked = AgentSession.objects.select_for_update().get(pk=session.id)
-            if locked.status == "running":
-                return JsonResponse({"detail": "Session is already running"}, status=409)
-            if locked.status == "terminated":
-                return JsonResponse({"detail": "Session has been terminated"}, status=409)
-            if locked.status == "failed":
-                return JsonResponse(
-                    {"detail": ("Session has failed and cannot be resumed. Start a new session.")},
-                    status=409,
-                )
+            err = check_can_accept_prompt(locked.status)
+            if err is not None:
+                return err
 
             next_turn_number = (
                 SessionTurn.objects.filter(session=locked).aggregate(n=Max("turn_number"))["n"] or 0
@@ -518,8 +509,9 @@ def terminate_session(request, session_id):
     try:
         with transaction.atomic():
             session = AgentSession.objects.select_for_update().get(pk=session_id, user=request.user)
-            if session.status == "terminated":
-                return JsonResponse({"detail": "Session is already terminated"}, status=409)
+            err = check_can_terminate(session.status)
+            if err is not None:
+                return err
             sprite_name = session.sprite_name
             session.status = "terminated"
             session.sprite_name = ""
@@ -555,8 +547,9 @@ def delete_session(request, session_id):
     try:
         with transaction.atomic():
             session = AgentSession.objects.select_for_update().get(pk=session_id, user=request.user)
-            if session.status == "running":
-                return JsonResponse({"detail": "Cannot delete a running session"}, status=409)
+            err = check_can_delete(session.status)
+            if err is not None:
+                return err
             session_id_str = str(session.id)
             session.delete()  # pre_delete signal handles Sprite cleanup
     except (AgentSession.DoesNotExist, ValueError):

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1,0 +1,132 @@
+"""Direct tests for the session state-machine predicates.
+
+These pin the API contract for status-transition rejection responses.
+SDKs read the `detail` strings to decide whether to retry, refetch, or
+surface to the user.
+"""
+
+import json
+
+from agent_on_demand.session_state import (
+    check_can_accept_prompt,
+    check_can_delete,
+    check_can_terminate,
+)
+
+
+def body(resp):
+    return json.loads(resp.content)
+
+
+# === check_can_accept_prompt ===
+
+
+def test_accept_prompt_allows_pending():
+    assert check_can_accept_prompt("pending") is None
+
+
+def test_accept_prompt_allows_completed():
+    assert check_can_accept_prompt("completed") is None
+
+
+def test_accept_prompt_rejects_running():
+    resp = check_can_accept_prompt("running")
+    assert resp is not None
+    assert resp.status_code == 409
+    assert body(resp) == {"detail": "Session is already running"}
+
+
+def test_accept_prompt_rejects_terminated():
+    resp = check_can_accept_prompt("terminated")
+    assert resp.status_code == 409
+    assert body(resp) == {"detail": "Session has been terminated"}
+
+
+def test_accept_prompt_rejects_failed():
+    resp = check_can_accept_prompt("failed")
+    assert resp.status_code == 409
+    assert body(resp) == {
+        "detail": "Session has failed and cannot be resumed. Start a new session."
+    }
+
+
+def test_accept_prompt_rejection_response_only_has_detail_key():
+    """No extra fields leak into the error response."""
+    for status in ("running", "terminated", "failed"):
+        payload = body(check_can_accept_prompt(status))
+        assert set(payload.keys()) == {"detail"}, status
+
+
+def test_accept_prompt_unknown_status_treated_as_acceptable():
+    """A status the helper doesn't recognize is allowed through; the caller
+    is responsible for ensuring `status` is a valid value. This test pins
+    that behavior so a future agent doesn't silently turn unknown statuses
+    into 409s (which would be a breaking change for any new statuses)."""
+    assert check_can_accept_prompt("queued") is None
+    assert check_can_accept_prompt("") is None
+
+
+# === check_can_terminate ===
+
+
+def test_terminate_allows_pending():
+    assert check_can_terminate("pending") is None
+
+
+def test_terminate_allows_running():
+    """A running session CAN be terminated — that's the whole point."""
+    assert check_can_terminate("running") is None
+
+
+def test_terminate_allows_completed():
+    assert check_can_terminate("completed") is None
+
+
+def test_terminate_allows_failed():
+    assert check_can_terminate("failed") is None
+
+
+def test_terminate_rejects_already_terminated():
+    resp = check_can_terminate("terminated")
+    assert resp is not None
+    assert resp.status_code == 409
+    assert body(resp) == {"detail": "Session is already terminated"}
+
+
+def test_terminate_rejection_response_only_has_detail_key():
+    payload = body(check_can_terminate("terminated"))
+    assert set(payload.keys()) == {"detail"}
+
+
+# === check_can_delete ===
+
+
+def test_delete_allows_pending():
+    assert check_can_delete("pending") is None
+
+
+def test_delete_allows_completed():
+    assert check_can_delete("completed") is None
+
+
+def test_delete_allows_failed():
+    """Failed sessions are deletable — failure is terminal but the row should
+    be removable."""
+    assert check_can_delete("failed") is None
+
+
+def test_delete_allows_terminated():
+    """Terminated sessions are deletable; terminate then delete is a real flow."""
+    assert check_can_delete("terminated") is None
+
+
+def test_delete_rejects_running():
+    resp = check_can_delete("running")
+    assert resp is not None
+    assert resp.status_code == 409
+    assert body(resp) == {"detail": "Cannot delete a running session"}
+
+
+def test_delete_rejection_response_only_has_detail_key():
+    payload = body(check_can_delete("running"))
+    assert set(payload.keys()) == {"detail"}


### PR DESCRIPTION
## Summary

- Extracts the session state-transition predicates from `views/sessions.py` into a new `agent_on_demand/session_state.py` module. Three helpers — `check_can_accept_prompt`, `check_can_terminate`, `check_can_delete` — cover the three operations the API exposes that depend on session status.
- The `check_can_accept_prompt` helper now backs **both** the pre-lock fast-fail and the post-lock race-safe checks in `send_prompt`. Before this PR the two paths had duplicated message strings; an agent updating the wording in one place would have silently drifted from the other. Now they share a single source of truth.
- Adds the new module to the mutation-test scope. **Mutmut now runs 219 mutants (was 154); all 65 new mutants in session_state.py are killed.** Surviving mutants unchanged from prior baseline — same 4 documented equivalents.

## What's locked down

The exact `detail` strings for status-transition rejections are part of the API contract. SDKs read them to decide whether to retry, refetch, or surface to the user. The new `tests/test_session_state.py` (19 tests) pins:

- accept-prompt: rejects `running`/`terminated`/`failed` with three distinct messages; allows `pending`/`completed`
- terminate: rejects `terminated` (idempotent-error per CLAUDE.md convention); allows everything else
- delete: rejects `running` only (would orphan a Sprite); allows even `terminated` (terminate-then-delete is a real flow)
- response shape: only `detail` key, status 409, exact wording

One non-obvious test pins that **unknown statuses are NOT rejected** by `check_can_accept_prompt`. This protects against a future agent silently turning a new status (e.g. a queued state) into a 409 — that would be a backward-incompatible change for any client that learns of the new status before the helper does.

## Test plan

- [x] `make test` — 357 passed (+19 from `test_session_state.py`)
- [x] `make lint` — passes
- [x] `make fmt-check` — passes
- [x] `make mutation-test` — 215/219 killed, 4 known-equivalent, gate passes
- [ ] CI runs the updated `mutation-test` job and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)