### PR TITLE
Pin model/runtime invariants in test_models_catalog

### DIFF
--- a/tests/test_models_catalog.py
+++ b/tests/test_models_catalog.py
@@ -46,3 +46,54 @@ def test_model_def_is_frozen():
 def test_runtimes_field_defaults_to_none():
     defn = ModelDef(id="anthropic/claude-sonnet-4-6", provider="anthropic")
     assert defn.runtimes is None
+
+
+def test_every_model_is_servable_by_at_least_one_runtime():
+    """No orphaned models: every entry in MODELS must be servable by at
+    least one runtime whose `providers` set includes the model's
+    provider. Otherwise creating an agent with that model would always
+    fail at session-create with a runtime/provider mismatch — a
+    catalog/runtime drift bug that's painful to diagnose in production."""
+    from agent_on_demand.runtimes import RUNTIMES
+
+    for model_id, model in MODELS.items():
+        servers = [
+            name for name, runtime in RUNTIMES.items() if model.provider in runtime.providers
+        ]
+        assert servers, (
+            f"Model {model_id!r} has provider {model.provider!r} "
+            f"but no runtime in RUNTIMES advertises support for it. "
+            f"Either add the provider to a runtime's providers set, or "
+            f"remove the model from MODELS."
+        )
+
+        # If the model restricts to specific runtimes, every restriction
+        # target must (a) actually exist in RUNTIMES and (b) be among the
+        # servers we just computed.
+        if model.runtimes is not None:
+            for restricted_to in model.runtimes:
+                assert restricted_to in RUNTIMES, (
+                    f"Model {model_id!r}.runtimes references {restricted_to!r} "
+                    f"which is not in RUNTIMES."
+                )
+                assert restricted_to in servers, (
+                    f"Model {model_id!r}.runtimes restricts to {restricted_to!r} "
+                    f"but that runtime does not advertise provider {model.provider!r}."
+                )
+
+
+def test_every_runtime_provider_has_at_least_one_model():
+    """Reverse-direction sanity check: every provider advertised by some
+    runtime has at least one model in MODELS targeting it. Otherwise a
+    runtime is half-wired — listed in RUNTIMES, mentioned in docs, but
+    unusable because no model targets it."""
+    from agent_on_demand.runtimes import RUNTIMES
+
+    advertised_providers = {p for runtime in RUNTIMES.values() for p in runtime.providers}
+    used_providers = {model.provider for model in MODELS.values()}
+    orphan_providers = advertised_providers - used_providers
+    assert not orphan_providers, (
+        f"Runtime(s) advertise provider(s) {sorted(orphan_providers)!r} but no model "
+        f"in MODELS targets them. Either remove from runtime.providers or "
+        f"add a model entry."
+    )


### PR DESCRIPTION
## Summary
Two new semantic tests in `tests/test_models_catalog.py`:
1. Every entry in `MODELS` must be servable by at least one runtime in `RUNTIMES`.
2. Every provider advertised by some runtime has at least one model targeting it.

Plus two sub-checks for `model.runtimes` restrictions: each restriction must reference a real runtime, and that runtime must advertise the provider the model needs.

## Why
These prevent the "edit MODELS but forget RUNTIMES" drift (and vice versa). The forward direction would silently break agent creation for the orphaned model — a session-time error that's painful to diagnose. The reverse direction surfaces half-wired runtimes that get listed in docs but can't be used.

Each assertion fails with a specific actionable message naming the offending model or provider.

## Test plan
- [x] All new tests pass
- [x] `make lint`, `make fmt-check` pass

## Base
Off `main`. Modifies tests/test_models_catalog.py — no overlap with #139–#157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)