### PR TITLE
Add scoped e2e CI gate (inactive until AOD_API_TOKEN set)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,63 @@ jobs:
       - run: uv sync --all-extras
       - run: make check-migrations BASE_SHA=$(git merge-base origin/main HEAD)
 
+  e2e-scoped:
+    # Runs the e2e tests that map to the current branch's diff. The scope
+    # computation always runs (validates the path-mapping script). The
+    # actual pytest invocation is gated on the AOD_API_TOKEN secret being
+    # configured — without it, this job becomes a no-op preview.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      - run: uv sync --all-extras
+
+      - id: scope
+        run: |
+          BASE=$(git merge-base origin/main HEAD)
+          DATABASE_URL=sqlite:///test.db uv run python -m scripts.scope_e2e \
+            --base-sha "$BASE" --format=github
+
+      - id: token
+        env:
+          TOKEN: ${{ secrets.AOD_API_TOKEN }}
+        run: |
+          if [ -n "$TOKEN" ]; then
+            echo "have_token=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_token=no" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run scoped e2e
+        if: steps.scope.outputs.tests != '' && steps.token.outputs.have_token == 'yes'
+        env:
+          AOD_API_TOKEN: ${{ secrets.AOD_API_TOKEN }}
+          AOD_API_URL: ${{ secrets.AOD_API_URL }}
+          E2E_RUNTIMES: ${{ steps.scope.outputs.runtimes }}
+        run: uv run pytest ${{ steps.scope.outputs.tests }} -v --dist loadfile -n auto
+
+      - name: Skip — no token configured
+        if: steps.scope.outputs.tests != '' && steps.token.outputs.have_token == 'no'
+        env:
+          TESTS: ${{ steps.scope.outputs.tests }}
+          RUNTIMES: ${{ steps.scope.outputs.runtimes }}
+        run: |
+          echo "::warning title=E2E gate inactive::AOD_API_TOKEN secret not configured."
+          echo "Would have run: $TESTS"
+          echo "With E2E_RUNTIMES=$RUNTIMES"
+          echo "Configure AOD_API_TOKEN and AOD_API_URL repository secrets to activate."
+
+      - name: Skip — nothing in scope
+        if: steps.scope.outputs.tests == ''
+        run: echo "No e2e tests in scope for this change."
+
   validate-openapi:
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,25 @@ directly (without `make`), `tests/e2e/conftest.py` defaults to
 - E2E fixtures (`create_agent`, `create_environment`, `create_session` in
   `tests/e2e/conftest.py`) auto-clean up created rows after each test.
 
+### Scoped e2e on PRs
+
+The `e2e-scoped` CI job runs only the e2e tests that map to source files
+changed on the current branch (via `scripts/scope_e2e.py`). The mapping
+is in that script's `RULES` table and is pinned by `tests/test_scope_e2e.py`
+— don't change either without updating the other.
+
+To preview locally what e2e would run for your branch:
+
+```bash
+make scope-e2e          # prints the test files + runtimes
+make test-e2e-scoped    # actually runs them (needs AOD_API_TOKEN)
+```
+
+**The CI job is currently a no-op preview** — it computes scope and prints
+what *would* run, but actual pytest is gated on `AOD_API_TOKEN` and
+`AOD_API_URL` repository secrets. To activate the gate, add both secrets
+under Repository Settings → Secrets and variables → Actions.
+
 ## Danger zones
 
 Files and patterns where mistakes have outsized blast radius. Treat any

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,24 @@ test-e2e-networking:
 test-e2e-mcp:
 	uv run pytest tests/e2e/test_mcp.py -v -m "mcp_matrix"
 
+# Print the e2e tests that map to the current branch's diff vs main.
+# Read-only; doesn't run anything. Use to preview what `test-e2e-scoped` would do.
+scope-e2e:
+	uv run python -m scripts.scope_e2e
+
+# Run only the e2e tests that map to the current branch's diff vs main.
+# Computes scope via scripts/scope_e2e.py, sets E2E_RUNTIMES, invokes pytest.
+# Skips silently if no e2e tests are in scope. Requires AOD_API_TOKEN.
+test-e2e-scoped:
+	@SCOPE=$$(uv run python -m scripts.scope_e2e --format=shell); \
+	eval "$$SCOPE"; \
+	if [ -z "$$TESTS" ]; then \
+		echo "No e2e tests in scope for this change."; \
+		exit 0; \
+	fi; \
+	echo "Running scoped e2e: $$TESTS (runtimes=$$RUNTIMES)"; \
+	E2E_RUNTIMES=$$RUNTIMES uv run pytest $$TESTS -v -n $(E2E_WORKERS) --dist loadfile
+
 # Run everything — unit + e2e. E2E auto-skips if AOD_API_TOKEN is unset.
 test-all:
 	uv run pytest tests/ -v

--- a/scripts/scope_e2e.py
+++ b/scripts/scope_e2e.py
@@ -1,0 +1,254 @@
+"""Compute which e2e tests to run for a PR based on changed source files.
+
+Maps source paths to e2e test files. Outputs the test selection plus an
+E2E_RUNTIMES value. Designed for CI: pair with an `AOD_API_TOKEN` check
+so the actual pytest invocation is gated separately.
+
+The mapping is intentionally coarse — when in doubt, fall through to
+`ALL` rather than risk missing a regression. A few seconds of extra
+runtime is cheaper than a missed bug.
+
+Usage
+-----
+    uv run python -m scripts.scope_e2e
+    uv run python -m scripts.scope_e2e --base-sha <SHA>
+    uv run python -m scripts.scope_e2e --format=github  # writes $GITHUB_OUTPUT entries
+    uv run python -m scripts.scope_e2e --format=shell   # eval-friendly RUNTIMES=... TESTS=...
+
+Exit code is always 0; a no-op scope (nothing to run) emits empty TESTS.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+E2E_DIR = "tests/e2e"
+
+# All e2e test files. Used when a rule's target is "ALL".
+ALL_E2E: tuple[str, ...] = (
+    "test_agents.py",
+    "test_environments.py",
+    "test_sessions.py",
+    "test_skills.py",
+    "test_mcp.py",
+)
+
+# Per-rule target shapes:
+#   "ALL"          — every file in ALL_E2E
+#   "PASS_THROUGH" — for changed files under tests/e2e/, run that exact file
+#   tuple[str]     — explicit list of test filenames (relative to tests/e2e/)
+#
+# Order is significant for readability only; the algorithm unions matches.
+# Prefix-match: a rule matches if a changed file starts with the rule's
+# path prefix. Trailing "/" makes a directory rule.
+RULES: tuple[tuple[str, object], ...] = (
+    # Cross-cutting concerns: any change here can break every endpoint.
+    ("src/agent_on_demand/auth.py", "ALL"),
+    ("src/agent_on_demand/crypto.py", "ALL"),
+    ("src/config/", "ALL"),
+    ("src/agent_on_demand/runtimes/__init__.py", "ALL"),
+    ("src/agent_on_demand/runtimes/base.py", "ALL"),
+    ("src/agent_on_demand/observability.py", "ALL"),
+    ("src/agent_on_demand/signals.py", "ALL"),
+    ("src/agent_on_demand/tasks.py", "ALL"),
+    ("src/agent_on_demand/urls.py", "ALL"),
+    # Versioning + state-machine helpers — scoped to where they're used.
+    (
+        "src/agent_on_demand/versioning.py",
+        ("test_agents.py", "test_environments.py"),
+    ),
+    ("src/agent_on_demand/session_state.py", ("test_sessions.py",)),
+    # Resource-specific code paths.
+    ("src/agent_on_demand/views/agents.py", ("test_agents.py",)),
+    ("src/agent_on_demand/models/agents.py", ("test_agents.py",)),
+    ("src/agent_on_demand/views/environments.py", ("test_environments.py",)),
+    ("src/agent_on_demand/models/environments.py", ("test_environments.py",)),
+    ("src/agent_on_demand/views/sessions.py", ("test_sessions.py",)),
+    ("src/agent_on_demand/models/sessions.py", ("test_sessions.py",)),
+    ("src/agent_on_demand/stream.py", ("test_sessions.py",)),
+    # Session orchestration touches every test that creates a real session.
+    (
+        "src/agent_on_demand/session_service/",
+        ("test_sessions.py", "test_skills.py", "test_mcp.py"),
+    ),
+    # Runtime-specific files: a change to e.g. codex.py needs the session-
+    # spawning tests run with E2E_RUNTIMES=codex (handled separately below).
+    (
+        "src/agent_on_demand/runtimes/claude.py",
+        ("test_sessions.py", "test_skills.py", "test_mcp.py"),
+    ),
+    (
+        "src/agent_on_demand/runtimes/codex.py",
+        ("test_sessions.py", "test_skills.py", "test_mcp.py"),
+    ),
+    (
+        "src/agent_on_demand/runtimes/gemini.py",
+        ("test_sessions.py", "test_skills.py", "test_mcp.py"),
+    ),
+    (
+        "src/agent_on_demand/runtimes/opencode.py",
+        ("test_sessions.py", "test_skills.py", "test_mcp.py"),
+    ),
+    # Pydantic models common to multiple resources.
+    ("src/agent_on_demand/models_catalog.py", "ALL"),
+    ("src/agent_on_demand/models/auth.py", "ALL"),
+    # E2E tests themselves: run only the changed file.
+    (E2E_DIR + "/", "PASS_THROUGH"),
+)
+
+# Source path → runtime name. Touching one of these scopes E2E_RUNTIMES
+# to that runtime; touching base/__init__ scopes to ALL.
+RUNTIME_PATHS: dict[str, str] = {
+    "claude": "src/agent_on_demand/runtimes/claude.py",
+    "codex": "src/agent_on_demand/runtimes/codex.py",
+    "gemini": "src/agent_on_demand/runtimes/gemini.py",
+    "opencode": "src/agent_on_demand/runtimes/opencode.py",
+}
+
+# When no runtime-specific file changed, default to claude (cheapest).
+DEFAULT_RUNTIME = "claude"
+
+
+def compute_scope(changed_files: Iterable[str]) -> dict:
+    """Pure mapping function: changed files → {tests, runtimes}.
+
+    `tests` is a sorted list of paths relative to the repo root.
+    `runtimes` is a sorted list of runtime names; empty means "no e2e
+    coverage relevant to this change."
+    """
+    tests: set[str] = set()
+    runtimes: set[str] = set()
+    runtime_path_changed = False
+
+    files = sorted(set(changed_files))
+
+    for path in files:
+        # Runtime-specific selection.
+        for runtime, runtime_path in RUNTIME_PATHS.items():
+            if path == runtime_path:
+                runtimes.add(runtime)
+                runtime_path_changed = True
+                break
+
+        # Test selection.
+        for prefix, target in RULES:
+            if not path.startswith(prefix):
+                continue
+            if target == "ALL":
+                tests.update(f"{E2E_DIR}/{f}" for f in ALL_E2E)
+            elif target == "PASS_THROUGH":
+                # Only direct children of tests/e2e/ that look like e2e tests.
+                if path.startswith(E2E_DIR + "/test_") and path.endswith(".py"):
+                    tests.add(path)
+            else:
+                tests.update(f"{E2E_DIR}/{f}" for f in target)
+            # Continue checking other rules — multiple may apply (e.g. a
+            # PR touching auth.py and views/agents.py picks up both).
+
+    # If a runtime file changed, scope to that runtime; otherwise default.
+    # If no test scope at all matched, runtimes don't matter — leave empty
+    # so callers can short-circuit.
+    if not tests:
+        return {"tests": [], "runtimes": []}
+
+    if not runtime_path_changed:
+        runtimes.add(DEFAULT_RUNTIME)
+
+    return {"tests": sorted(tests), "runtimes": sorted(runtimes)}
+
+
+def _git_changed_files(base_sha: str) -> list[str]:
+    out = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_sha}...HEAD"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in out.stdout.splitlines() if line.strip()]
+
+
+def _resolve_base_sha(arg: str | None) -> str:
+    if arg:
+        return arg
+    out = subprocess.run(
+        ["git", "merge-base", "origin/main", "HEAD"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if out.returncode != 0 or not out.stdout.strip():
+        # Fallback to main if origin/main isn't fetched.
+        out = subprocess.run(
+            ["git", "merge-base", "main", "HEAD"],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    return out.stdout.strip()
+
+
+def _format_output(scope: dict, fmt: str) -> str:
+    tests = " ".join(scope["tests"])
+    runtimes = ",".join(scope["runtimes"])
+    if fmt == "shell":
+        return f"TESTS={tests!r}\nRUNTIMES={runtimes!r}\n"
+    if fmt == "github":
+        return f"tests={tests}\nruntimes={runtimes}\n"
+    if fmt == "json":
+        import json
+
+        return json.dumps(scope, indent=2) + "\n"
+    # human
+    if not tests:
+        return "No e2e tests in scope for this change.\n"
+    lines = [
+        f"E2E tests in scope ({len(scope['tests'])}):",
+        *[f"  - {t}" for t in scope["tests"]],
+        f"Runtimes: {runtimes or '(none)'}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-sha",
+        default=None,
+        help="Compute diff against this SHA. Defaults to `git merge-base origin/main HEAD`.",
+    )
+    parser.add_argument(
+        "--format",
+        default="human",
+        choices=["human", "shell", "github", "json"],
+        help="Output format. `github` writes `tests=...\\nruntimes=...` for $GITHUB_OUTPUT.",
+    )
+    args = parser.parse_args(argv)
+
+    base = _resolve_base_sha(args.base_sha)
+    changed = _git_changed_files(base)
+    scope = compute_scope(changed)
+
+    output = _format_output(scope, args.format)
+    if args.format == "github":
+        # Write to $GITHUB_OUTPUT if available, otherwise stdout.
+        gh_out = os.environ.get("GITHUB_OUTPUT")
+        if gh_out:
+            with open(gh_out, "a") as f:
+                f.write(output)
+            return 0
+    sys.stdout.write(output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_scope_e2e.py
+++ b/tests/test_scope_e2e.py
@@ -1,0 +1,171 @@
+"""Pin the source-path → e2e-test mapping in scripts/scope_e2e.py.
+
+These tests treat the mapping as a contract: removing a rule, changing
+a target, or breaking the runtime selection should fail at least one
+test here. Mutmut-style protection for a script that's not under the
+mutation gate (the script is too small to mutate-test usefully — these
+explicit tests pin it instead).
+"""
+
+import pytest
+
+from scripts.scope_e2e import (
+    ALL_E2E,
+    DEFAULT_RUNTIME,
+    RUNTIME_PATHS,
+    compute_scope,
+)
+
+
+# === Runtime-specific files trigger their own runtime ===
+
+
+@pytest.mark.parametrize("runtime,path", RUNTIME_PATHS.items())
+def test_runtime_file_scopes_to_that_runtime(runtime, path):
+    scope = compute_scope([path])
+    assert scope["runtimes"] == [runtime]
+    # Each runtime change should pull in the session-spawning tests.
+    assert "tests/e2e/test_sessions.py" in scope["tests"]
+    assert "tests/e2e/test_skills.py" in scope["tests"]
+    assert "tests/e2e/test_mcp.py" in scope["tests"]
+
+
+def test_two_runtimes_changed_unions_runtimes():
+    scope = compute_scope(
+        [
+            "src/agent_on_demand/runtimes/codex.py",
+            "src/agent_on_demand/runtimes/gemini.py",
+        ]
+    )
+    assert scope["runtimes"] == ["codex", "gemini"]
+
+
+# === Cross-cutting files trigger ALL e2e tests ===
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "src/agent_on_demand/auth.py",
+        "src/agent_on_demand/crypto.py",
+        "src/agent_on_demand/runtimes/__init__.py",
+        "src/agent_on_demand/runtimes/base.py",
+        "src/config/settings.py",
+        "src/config/urls.py",
+        "src/agent_on_demand/observability.py",
+        "src/agent_on_demand/signals.py",
+        "src/agent_on_demand/tasks.py",
+        "src/agent_on_demand/urls.py",
+        "src/agent_on_demand/models_catalog.py",
+        "src/agent_on_demand/models/auth.py",
+    ],
+)
+def test_cross_cutting_files_pull_in_all_e2e(path):
+    scope = compute_scope([path])
+    expected = {f"tests/e2e/{f}" for f in ALL_E2E}
+    assert set(scope["tests"]) == expected
+    # Default runtime applied since no runtime file changed.
+    assert scope["runtimes"] == [DEFAULT_RUNTIME]
+
+
+# === Resource-scoped files map to their resource's e2e file ===
+
+
+@pytest.mark.parametrize(
+    "path,expected_test",
+    [
+        ("src/agent_on_demand/views/agents.py", "test_agents.py"),
+        ("src/agent_on_demand/models/agents.py", "test_agents.py"),
+        ("src/agent_on_demand/views/environments.py", "test_environments.py"),
+        ("src/agent_on_demand/models/environments.py", "test_environments.py"),
+        ("src/agent_on_demand/views/sessions.py", "test_sessions.py"),
+        ("src/agent_on_demand/models/sessions.py", "test_sessions.py"),
+        ("src/agent_on_demand/stream.py", "test_sessions.py"),
+        ("src/agent_on_demand/session_state.py", "test_sessions.py"),
+    ],
+)
+def test_resource_scoped_change_runs_only_that_resource(path, expected_test):
+    scope = compute_scope([path])
+    assert scope["tests"] == [f"tests/e2e/{expected_test}"]
+
+
+def test_versioning_pulls_in_both_versioned_resources():
+    scope = compute_scope(["src/agent_on_demand/versioning.py"])
+    assert scope["tests"] == [
+        "tests/e2e/test_agents.py",
+        "tests/e2e/test_environments.py",
+    ]
+
+
+def test_session_service_pulls_in_session_spawning_tests():
+    scope = compute_scope(["src/agent_on_demand/session_service/tasks.py"])
+    assert set(scope["tests"]) == {
+        "tests/e2e/test_sessions.py",
+        "tests/e2e/test_skills.py",
+        "tests/e2e/test_mcp.py",
+    }
+
+
+# === Test files themselves: PASS_THROUGH ===
+
+
+def test_e2e_test_file_change_runs_only_that_file():
+    scope = compute_scope(["tests/e2e/test_skills.py"])
+    assert scope["tests"] == ["tests/e2e/test_skills.py"]
+
+
+def test_e2e_conftest_change_does_not_pass_through():
+    """conftest.py is not a test file; it shouldn't match PASS_THROUGH."""
+    scope = compute_scope(["tests/e2e/conftest.py"])
+    assert scope["tests"] == []
+
+
+# === Unrelated files: empty scope ===
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "README.md",
+        "docs/openapi.yaml",
+        "tests/test_auth.py",  # unit test, not e2e
+        "scripts/check_mutmut.py",
+        ".github/workflows/ci.yml",
+    ],
+)
+def test_unrelated_files_yield_empty_scope(path):
+    scope = compute_scope([path])
+    assert scope == {"tests": [], "runtimes": []}
+
+
+def test_empty_change_set_yields_empty_scope():
+    scope = compute_scope([])
+    assert scope == {"tests": [], "runtimes": []}
+
+
+# === Combinations ===
+
+
+def test_mixed_change_unions_test_files():
+    """A PR touching a view AND a runtime gets both the resource e2e and
+    the runtime-specific session tests."""
+    scope = compute_scope(
+        [
+            "src/agent_on_demand/views/agents.py",
+            "src/agent_on_demand/runtimes/claude.py",
+        ]
+    )
+    assert set(scope["tests"]) == {
+        "tests/e2e/test_agents.py",
+        "tests/e2e/test_sessions.py",
+        "tests/e2e/test_skills.py",
+        "tests/e2e/test_mcp.py",
+    }
+    assert scope["runtimes"] == ["claude"]
+
+
+def test_default_runtime_when_no_runtime_file_changed():
+    """A change that triggers e2e but doesn't touch a runtime file falls
+    back to the default runtime (claude — the cheapest)."""
+    scope = compute_scope(["src/agent_on_demand/views/sessions.py"])
+    assert scope["runtimes"] == [DEFAULT_RUNTIME]


### PR DESCRIPTION
## Summary

- New `scripts/scope_e2e.py` computes which e2e tests to run for a PR based on changed source files. Pure `compute_scope()` function; mapping pinned by `tests/test_scope_e2e.py` (37 test cases).
- New `e2e-scoped` CI job runs the scope computation on every PR. If scope is empty → silent skip. If scope is non-empty AND `AOD_API_TOKEN` secret is configured → runs scoped pytest. If scope is non-empty but no token → prints a workflow warning showing what *would* have run.
- New `make scope-e2e` (preview) and `make test-e2e-scoped` (run locally with `AOD_API_TOKEN`) targets.

**The gate is inactive until you configure secrets.** This PR ships all the infrastructure; flipping the switch is a 30-second config change in repo settings (see "How to activate" below).

## Mapping

| Source path | E2E scope |
|---|---|
| `auth.py`, `crypto.py`, `config/`, `runtimes/__init__.py`, `runtimes/base.py`, `observability.py`, `signals.py`, `tasks.py`, `urls.py`, `models_catalog.py`, `models/auth.py` | **ALL** e2e tests |
| `versioning.py` | `test_agents.py` + `test_environments.py` |
| `session_state.py`, `views/sessions.py`, `models/sessions.py`, `stream.py` | `test_sessions.py` |
| `views\|models/{agents,environments}.py` | `test_{agents,environments}.py` |
| `session_service/` | `test_sessions.py` + `test_skills.py` + `test_mcp.py` |
| `runtimes/{name}.py` | session-spawning tests with `E2E_RUNTIMES={name}` |
| `tests/e2e/test_*.py` | that file only (PASS_THROUGH) |
| everything else | empty (no e2e) |

The mapping deliberately falls through to `ALL` for cross-cutting concerns. A few extra test seconds on the wrong PR is cheaper than a missed regression.

## How to activate

1. Add `AOD_API_TOKEN` as a repository secret (Settings → Secrets and variables → Actions)
2. Add `AOD_API_URL` pointing at a CI/staging deployment
3. Next PR will run scoped e2e automatically

Until then, the job runs the scope computation (so any mapping bugs surface) and prints what would have run.

## Cost expectations

A single scoped run targets the cheapest model per runtime (`claude-haiku-4-5`, `gemini-2.5-flash`, `o4-mini`). Most PRs will trigger 1-2 e2e files; cross-cutting changes trigger all 5. Order-of-magnitude: $0.05-$1 per PR depending on scope. The scope mapping is tunable if it's too aggressive.

## Test plan

- [x] `make test` — 395 passed (+37 from `test_scope_e2e.py`)
- [x] `make lint` / `make fmt-check` — pass
- [x] `make scope-e2e` on this branch returns "No e2e tests in scope" (correct — only scripts and infra changed)
- [x] All cases in the mapping pinned by tests
- [ ] CI runs the new `e2e-scoped` job and either runs scoped e2e or prints the no-token notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)