### PR TITLE
Add CLAUDE.md fences and request-schema drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,19 @@ jobs:
       - run: uv sync --all-extras
       - run: uv run python -m scripts.validate_openapi
 
+  check-schemas:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      - run: uv sync --all-extras
+      - run: make check-schemas
+
   typescript-sdk:
     runs-on: ubuntu-latest
     defaults:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,53 @@ directly (without `make`), `tests/e2e/conftest.py` defaults to
 - E2E fixtures (`create_agent`, `create_environment`, `create_session` in
   `tests/e2e/conftest.py`) auto-clean up created rows after each test.
 
+## Danger zones
+
+Files and patterns where mistakes have outsized blast radius. Treat any
+non-trivial change to the files below as needing human review even if a
+test passes — automated coverage cannot catch every class of bug here.
+
+**Files: any change here requires explicit human review before landing.**
+
+- `src/agent_on_demand/auth.py` — bearer-token check. A weakened comparison
+  or short-circuited check is a full breach. Mutation-tested.
+- `src/agent_on_demand/crypto.py` — Fernet wrapper for `env_vars` and other
+  secrets at rest. A wrong key derivation silently corrupts every encrypted
+  field. Mutation-tested.
+- `src/agent_on_demand/versioning.py` — optimistic-concurrency mismatch
+  response. The exact `detail` string is part of the API contract; SDKs
+  parse it. Mutation-tested.
+- `src/agent_on_demand/session_state.py` — session state-machine
+  predicates. Wrong rejection = duplicate agent runs (\$\$\$) or stuck
+  sessions. Mutation-tested.
+- `src/agent_on_demand/migrations/*.py` — DB migrations are forward-only in
+  prod. New migrations are linted in CI (`make check-migrations`); see
+  `MIGRATION_LINTER_OPTIONS` in `src/config/settings.py`.
+
+**Forbidden patterns (do not do these without explicit human approval):**
+
+- Removing or weakening a `version` check in a write path. Optimistic
+  concurrency is the only thing preventing silent data loss under
+  concurrent updates.
+- Removing the `select_for_update()` lock around session state changes
+  (`terminate_session`, `delete_session`, `send_prompt`'s post-lock check).
+  These prevent races that orphan Sprites or double-spend agent runs.
+- Changing the response shape of any documented endpoint without
+  also updating `docs/openapi.yaml` and `docs/request_schemas.json`. CI
+  enforces request-schema snapshots; response shapes are pinned by tests.
+- Skipping CI hooks (`--no-verify`, `--no-gpg-sign`) or disabling a
+  required check. If a check fails, fix the underlying issue.
+- Adding migrations that drop columns / tables, add NOT NULL on populated
+  tables, or change column types without a backfill plan. The migration
+  linter catches the mechanical patterns; the deploy-time impact still
+  needs review.
+
+**When the mutation-test gate fires unexpectedly,** read the survivor list
+in the CI output — `scripts/check_mutmut.py` prints the exact `mutmut
+show <name>` command. Don't add the survivor to the equivalent allowlist
+unless you can prove (with the diff) that no input distinguishes the
+mutant from the original.
+
 ## Style
 
 - Python 3.11+, ruff with `line-length = 100`.

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,16 @@ check-migrations:
 	DATABASE_URL=sqlite:///test.db uv run python manage.py lintmigrations \
 		--include-apps fairy --git-commit-id $(BASE_SHA) --project-root-path .
 
+# Snapshot the JSON schemas of all pydantic request models in views/ and
+# fail if they drift from docs/request_schemas.json. Catches accidental
+# breaking changes (added/removed/renamed fields, type flips). After an
+# intentional change, regenerate with `make snapshot-schemas`.
+check-schemas:
+	DATABASE_URL=sqlite:///test.db uv run python -m scripts.check_request_schemas
+
+snapshot-schemas:
+	DATABASE_URL=sqlite:///test.db uv run python -m scripts.check_request_schemas --write
+
 lint:
 	uv run ruff check src/ tests/
 

--- a/docs/request_schemas.json
+++ b/docs/request_schemas.json
@@ -1,0 +1,480 @@
+{
+  "agent_on_demand.views.agents.CreateAgentRequest": {
+    "properties": {
+      "description": {
+        "default": "",
+        "title": "Description",
+        "type": "string"
+      },
+      "environment_id": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Environment Id"
+      },
+      "mcp_servers": {
+        "items": {},
+        "title": "Mcp Servers",
+        "type": "array"
+      },
+      "metadata": {
+        "additionalProperties": true,
+        "title": "Metadata",
+        "type": "object"
+      },
+      "model": {
+        "maxLength": 100,
+        "title": "Model",
+        "type": "string"
+      },
+      "name": {
+        "maxLength": 200,
+        "title": "Name",
+        "type": "string"
+      },
+      "runtime": {
+        "maxLength": 32,
+        "title": "Runtime",
+        "type": "string"
+      },
+      "skills": {
+        "items": {},
+        "title": "Skills",
+        "type": "array"
+      },
+      "system": {
+        "default": "",
+        "title": "System",
+        "type": "string"
+      }
+    },
+    "required": [
+      "name",
+      "model",
+      "runtime"
+    ],
+    "title": "CreateAgentRequest",
+    "type": "object"
+  },
+  "agent_on_demand.views.agents.UpdateAgentRequest": {
+    "properties": {
+      "description": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Description"
+      },
+      "environment_id": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Environment Id"
+      },
+      "mcp_servers": {
+        "anyOf": [
+          {
+            "items": {},
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Mcp Servers"
+      },
+      "metadata": {
+        "anyOf": [
+          {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Metadata"
+      },
+      "model": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Model"
+      },
+      "name": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Name"
+      },
+      "runtime": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime"
+      },
+      "skills": {
+        "anyOf": [
+          {
+            "items": {},
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Skills"
+      },
+      "system": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "System"
+      },
+      "version": {
+        "description": "Current version \u2014 optimistic concurrency check",
+        "title": "Version",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "version"
+    ],
+    "title": "UpdateAgentRequest",
+    "type": "object"
+  },
+  "agent_on_demand.views.environments.CreateEnvironmentRequest": {
+    "properties": {
+      "env_vars": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "title": "Env Vars",
+        "type": "object"
+      },
+      "name": {
+        "maxLength": 200,
+        "title": "Name",
+        "type": "string"
+      },
+      "networking": {
+        "additionalProperties": true,
+        "title": "Networking",
+        "type": "object"
+      },
+      "packages": {
+        "additionalProperties": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": "Packages",
+        "type": "object"
+      },
+      "setup_script": {
+        "default": "",
+        "title": "Setup Script",
+        "type": "string"
+      }
+    },
+    "required": [
+      "name"
+    ],
+    "title": "CreateEnvironmentRequest",
+    "type": "object"
+  },
+  "agent_on_demand.views.environments.UpdateEnvironmentRequest": {
+    "properties": {
+      "env_vars": {
+        "anyOf": [
+          {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Env Vars"
+      },
+      "name": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Name"
+      },
+      "networking": {
+        "anyOf": [
+          {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Networking"
+      },
+      "packages": {
+        "anyOf": [
+          {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Packages"
+      },
+      "setup_script": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Setup Script"
+      },
+      "version": {
+        "description": "Current version \u2014 optimistic concurrency check",
+        "title": "Version",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "version"
+    ],
+    "title": "UpdateEnvironmentRequest",
+    "type": "object"
+  },
+  "agent_on_demand.views.sessions.GitHubRepoResource": {
+    "properties": {
+      "authorization_token": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "description": "GitHub PAT for private repos",
+        "title": "Authorization Token"
+      },
+      "mount_path": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "description": "Absolute path inside the Sprite where repo is cloned. Defaults to /workspace/<repo-name>.",
+        "title": "Mount Path"
+      },
+      "type": {
+        "const": "github_repository",
+        "title": "Type",
+        "type": "string"
+      },
+      "url": {
+        "description": "HTTPS GitHub repo URL, e.g. https://github.com/org/repo",
+        "title": "Url",
+        "type": "string"
+      }
+    },
+    "required": [
+      "type",
+      "url"
+    ],
+    "title": "GitHubRepoResource",
+    "type": "object"
+  },
+  "agent_on_demand.views.sessions.PromptRequest": {
+    "properties": {
+      "prompt": {
+        "description": "The prompt to send to the agent",
+        "title": "Prompt",
+        "type": "string"
+      },
+      "timeout": {
+        "default": 600,
+        "description": "Max seconds",
+        "maximum": 3600,
+        "minimum": 10,
+        "title": "Timeout",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "prompt"
+    ],
+    "title": "PromptRequest",
+    "type": "object"
+  },
+  "agent_on_demand.views.sessions.RunRequest": {
+    "$defs": {
+      "GitHubRepoResource": {
+        "properties": {
+          "authorization_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "GitHub PAT for private repos",
+            "title": "Authorization Token"
+          },
+          "mount_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Absolute path inside the Sprite where repo is cloned. Defaults to /workspace/<repo-name>.",
+            "title": "Mount Path"
+          },
+          "type": {
+            "const": "github_repository",
+            "title": "Type",
+            "type": "string"
+          },
+          "url": {
+            "description": "HTTPS GitHub repo URL, e.g. https://github.com/org/repo",
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "url"
+        ],
+        "title": "GitHubRepoResource",
+        "type": "object"
+      }
+    },
+    "properties": {
+      "agent_id": {
+        "description": "Agent ID to use for this session",
+        "title": "Agent Id",
+        "type": "string"
+      },
+      "environment_id": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "description": "Environment ID (overrides agent default)",
+        "title": "Environment Id"
+      },
+      "prompt": {
+        "description": "The prompt to send to the agent",
+        "title": "Prompt",
+        "type": "string"
+      },
+      "resources": {
+        "description": "GitHub repositories to clone into the session",
+        "items": {
+          "$ref": "#/$defs/GitHubRepoResource"
+        },
+        "title": "Resources",
+        "type": "array"
+      },
+      "timeout": {
+        "default": 600,
+        "description": "Max seconds",
+        "maximum": 3600,
+        "minimum": 10,
+        "title": "Timeout",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "agent_id",
+      "prompt"
+    ],
+    "title": "RunRequest",
+    "type": "object"
+  }
+}

--- a/scripts/check_request_schemas.py
+++ b/scripts/check_request_schemas.py
@@ -1,0 +1,135 @@
+"""Snapshot the JSON schemas of all request-body pydantic models in views/.
+
+Catches accidental drift in the public request contract — added/removed
+fields, renamed fields, type changes, required vs. optional flips. Pairs
+with `validate_openapi.py` (which checks routes/methods) and the
+`docs/openapi.yaml` (which documents the contract for SDK consumers).
+
+Usage
+-----
+Default (CI): compare current schemas against the committed snapshot.
+    uv run python -m scripts.check_request_schemas
+
+Regenerate the snapshot after an intentional contract change:
+    uv run python -m scripts.check_request_schemas --write
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import django
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SNAPSHOT_PATH = REPO_ROOT / "docs" / "request_schemas.json"
+
+
+def _setup_django() -> None:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    django.setup()
+
+
+# Each entry: (module path, attribute name). The output dict is keyed
+# "module.ClassName" so a renamed model surfaces as a clear diff.
+MODELS = [
+    ("agent_on_demand.views.agents", "CreateAgentRequest"),
+    ("agent_on_demand.views.agents", "UpdateAgentRequest"),
+    ("agent_on_demand.views.environments", "CreateEnvironmentRequest"),
+    ("agent_on_demand.views.environments", "UpdateEnvironmentRequest"),
+    ("agent_on_demand.views.sessions", "GitHubRepoResource"),
+    ("agent_on_demand.views.sessions", "RunRequest"),
+    ("agent_on_demand.views.sessions", "PromptRequest"),
+]
+
+
+def _current_schemas() -> dict:
+    import importlib
+
+    out: dict[str, dict] = {}
+    for module_path, attr in MODELS:
+        module = importlib.import_module(module_path)
+        cls = getattr(module, attr)
+        out[f"{module_path}.{attr}"] = cls.model_json_schema()
+    return out
+
+
+def _write_snapshot(schemas: dict) -> None:
+    SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(SNAPSHOT_PATH, "w") as f:
+        json.dump(schemas, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def _read_snapshot() -> dict | None:
+    if not SNAPSHOT_PATH.exists():
+        return None
+    with open(SNAPSHOT_PATH) as f:
+        return json.load(f)
+
+
+def _diff_summary(current: dict, snapshot: dict) -> list[str]:
+    """Human-readable summary of which models drifted, by name."""
+    errors: list[str] = []
+    cur_keys = set(current)
+    snap_keys = set(snapshot)
+    for added in sorted(cur_keys - snap_keys):
+        errors.append(f"new model not in snapshot: {added}")
+    for removed in sorted(snap_keys - cur_keys):
+        errors.append(f"model removed (or renamed) from snapshot: {removed}")
+    for name in sorted(cur_keys & snap_keys):
+        if current[name] != snapshot[name]:
+            errors.append(f"schema drift in {name}")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Regenerate the snapshot file from current models. "
+        "Use after an intentional contract change.",
+    )
+    args = parser.parse_args()
+
+    _setup_django()
+    current = _current_schemas()
+
+    if args.write:
+        _write_snapshot(current)
+        print(f"Wrote {len(current)} request schemas to {SNAPSHOT_PATH.relative_to(REPO_ROOT)}")
+        return 0
+
+    snapshot = _read_snapshot()
+    if snapshot is None:
+        print(
+            f"No snapshot at {SNAPSHOT_PATH.relative_to(REPO_ROOT)}. "
+            "Run with --write to create one.",
+            file=sys.stderr,
+        )
+        return 1
+
+    errors = _diff_summary(current, snapshot)
+    if errors:
+        print("Request-schema drift detected:\n", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        print(
+            "\nIf this is an intentional contract change, regenerate the snapshot:\n"
+            "    uv run python -m scripts.check_request_schemas --write\n"
+            "and update docs/openapi.yaml in the same PR.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Request schemas OK ({len(current)} models verified)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two complementary safety additions for autonomous agents:

**1. CLAUDE.md "Danger zones" section** — explicit list of files where any non-trivial change requires human review, plus a forbidden-pattern list (removing version checks, removing `select_for_update` locks, silently changing endpoint shapes, skipping CI hooks). Agents read CLAUDE.md, so making protections explicit catches the "innocent refactor" class of mistake before code is written.

**2. Request-schema drift gate (`scripts/check_request_schemas.py`)** — snapshots the JSON schemas of all 7 pydantic request models in `views/*.py` against `docs/request_schemas.json`. Catches added/removed/renamed fields, type flips, and required-vs-optional changes. New `check-schemas` CI job; `make snapshot-schemas` regenerates after an intentional change.

## Why request-schema drift specifically

The existing `validate_openapi` job enforces that **routes** and **methods** stay in sync with `docs/openapi.yaml`. It does NOT catch:

- Adding a required field to `CreateAgentRequest` (breaks existing clients)
- Removing or renaming a field (clients sending old name → 422)
- Changing a field's type (clients sending wrong type → 422)
- Flipping required ↔ optional

These are all backward-incompatible changes the SDK ecosystem would feel immediately. The new gate detects all four classes via JSON-schema comparison against a committed snapshot.

## Verification

- Injected a fake `secret_field: str = ""` into `CreateAgentRequest` → `make check-schemas` exited 1 with `schema drift in agent_on_demand.views.agents.CreateAgentRequest` and printed the regenerate command. Reverted, gate passed again.
- Output includes a clear remediation hint: regenerate via `make snapshot-schemas` AND update `docs/openapi.yaml` in the same PR.

## Test plan

- [x] `make test` — 358 passed
- [x] `make lint` / `make fmt-check` — pass
- [x] `make check-schemas` — passes (initial snapshot committed)
- [x] `make check-migrations` — passes
- [x] Drift detection verified manually with synthesized field
- [ ] CI runs the new `check-schemas` job and passes

## Roadmap status after this PR

| Item | State |
|---|---|
| 1. Mutation-test danger zones | ✅ shipped |
| 2. Migration safety in CI | ✅ shipped |
| 3. API contract diffing | ✅ shipped (request-side via this PR; routes/methods via existing `validate_openapi`) |
| 4. Scoped e2e per PR | not started |
| 5. CLAUDE.md fences | ✅ shipped |
| 6. Rollback + alerting | not started |

🤖 Generated with [Claude Code](https://claude.com/claude-code)