### PR TITLE
Add django-migration-linter as a CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,22 @@ jobs:
       - run: uv sync --all-extras
       - run: make mutation-test
 
+  migration-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so `git merge-base origin/main HEAD` resolves.
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      - run: uv sync --all-extras
+      - run: make check-migrations BASE_SHA=$(git merge-base origin/main HEAD)
+
   validate-openapi:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,21 @@ test-e2e-mcp:
 test-all:
 	uv run pytest tests/ -v
 
+# Lint migrations introduced on the current branch (since it diverged from main)
+# for safety issues like NOT NULL adds on populated tables, column drops/renames,
+# and dangerous index changes. Existing migrations on main are grandfathered.
+#
+# CI sets BASE_SHA explicitly via `git merge-base origin/main HEAD`. Locally,
+# `git merge-base main HEAD` works as long as your local main is up-to-date.
+BASE_SHA ?= $(shell git merge-base main HEAD 2>/dev/null)
+check-migrations:
+	@if [ -z "$(BASE_SHA)" ]; then \
+		echo "Could not compute BASE_SHA — pass BASE_SHA=<sha> or ensure 'main' branch exists locally"; \
+		exit 1; \
+	fi
+	DATABASE_URL=sqlite:///test.db uv run python manage.py lintmigrations \
+		--include-apps fairy --git-commit-id $(BASE_SHA) --project-root-path .
+
 lint:
 	uv run ruff check src/ tests/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "pylint>=3.2",
     "pyyaml>=6.0",
     "mutmut>=3.0",
+    "django-migration-linter>=5.0",
 ]
 
 [tool.ruff]
@@ -63,7 +64,7 @@ line-length = 100
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "config.settings"
 pythonpath = ["src"]
-norecursedirs = ["tests/e2e", ".venv"]
+norecursedirs = ["tests/e2e", ".venv", "clients"]
 asyncio_mode = "auto"
 markers = [
     "slow: tests that create real agent sessions (may take minutes)",

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -25,6 +25,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "corsheaders",
     "procrastinate.contrib.django",
+    "django_migration_linter",
     "agent_on_demand.apps.AgentOnDemandConfig",
 ]
 
@@ -113,3 +114,10 @@ DEFAULT_TIMEOUT = int(os.environ.get("DEFAULT_TIMEOUT", "600"))
 # is borne by the user (own token), so this cap protects our worker queue from
 # a single user saturating it, not our spend.
 DEFAULT_MAX_CONCURRENT_SESSIONS = int(os.environ.get("DEFAULT_MAX_CONCURRENT_SESSIONS", "100"))
+
+# Defaults for `manage.py lintmigrations`. The Makefile's `check-migrations`
+# target overrides these with --git-commit-id to scope linting to migrations
+# added on the current branch (existing migrations are grandfathered).
+MIGRATION_LINTER_OPTIONS = {
+    "include_apps": ["fairy"],
+}

--- a/uv.lock
+++ b/uv.lock
@@ -38,6 +38,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "bandit" },
+    { name = "django-migration-linter" },
     { name = "mutmut" },
     { name = "mypy" },
     { name = "pip-audit" },
@@ -64,6 +65,7 @@ requires-dist = [
     { name = "dj-database-url", specifier = ">=2.1" },
     { name = "django", specifier = ">=5.1" },
     { name = "django-cors-headers", specifier = ">=4.0" },
+    { name = "django-migration-linter", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mutmut", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
@@ -117,6 +119,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "appdirs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470, upload-time = "2020-05-11T07:59:51.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566, upload-time = "2020-05-11T07:59:49.499Z" },
 ]
 
 [[package]]
@@ -688,6 +699,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/21/39/55822b15b7ec87410f34cd16ce04065ff390e50f9e29f31d6d116fc80456/django_cors_headers-4.9.0.tar.gz", hash = "sha256:fe5d7cb59fdc2c8c646ce84b727ac2bca8912a247e6e68e1fb507372178e59e8", size = 21458, upload-time = "2025-09-18T10:40:52.326Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/d8/19ed1e47badf477d17fb177c1c19b5a21da0fd2d9f093f23be3fb86c5fab/django_cors_headers-4.9.0-py3-none-any.whl", hash = "sha256:15c7f20727f90044dcee2216a9fd7303741a864865f0c3657e28b7056f61b449", size = 12809, upload-time = "2025-09-18T10:40:50.843Z" },
+]
+
+[[package]]
+name = "django-migration-linter"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appdirs" },
+    { name = "django", version = "5.2.13", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "django", version = "6.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "toml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/0c/fed1d01477ecb8547750df6b4922129cbf4bab26433df77c81fa77da06df/django_migration_linter-6.0.0.tar.gz", hash = "sha256:b7fdd4fe55862795378d99b4d8d80d454408c22647909d0fa533b63f9545c63e", size = 35917, upload-time = "2026-01-04T13:08:26.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/22/1f99542f53f0f55ad766ed2fe4c788f1a6120dbdbb2d05446c5127dfb84e/django_migration_linter-6.0.0-py3-none-any.whl", hash = "sha256:8fbac51a77fbe86d814e2b996b80aa831d21499982085cda1cacc84b7b4971a5", size = 27660, upload-time = "2026-01-04T13:08:23.819Z" },
 ]
 
 [[package]]
@@ -2376,6 +2402,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/89/bec5709fb759f9c784bbcb30b2e3497df3f901691d13c2b864dbf6694a17/textual-8.2.4.tar.gz", hash = "sha256:d4e2b2ddd7157191d00b228592b7c739ea080b7d792fd410f23ca75f05ea76c4", size = 1848933, upload-time = "2026-04-19T04:20:45.845Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/32/02932f0d597cdbb34e34bf24266ff0f2cf292ccb3aafc37dd9efcb0cc416/textual-8.2.4-py3-none-any.whl", hash = "sha256:a83bd3f0cc7125ca203845af753f9d6b6be030025ecd1b05cc75ebe645b9c4ba", size = 724390, upload-time = "2026-04-19T04:20:49.968Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Wires `django-migration-linter` into CI so any PR adding a database migration with a known-dangerous pattern (NOT NULL on populated tables, column drops/renames, type changes, dangerous index ops) gets blocked.
- Picks up partial work from the abandoned `wip/claude/add-migration-linter` branch (PR #131): keeps the dep + `INSTALLED_APPS` additions, but **fixes the broken `--exclude-applied-migrations` flag** (doesn't exist in v6) and replaces it with the correct `--git-commit-id` semantic.
- New `migration-lint` GH Actions job runs the gate; existing migrations on main are grandfathered.

## Why grandfathering

The 16 existing migrations include 8 with patterns the linter flags (NOT NULL adds, column drops, table drops). Those have already shipped to prod — there's nothing to do about them retroactively. The CI gate scopes linting to *new* migrations introduced on the current branch via `--git-commit-id $(git merge-base origin/main HEAD)`. PRs that don't touch migrations report `0/0` and pass instantly.

## Verification

- Synthesized a bad migration (`AddField` with `null=False`, no default) → linter caught it with `NOT NULL constraint on columns` and `make check-migrations` exited 1
- Removed the bad migration → `0/0` and exits 0
- One non-obvious gotcha: the linter runs `git diff --relative` from the directory containing `settings.py` (`src/config/`), but our migrations live at `src/agent_on_demand/migrations/`. Fixed by passing `--project-root-path .` in the make target. Without that flag, the linter silently reports `0/0` for everything.

## Test plan

- [x] `make test` — 358 passed
- [x] `make lint` — passes
- [x] `make fmt-check` — passes
- [x] `make check-migrations` — passes (no new migrations on this branch)
- [ ] CI runs the new `migration-lint` job and passes

## Follow-up

Closes the partial work tracked in #131. That branch can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)