### PR TITLE
Bump coverage floor 89.7 → 96 to lock in recent gains

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ exclude_lines = [
 ]
 # Ratcheted floor — raise this in PRs that add tests, never lower it without
 # explicit human approval. `make coverage` enforces. See docs/runbook.md.
-fail_under = 89.7
+fail_under = 96
 precision = 2
 show_missing = true
 skip_covered = true


### PR DESCRIPTION
## Summary
Bump `[tool.coverage.report].fail_under` from `89.7` to `96`. Project total is now **96.66%** (up from 87.87% when the floor was first established in #138).

## Why
Across the recently merged batch (#139, #140, #141, #142, #144, #146–162) the actual coverage rose ~9 points but the floor stayed at 89.7. That's a 6+ point slack — a future PR could silently delete tests and drop coverage to 90% without tripping the gate. Locking in the gain is the whole point of the ratchet.

96 is conservative (actual is 96.66; the 0.66-point buffer absorbs normal test-run variance).

## Test plan
- [x] `make coverage` passes at 96.66% with floor=96
- [x] Floor would correctly fail if total dropped to 95.99%

🤖 Generated with [Claude Code](https://claude.com/claude-code)