### PR TITLE
Expand ruff lint to bugbear, async, pie, tidy-imports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,14 @@ tests should raise the floor toward the new total; PRs that remove tests
 must justify lowering it. Treat the floor like a high-water mark — never
 move it down to "make CI green."
 
+**Ruff `select` is a ratchet.** `[tool.ruff.lint].select` in
+`pyproject.toml` lists rule families that were zero-violation at the
+time they were added. Each one prevents a class of bug from regressing
+silently. To add a new family, run `ruff check --select=<rule>` until
+clean, then merge it in. Don't drop a family from `select` to "make CI
+green" — fix the violation or `# noqa` the specific line with a
+justification.
+
 ## Production observability
 
 `/health` exercises a real DB query plus a field-encryption round-trip — a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,22 @@ dev = [
 target-version = "py311"
 line-length = 100
 
+[tool.ruff.lint]
+# Default ruff selection (E4, E7, E9, F) plus rule families that catch real
+# bugs without requiring code changes today. Each addition was zero-violation
+# at adoption time — adding here is a one-way ratchet that prevents the same
+# class of bug from sneaking back in.
+select = [
+    "E4",     # pycodestyle: import errors
+    "E7",     # pycodestyle: statement errors
+    "E9",     # pycodestyle: runtime errors (syntax)
+    "F",      # pyflakes: undefined names, unused imports
+    "B",      # flake8-bugbear: likely bugs (mutable defaults, stale references)
+    "ASYNC",  # flake8-async: blocking calls in async, missing awaits
+    "PIE",    # flake8-pie: misc anti-patterns
+    "TID",    # flake8-tidy-imports: relative-import drift, banned imports
+]
+
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "config.settings"
 pythonpath = ["src"]


### PR DESCRIPTION
## Summary
- Add `[tool.ruff.lint].select` listing the default subset (E4/E7/E9/F) plus four new rule families: B (bugbear), ASYNC, PIE, TID.
- Each family was **zero-violation** at adoption time, so no code changes are needed today — this is purely a gate addition.
- CLAUDE.md adds a short ratchet note (treat `select` like a high-water mark).

## Why
Same pattern as the coverage gate (#138), mutation testing (#126/#130/#132), migration linter (#133), and schema drift (#135): pin current state, fail CI on regression. Each new rule family blocks a real class of bug that's currently impossible to introduce *only because nobody happens to have done it*:

- **B006 mutable default args** — silent shared state across calls; classic Python footgun.
- **B017 `pytest.raises(Exception)`** — too broad; lets a test pass on any error including the wrong one.
- **B023 stale loop variable** — closure captures the variable, not the value; broken async/lazy code.
- **ASYNC1 blocking calls in async** — defeats async; common to add accidentally when refactoring.
- **PIE790 unnecessary `pass`/`...`** — usually leftover from an in-progress edit.
- **TID252 relative imports** — drift with the codebase's `from agent_on_demand.X` convention.

## Test plan
- [x] `make lint` clean (0 errors with new select)
- [x] `make fmt-check` clean
- [x] `make test` clean (no behavior change)
- [ ] CI green

## Base
Off `main`. Independent of #139–#144 (no shared files except CLAUDE.md, but the section I'm editing is appended below the section #138 introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)