### PR TITLE
Cover error-path branches in views/agents.py

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -4,8 +4,16 @@ import uuid
 import pytest
 from django.contrib.auth.models import User
 from django.test import Client
+from django.utils import timezone
 
-from agent_on_demand.models import Agent, AgentVersion, APIKey, UserCredential, UserSpritesKey
+from agent_on_demand.models import (
+    Agent,
+    AgentVersion,
+    APIKey,
+    Environment,
+    UserCredential,
+    UserSpritesKey,
+)
 
 
 @pytest.fixture
@@ -439,3 +447,201 @@ def test_create_session_with_archived_agent(client: Client, auth_headers, agent,
     )
     assert resp.status_code == 409
     assert "archived" in resp.json()["detail"]
+
+
+# --- Method-not-allowed and JSON-error paths ---
+#
+# These pin the contract for malformed requests, wrong HTTP methods, and the
+# never-quite-tested "validate-then-load" sequence in PUT /agents/{id}. Each
+# branch was reachable but uncovered, so a refactor that, say, returned 422
+# instead of 400 for invalid JSON could land silently.
+
+
+@pytest.mark.django_db
+def test_agents_collection_rejects_unknown_method(client: Client, auth_headers):
+    """PATCH on /agents must return 405 — anything else would be a contract change."""
+    resp = client.patch("/agents", **auth_headers)
+    assert resp.status_code == 405
+    assert resp.json()["detail"] == "Method not allowed"
+
+
+@pytest.mark.django_db
+def test_agent_detail_rejects_unknown_method(client: Client, auth_headers, agent):
+    """DELETE on /agents/{id} must return 405. Agents are archived (POST
+    /agents/{id}/archive), not deleted, so DELETE has no defined behavior."""
+    resp = client.delete(f"/agents/{agent.id}", **auth_headers)
+    assert resp.status_code == 405
+
+
+@pytest.mark.django_db
+def test_create_agent_invalid_json(client: Client, auth_headers):
+    resp = client.post("/agents", data="{not json", content_type="application/json", **auth_headers)
+    assert resp.status_code == 400
+    assert "Invalid JSON" in resp.json()["detail"]
+
+
+@pytest.mark.django_db
+def test_update_agent_invalid_json(client: Client, auth_headers, agent):
+    resp = client.put(
+        f"/agents/{agent.id}",
+        data="{not json",
+        content_type="application/json",
+        **auth_headers,
+    )
+    assert resp.status_code == 400
+    assert "Invalid JSON" in resp.json()["detail"]
+
+
+@pytest.mark.django_db
+def test_update_agent_unknown_runtime(client: Client, auth_headers, agent):
+    """A PUT that names a runtime not in RUNTIMES must 400 with the list of
+    known runtimes — same contract as POST /agents."""
+    resp = client.put(
+        f"/agents/{agent.id}",
+        data=json.dumps({"version": agent.version, "runtime": "nonexistent-runtime"}),
+        content_type="application/json",
+        **auth_headers,
+    )
+    assert resp.status_code == 400
+    assert "Unknown runtime" in resp.json()["detail"]
+
+
+@pytest.mark.django_db
+def test_update_agent_runtime_model_incompat(client: Client, auth_headers, agent):
+    """Switching to a runtime whose providers don't include the agent's
+    current model must 422 — otherwise sessions would 500 at provision time."""
+    # claude runtime can't serve openai/* models.
+    resp = client.put(
+        f"/agents/{agent.id}",
+        data=json.dumps({"version": agent.version, "model": "openai/gpt-4.1"}),
+        content_type="application/json",
+        **auth_headers,
+    )
+    assert resp.status_code == 422
+    assert "cannot serve" in resp.json()["detail"]
+
+
+# --- Environment edge cases on create + update ---
+
+
+@pytest.mark.django_db
+def test_create_agent_environment_not_found(client: Client, auth_headers):
+    resp = client.post(
+        "/agents",
+        data=json.dumps(
+            {
+                "name": "x",
+                "model": "anthropic/claude-sonnet-4-6",
+                "runtime": "claude",
+                "environment_id": str(uuid.uuid4()),
+            }
+        ),
+        content_type="application/json",
+        **auth_headers,
+    )
+    assert resp.status_code == 404
+    assert "Environment not found" in resp.json()["detail"]
+
+
+@pytest.mark.django_db
+def test_create_agent_environment_archived(client: Client, auth_headers, user):
+    """Archived envs must not be assignable to new agents — otherwise the
+    agent could only ever produce sessions that fail at provisioning."""
+    env = Environment.objects.create(
+        user=user,
+        name="archived-env",
+        archived_at=timezone.now(),
+        version=1,
+    )
+    resp = client.post(
+        "/agents",
+        data=json.dumps(
+            {
+                "name": "x",
+                "model": "anthropic/claude-sonnet-4-6",
+                "runtime": "claude",
+                "environment_id": str(env.id),
+            }
+        ),
+        content_type="application/json",
+        **auth_headers,
+    )
+    assert resp.status_code == 409
+    assert "archived environment" in resp.json()["detail"]
+
+
+@pytest.mark.django_db
+def test_update_agent_environment_not_found(client: Client, auth_headers, agent):
+    resp = client.put(
+        f"/agents/{agent.id}",
+        data=json.dumps({"version": agent.version, "environment_id": str(uuid.uuid4())}),
+        content_type="application/json",
+        **auth_headers,
+    )
+    assert resp.status_code == 404
+    assert "Environment not found" in resp.json()["detail"]
+
+
+@pytest.mark.django_db
+def test_update_agent_environment_archived(client: Client, auth_headers, agent, user):
+    env = Environment.objects.create(
+        user=user,
+        name="archived-env",
+        archived_at=timezone.now(),
+        version=1,
+    )
+    resp = client.put(
+        f"/agents/{agent.id}",
+        data=json.dumps({"version": agent.version, "environment_id": str(env.id)}),
+        content_type="application/json",
+        **auth_headers,
+    )
+    assert resp.status_code == 409
+    assert "archived environment" in resp.json()["detail"]
+
+
+@pytest.mark.django_db
+def test_update_agent_clears_environment_with_explicit_null(
+    client: Client, auth_headers, agent, user
+):
+    """Sending environment_id=null must detach the env (PR #115 contract).
+    Explicit null is distinct from absent: an absent key leaves the env
+    unchanged, but `null` clears it."""
+    env = Environment.objects.create(user=user, name="e", version=1)
+    agent.environment = env
+    agent.save()
+
+    resp = client.put(
+        f"/agents/{agent.id}",
+        data=json.dumps({"version": agent.version, "environment_id": None}),
+        content_type="application/json",
+        **auth_headers,
+    )
+    assert resp.status_code == 200
+    agent.refresh_from_db()
+    assert agent.environment_id is None
+
+
+# --- Archive + versions 404 paths ---
+
+
+@pytest.mark.django_db
+def test_archive_agent_not_found(client: Client, auth_headers):
+    resp = client.post(f"/agents/{uuid.uuid4()}/archive", **auth_headers)
+    assert resp.status_code == 404
+
+
+@pytest.mark.django_db
+def test_archive_agent_invalid_uuid(client: Client, auth_headers):
+    """A non-UUID string in the URL must 404, not 500. The view catches
+    ValueError from the DB layer's UUID parser."""
+    resp = client.post("/agents/not-a-uuid/archive", **auth_headers)
+    # Either Django's URL routing (uuid converter) gives a 404, or the view
+    # catches ValueError → 404. Both paths are valid; what matters is no 500.
+    assert resp.status_code == 404
+
+
+@pytest.mark.django_db
+def test_list_versions_agent_not_found(client: Client, auth_headers):
+    resp = client.get(f"/agents/{uuid.uuid4()}/versions", **auth_headers)
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
Fourteen new tests for `views/agents.py` error paths that were previously uncovered. `views/agents.py` from 90% → **97%** line coverage.

Branches pinned:
- 405 method-not-allowed on collection (PATCH) and detail (DELETE)
- 400 invalid JSON on POST and PUT
- 400 unknown runtime on PUT (mirror of POST contract)
- 422 runtime/model incompatibility on PUT
- 404/409 environment-not-found / environment-archived on POST and PUT
- 200 explicit `environment_id: null` clears the env (pins PR #115)
- 404 archive/versions on missing agent + non-UUID path

## Why
The 405 paths and explicit-null clear were the most worth pinning. A refactor that returned 500 on a malformed UUID (vs 404), or a refactor that "simplified" the explicit-null detection to coalesce with absent-from-payload, would silently break SDK behavior — the explicit-null path was the bug fixed in #115 and currently had no regression test outside of integration. The archived-env-not-assignable contract was the bug fixed in #122 and gets a fresh, focused test.

## Test plan
- [x] All 14 new tests pass; existing 24 pass too (38 total)
- [x] views/agents.py 90% → 97%; project total 87.87% → 88.92%
- [x] `make lint`, `make fmt-check`, `make test` clean
- [ ] CI green

## Base
Off `main`. No file overlap with the in-flight PRs (#139–#145).

🤖 Generated with [Claude Code](https://claude.com/claude-code)