### PR TITLE
Cover real exception paths in /health helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ exclude_lines = [
 ]
 # Ratcheted floor — raise this in PRs that add tests, never lower it without
 # explicit human approval. `make coverage` enforces. See docs/runbook.md.
-fail_under = 87
+fail_under = 88
 precision = 2
 show_missing = true
 skip_covered = true

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -86,3 +86,52 @@ def test_health_does_not_require_auth(client: Client, db):
     assert resp.status_code == 200
     # No Authorization header sent.
     assert resp.headers.get("WWW-Authenticate") is None
+
+
+# The tests above monkey-patch `_check_db` / `_check_crypto` to short-circuit
+# the failure response, which means the *actual* exception-handling branches
+# never execute. The tests below exercise those branches with real raises so
+# a future refactor that narrows `except Exception` to a specific class can't
+# silently slip past CI.
+
+
+def test_check_db_returns_failure_string_on_real_exception(db, monkeypatch):
+    """The bare `except Exception` in _check_db must catch arbitrary errors
+    and surface the class name. If a refactor narrows that catch and the DB
+    raises an unexpected class, /health would 500 instead of returning 503,
+    defeating Render auto-rollback."""
+
+    from agent_on_demand.views import health
+
+    class _BoomConnection:
+        def cursor(self):
+            raise RuntimeError("simulated outage")
+
+    monkeypatch.setattr(health, "connection", _BoomConnection())
+    assert health._check_db() == "fail: RuntimeError"
+
+
+def test_check_crypto_returns_round_trip_mismatch_when_decrypt_differs(monkeypatch):
+    """If encrypt/decrypt are wired up but the round-trip yields a different
+    plaintext (key rotation gone wrong, wrong cipher selected), the helper
+    must report 'round-trip mismatch' — a distinct signal from a hard raise."""
+
+    from agent_on_demand.views import health
+
+    monkeypatch.setattr(health, "encrypt", lambda s: b"opaque-bytes")
+    monkeypatch.setattr(health, "decrypt", lambda b: "not-ping")
+    assert health._check_crypto() == "fail: round-trip mismatch"
+
+
+def test_check_crypto_returns_failure_string_on_real_exception(monkeypatch):
+    """An exception thrown by encrypt or decrypt (e.g. InvalidToken from a
+    rotated FIELD_ENCRYPTION_KEY) must be caught and surfaced via class
+    name — same contract as _check_db."""
+
+    from agent_on_demand.views import health
+
+    def _boom(_):
+        raise ValueError("simulated cipher failure")
+
+    monkeypatch.setattr(health, "encrypt", _boom)
+    assert health._check_crypto() == "fail: ValueError"


### PR DESCRIPTION
## Summary
- Three new tests exercise the *actual* exception branches in `_check_db` and `_check_crypto` (existing tests monkey-patched the helpers, leaving the `except Exception` blocks and `round-trip mismatch` early-return uncovered).
- Lifts `views/health.py` from 78% → **100%** line coverage; project total 87.87% → **88.10%**.
- Bumps the coverage floor from 87 to 88 (one-way ratchet from #138).

## Why
A refactor that narrows `except Exception` to a specific class (e.g., `OperationalError`) would silently slip past CI today — but in production, an unexpected exception class would 500 instead of returning 503, and Render auto-rollback wouldn't fire. Same risk for the round-trip equality check: if someone removes it, /health would return 'ok' even when crypto is broken. These tests pin those contracts to real exceptions.

## Test plan
- [x] All 3 new tests pass
- [x] `make coverage` passes at 88.10% with floor=88
- [x] `make lint` passes
- [ ] CI green

## Base branch
This PR stacks on #138 (`coverage-gate-floor`). Merge #138 first, then this rebases cleanly onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)