### PR TITLE
Deepen /health + document post-deploy alert checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,18 @@ show <name>` command. Don't add the survivor to the equivalent allowlist
 unless you can prove (with the diff) that no input distinguishes the
 mutant from the original.
 
+## Production observability
+
+`/health` exercises a real DB query plus a field-encryption round-trip — a
+broken deploy that can't reach the DB or has a misconfigured
+`FIELD_ENCRYPTION_KEY` returns 503, and Render auto-rollback fires. See
+`src/agent_on_demand/views/health.py` and `tests/test_health.py`.
+
+For post-deploy alerting (5xx spikes, session-completion drops, worker
+error rates), see the **Alerts to configure** section in
+`docs/runbook.md`. Five Honeycomb + PostHog triggers cover the most
+common regression shapes; setup is GUI-only on those services.
+
 ## Style
 
 - Python 3.11+, ruff with `line-length = 100`.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -24,12 +24,46 @@ External dependencies:
 | Signal                         | Where |
 | ------------------------------ | ----- |
 | Alerts                         | Slack `#alerts` |
-| External `/health` reachability | Checkly — scheduled `GET /health` from outside our network |
+| External `/health` reachability | Checkly — scheduled `GET /health` from outside our network. `/health` exercises DB + field-encryption round-trip; a 503 here means Render auto-rollback should already be firing. See `views/health.py`. |
 | Request rate, error rate, p95  | Honeycomb `aod-web` |
 | Worker task durations, failures | Honeycomb `aod-worker` — look for `session.provision_task` and `session.execute_turn` spans |
 | Session outcomes by runtime    | PostHog — event names above |
 | Deploys, service health, logs, shell | Render dashboard |
 | Queue depth                    | `SELECT status, queue_name, count(*) FROM procrastinate_jobs GROUP BY 1,2;` |
+
+## Alerts to configure
+
+Five triggers cover the regressions we most want to catch in the first 5 minutes after a deploy. Set these up in the listed tool with destination Slack `#alerts`. More than five and people start ignoring; fewer and we miss things.
+
+**1. Web 5xx rate spike** — Honeycomb `aod-web`
+
+```
+COUNT WHERE response.status_code >= 500 GROUP BY 1m
+```
+
+Trigger: more than 5/min for 3 consecutive minutes. Catches the generic "deploy broke a backend handler" class of regression.
+
+**2. `session.completed` volume drop** — PostHog
+
+Insight: count of `session.completed` events, last 30 min vs. previous 30 min. Trigger: > 50% drop. This is the canary for "agents stopped working" — the most user-visible failure mode that doesn't surface as a 5xx.
+
+**3. `session.provision_failed` spike** — PostHog
+
+Insight: count of `session.provision_failed` events, last 5 min. Trigger: > 5 in 5 min (or > 10× baseline). Specifically catches Sprites outages, env-var decryption failures, and auth-to-Sprites bugs — none of which appear as web 5xxs because they happen in the worker.
+
+**4. Worker `execute_turn` error rate** — Honeycomb `aod-worker`
+
+```
+COUNT WHERE error = true AND name = "session.execute_turn" GROUP BY 1m
+```
+
+Trigger: > 5 errors in 5 min. The worker side is invisible to the `aod-web` 5xx alert; this is its counterpart.
+
+**5. `session.failed` rate** — PostHog
+
+Insight: ratio of `session.failed` to (`session.completed` + `session.failed`), last 30 min. Trigger: failure ratio > 30% (typical baseline is < 5%). Stronger than #2 because it catches "sessions still start but most of them break" — a regression that volume metrics miss.
+
+---
 
 ## General triage
 

--- a/src/agent_on_demand/views/health.py
+++ b/src/agent_on_demand/views/health.py
@@ -1,7 +1,46 @@
+"""Health check exercised by Render's auto-rollback path.
+
+Verifies enough that a broken deploy gets rolled back automatically: DB is
+reachable + queryable, and field encryption round-trips. Returns 503 (not
+200) when a check fails so Render's healthCheckPath catches it.
+
+Render polls this every ~5s; both checks are O(1) and the total budget is
+well under the default 5s health-check timeout.
+"""
+
+from django.db import connection
 from django.http import JsonResponse
 from django.views.decorators.http import require_GET
+
+from agent_on_demand.crypto import decrypt, encrypt
+
+
+def _check_db() -> str:
+    try:
+        with connection.cursor() as cur:
+            cur.execute("SELECT 1")
+        return "ok"
+    except Exception as e:
+        return f"fail: {e.__class__.__name__}"
+
+
+def _check_crypto() -> str:
+    try:
+        if decrypt(encrypt("ping")) == "ping":
+            return "ok"
+        return "fail: round-trip mismatch"
+    except Exception as e:
+        return f"fail: {e.__class__.__name__}"
 
 
 @require_GET
 def health(request):
-    return JsonResponse({"status": "ok"})
+    checks = {
+        "db": _check_db(),
+        "crypto": _check_crypto(),
+    }
+    all_ok = all(v == "ok" for v in checks.values())
+    return JsonResponse(
+        {"status": "ok" if all_ok else "degraded", "checks": checks},
+        status=200 if all_ok else 503,
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -100,7 +100,9 @@ def agent(user):
 def test_health(client: Client):
     resp = client.get("/health")
     assert resp.status_code == 200
-    assert resp.json() == {"status": "ok"}
+    # Response shape now includes per-check details — see tests/test_health.py
+    # for the full contract. This test only pins the smoke-test surface.
+    assert resp.json()["status"] == "ok"
 
 
 @pytest.mark.django_db

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,88 @@
+"""Tests for /health — Render's auto-rollback signal.
+
+The endpoint must:
+  - return 200 + status=ok when DB and crypto round-trip both work
+  - return 503 + per-check detail when either fails
+
+These pin the contract Render relies on; a regression here disables
+auto-rollback for downstream deploys.
+"""
+
+import json
+
+from django.test import Client
+
+
+def body(resp):
+    return json.loads(resp.content)
+
+
+def test_health_happy_path(client: Client, db):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    payload = body(resp)
+    assert payload == {"status": "ok", "checks": {"db": "ok", "crypto": "ok"}}
+
+
+def test_health_503_when_db_check_fails(client: Client, db, monkeypatch):
+    """A DB failure must surface as 503 so Render rolls back."""
+
+    def raise_oserror():
+        raise OSError("simulated DB outage")
+
+    # Patch the helper directly — simpler than mocking django.db.connection.
+    monkeypatch.setattr("agent_on_demand.views.health._check_db", lambda: "fail: OSError")
+
+    resp = client.get("/health")
+    assert resp.status_code == 503
+    payload = body(resp)
+    assert payload["status"] == "degraded"
+    assert payload["checks"]["db"].startswith("fail")
+    assert payload["checks"]["crypto"] == "ok"
+
+
+def test_health_503_when_crypto_check_fails(client: Client, db, monkeypatch):
+    """A crypto failure (e.g. FIELD_ENCRYPTION_KEY misconfig) must surface as 503."""
+    monkeypatch.setattr(
+        "agent_on_demand.views.health._check_crypto",
+        lambda: "fail: InvalidToken",
+    )
+
+    resp = client.get("/health")
+    assert resp.status_code == 503
+    payload = body(resp)
+    assert payload["status"] == "degraded"
+    assert payload["checks"]["db"] == "ok"
+    assert payload["checks"]["crypto"].startswith("fail")
+
+
+def test_health_503_when_both_fail(client: Client, db, monkeypatch):
+    monkeypatch.setattr("agent_on_demand.views.health._check_db", lambda: "fail: A")
+    monkeypatch.setattr("agent_on_demand.views.health._check_crypto", lambda: "fail: B")
+
+    resp = client.get("/health")
+    assert resp.status_code == 503
+    payload = body(resp)
+    assert payload == {
+        "status": "degraded",
+        "checks": {"db": "fail: A", "crypto": "fail: B"},
+    }
+
+
+def test_health_response_keys_are_stable(client: Client, db):
+    """Outer keys are part of the contract for whatever's parsing /health
+    (Checkly external probe, Render auto-rollback). Pin them so a refactor
+    can't silently rename them."""
+    resp = client.get("/health")
+    payload = body(resp)
+    assert set(payload.keys()) == {"status", "checks"}
+    assert set(payload["checks"].keys()) == {"db", "crypto"}
+
+
+def test_health_does_not_require_auth(client: Client, db):
+    """Render and Checkly probe /health unauthenticated — adding auth here
+    would break auto-rollback and external monitoring."""
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    # No Authorization header sent.
+    assert resp.headers.get("WWW-Authenticate") is None


### PR DESCRIPTION
## Summary

- **Deepens `/health`** to exercise a real DB query plus a field-encryption round-trip. Returns 200 if both checks pass, 503 with per-check details if either fails. Render's `healthCheckPath: /health` was wired up but pointing at a static `{"status": "ok"}` — auto-rollback was a no-op for any logic regression. Now a broken deploy that can't reach the DB or has a misconfigured `FIELD_ENCRYPTION_KEY` rolls back automatically.
- **Adds an `Alerts to configure` section to `docs/runbook.md`** with the 5 highest-leverage Honeycomb + PostHog triggers covering the regression shapes most likely to slip past CI: 5xx rate spike, `session.completed` volume drop, `session.provision_failed` spike, worker `execute_turn` error rate, `session.failed` ratio.

The runbook section is GUI-setup work on Honeycomb/PostHog (can't ship triggers in code there) — this PR documents what to set up, with concrete queries.

## What's in scope vs. out of scope

This is option A from the design discussion: ship the deeper `/health` (autonomous code work) plus the alert checklist (the only honest substitute for shipping triggers). Option C — a post-deploy probe script that queries Honeycomb/PostHog APIs and pages on anomaly — is deferred until we see whether the manual triggers are sufficient.

## Tests pinning the contract

`tests/test_health.py` (6 tests):
- Happy path: 200 + `{"status": "ok", "checks": {"db": "ok", "crypto": "ok"}}`
- DB check fails → 503 + `checks.db` starts with "fail"
- Crypto check fails → 503 + `checks.crypto` starts with "fail"
- Both fail → 503 + both report failures
- Response keys are stable (Checkly + Render parse this)
- No auth required (Render and Checkly probe unauthenticated)

## Test plan

- [x] `make test` — 401 passed (+6 from `test_health.py`)
- [x] `make lint` / `make fmt-check` — pass
- [x] `make check-schemas` / `make check-migrations` — pass
- [ ] CI green
- [ ] Render deploys; `/health` returns 200; Checkly stays green

## Roadmap status after this PR

| Item | State |
|---|---|
| 1. Mutation-test danger zones | ✅ |
| 2. Migration safety in CI | ✅ |
| 3. API contract diffing | ✅ |
| 4. Scoped e2e per PR | ✅ (gate inactive pending `AOD_API_TOKEN` secret) |
| 5. CLAUDE.md fences | ✅ |
| 6. Rollback + alerting | ✅ (autonomous slice — `/health` + checklist; manual triggers still need GUI setup) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)