### PR TITLE
ci: trigger CI on every PR regardless of base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 name: CI
 on:
+  # Run on every pull request regardless of base branch so stacked PRs
+  # (PR #N based on PR #N-1 instead of main) get the same gate coverage as
+  # PRs that target main directly. The `concurrency` group below de-dupes
+  # superseded runs on the same ref.
   pull_request:
-    branches: [main]
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- Drop the `branches: [main]` filter on the `pull_request` trigger so stacked PRs (PR #N based on PR #N-1) get the same gate coverage as PRs against main.
- Push trigger remains main-only; concurrency group already handles dedup.

## Why
This came up while stacking the coverage-improvement chain (#138, #139, #140, #141, #142). PRs #140–#142 ran zero checks — the entire CI suite (coverage, mutation, schema, migration, e2e-scope) was silently skipped because their base wasn't main. That defeats the point of the gates: a stacked PR can land changes without ever being verified, then go green only after rebasing onto main right before merge.

After this lands, future stacks will run their full gate set on every push, so a regression in PR #N-1's content gets caught before #N stacks more on top.

## Test plan
- [x] Diff is minimal — just the trigger config
- [ ] CI green on this PR
- [ ] After landing, rebase a stacked PR (e.g. #140) and verify checks fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)