### PR TITLE
Cover Gemini MCP headers/env branches and no-op install

### DIFF
--- a/tests/runtimes/test_gemini.py
+++ b/tests/runtimes/test_gemini.py
@@ -92,3 +92,87 @@ def test_write_config_empty_mcp_servers_writes_nothing(user):
     sprite = RecordingSprite("s")
     GeminiRuntime().write_config(sprite, _spec(user), [])
     assert "/home/sprite/.gemini/settings.json" not in sprite.write_map()
+
+
+def test_install_is_a_no_op():
+    """The Gemini CLI is preinstalled in the runtime image, so .install() must
+    do nothing — adding work here would silently slow every session start."""
+    assert GeminiRuntime().install(sprite=None) is None
+
+
+@pytest.mark.django_db
+def test_write_config_url_server_includes_headers_when_provided(user):
+    """Custom headers (e.g. Authorization) must round-trip into the JSON
+    config; otherwise authenticated remote MCP servers silently fail to
+    connect at session start."""
+    sprite = RecordingSprite("s")
+    GeminiRuntime().write_config(
+        sprite,
+        _spec(user),
+        [
+            McpServerSpec(
+                name="api",
+                type="url",
+                url="https://mcp.example.com/mcp",
+                headers={"Authorization": "Bearer abc", "X-Trace": "1"},
+            )
+        ],
+    )
+    cfg = json.loads(sprite.write_map()["/home/sprite/.gemini/settings.json"])
+    entry = cfg["mcpServers"]["api"]
+    assert entry["headers"] == {"Authorization": "Bearer abc", "X-Trace": "1"}
+    assert entry["httpUrl"] == "https://mcp.example.com/mcp"
+    assert entry["trust"] is True
+
+
+@pytest.mark.django_db
+def test_write_config_stdio_server_includes_env_when_provided(user):
+    """env is optional but, when provided, must reach the MCP process —
+    a missing env block silently breaks API-key auth for stdio servers."""
+    sprite = RecordingSprite("s")
+    GeminiRuntime().write_config(
+        sprite,
+        _spec(user),
+        [
+            McpServerSpec(
+                name="local",
+                type="stdio",
+                command="npx",
+                args=["-y", "@some/mcp-server"],
+                env={"API_KEY": "secret-from-env-vars", "DEBUG": "1"},
+            )
+        ],
+    )
+    cfg = json.loads(sprite.write_map()["/home/sprite/.gemini/settings.json"])
+    entry = cfg["mcpServers"]["local"]
+    assert entry["env"] == {"API_KEY": "secret-from-env-vars", "DEBUG": "1"}
+    assert entry["command"] == "npx"
+    assert entry["args"] == ["-y", "@some/mcp-server"]
+    assert entry["trust"] is True
+
+
+@pytest.mark.django_db
+def test_write_config_url_server_omits_headers_when_absent(user):
+    """The optional `headers` key must be absent from the JSON when the
+    spec carries no headers — adding `"headers": null` (or {}) would change
+    the schema downstream consumers see."""
+    sprite = RecordingSprite("s")
+    GeminiRuntime().write_config(
+        sprite,
+        _spec(user),
+        [McpServerSpec(name="bare", type="url", url="https://x")],
+    )
+    cfg = json.loads(sprite.write_map()["/home/sprite/.gemini/settings.json"])
+    assert "headers" not in cfg["mcpServers"]["bare"]
+
+
+@pytest.mark.django_db
+def test_write_config_stdio_server_omits_env_when_absent(user):
+    sprite = RecordingSprite("s")
+    GeminiRuntime().write_config(
+        sprite,
+        _spec(user),
+        [McpServerSpec(name="bare", type="stdio", command="run-mcp")],
+    )
+    cfg = json.loads(sprite.write_map()["/home/sprite/.gemini/settings.json"])
+    assert "env" not in cfg["mcpServers"]["bare"]


### PR DESCRIPTION
## Summary
- Five new tests for `GeminiRuntime` cover the previously-uncovered `headers` (URL MCP) and `env` (stdio MCP) optional-field branches, plus pin the absence-of-key contract when those fields aren't provided.
- Adds the no-op `install()` test (parity with the codex no-op test in #141).
- Lifts `runtimes/gemini.py` from 91% → **100%** line coverage.
- **No `fail_under` bump** — avoids pyproject.toml merge conflicts with the in-flight ratchet PRs (#139/#140/#141/#142).

## Why
Three of the five tests guard concrete failure modes:
- A refactor that fails to copy `headers` into the JSON would silently break authenticated remote MCP servers — connections would fail at session start with no clear signal.
- Same for `env` on stdio MCP — API keys provided that way would silently disappear.
- The two "omits when absent" tests pin schema shape: emitting `"headers": null` or `"env": {}` looks innocuous in Python but changes what downstream consumers see in the JSON file the Gemini CLI reads.

## Test plan
- [x] All 12 gemini tests pass (5 new + 7 existing)
- [x] `runtimes/gemini.py` at 100% coverage
- [x] Project total 87.87% → 88.01%
- [x] `make lint`, `make fmt-check` pass
- [ ] CI green

## Base
Off `main` to avoid the no-CI-on-stacked-PRs issue (which #143 fixes once it lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)