### PR TITLE
Add coverage ratchet gate to CI (floor 87%)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,19 @@ jobs:
       - run: uv sync --all-extras
       - run: make test
 
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      - run: uv sync --all-extras
+      - run: make coverage
+
   mutation-test:
     runs-on: ubuntu-latest
     permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,12 @@ show <name>` command. Don't add the survivor to the equivalent allowlist
 unless you can prove (with the diff) that no input distinguishes the
 mutant from the original.
 
+**Coverage floor is a ratchet.** `make coverage` enforces
+`[tool.coverage.report].fail_under` in `pyproject.toml`. PRs that add
+tests should raise the floor toward the new total; PRs that remove tests
+must justify lowering it. Treat the floor like a high-water mark — never
+move it down to "make CI green."
+
 ## Production observability
 
 `/health` exercises a real DB query plus a field-encryption round-trip — a

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,13 @@ worker:
 test:
 	DATABASE_URL=sqlite:///test.db uv run pytest tests/ -v --ignore=tests/e2e
 
+# Run the test suite under coverage and enforce the floor in pyproject.toml
+# (`[tool.coverage.report].fail_under`). Floor is a ratchet — raise it in PRs
+# that add tests; lowering it requires explicit human approval.
+coverage:
+	DATABASE_URL=sqlite:///test.db uv run coverage run -m pytest tests/ --ignore=tests/e2e
+	uv run coverage report
+
 # Mutation testing for danger-zone modules (auth.py, crypto.py). Asserts that
 # every mutant is killed except a small documented set of known-equivalents.
 # See scripts/check_mutmut.py for the equivalent-mutant allowlist.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,12 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "if __name__ == .__main__.:",
 ]
+# Ratcheted floor — raise this in PRs that add tests, never lower it without
+# explicit human approval. `make coverage` enforces. See docs/runbook.md.
+fail_under = 87
+precision = 2
+show_missing = true
+skip_covered = true
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
## Summary
- New `coverage` CI job runs the unit suite under `coverage` and enforces `fail_under = 87` from pyproject.toml (current total: **87.87%**).
- Same pattern as `mutation-test`, `migration-lint`, `check-schemas` — a one-way ratchet that prevents quality regressions at PR time.
- Floor is meant to climb. Subsequent PRs that add tests should raise it; lowering it requires explicit human approval per CLAUDE.md.

## Why
Three of the recently-merged quality PRs (mutation testing, migration linter, schema drift) all share a structural shape: pin the current state, fail CI when a regression sneaks in. Coverage is the missing fourth gate. Without it, a future PR can quietly delete tests for an under-tested module and we'd only notice when something breaks in production.

## Test plan
- [x] `make coverage` passes locally at 87.87% with floor=87
- [x] `coverage report --fail-under=99` exits 2 (gate fails when floor exceeds total)
- [x] `make lint` and `make fmt-check` pass
- [ ] CI `coverage` job goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)