### PR TITLE
Enable ruff C4 and RET; auto-fix the 4 violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,8 @@ select = [
     "ASYNC",  # flake8-async: blocking calls in async, missing awaits
     "PIE",    # flake8-pie: misc anti-patterns
     "TID",    # flake8-tidy-imports: relative-import drift, banned imports
+    "C4",     # flake8-comprehensions: dict()/list() literal preferences
+    "RET",    # flake8-return: unnecessary elif/else after return
 ]
 
 [tool.pytest.ini_options]

--- a/src/agent_on_demand/views/agents.py
+++ b/src/agent_on_demand/views/agents.py
@@ -367,7 +367,7 @@ def agents_list_create(request):
 
         return JsonResponse(_serialize_agent(agent), status=201)
 
-    elif request.method == "GET":
+    if request.method == "GET":
         qs = Agent.objects.filter(user=request.user, archived_at__isnull=True).order_by(
             "-created_at"
         )

--- a/src/agent_on_demand/views/environments.py
+++ b/src/agent_on_demand/views/environments.py
@@ -215,7 +215,7 @@ def environments_list_create(request):
 
         return JsonResponse(_serialize_environment(env), status=201)
 
-    elif request.method == "GET":
+    if request.method == "GET":
         qs = Environment.objects.filter(user=request.user, archived_at__isnull=True).order_by(
             "-created_at"
         )

--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -40,17 +40,17 @@ def user(db):
 
 
 def _spec(user, **overrides) -> SessionSpec:
-    defaults = dict(
-        name="sprite-x",
-        runtime=RUNTIMES["claude"],
-        model="anthropic/claude-sonnet-4-6",
-        user=user,
-        runtime_session_id="11111111-2222-3333-4444-555555555555",
-        environment=None,
-        repos=[],
-        mcp_servers=[],
-        skills=[],
-    )
+    defaults = {
+        "name": "sprite-x",
+        "runtime": RUNTIMES["claude"],
+        "model": "anthropic/claude-sonnet-4-6",
+        "user": user,
+        "runtime_session_id": "11111111-2222-3333-4444-555555555555",
+        "environment": None,
+        "repos": [],
+        "mcp_servers": [],
+        "skills": [],
+    }
     defaults.update(overrides)
     return SessionSpec(**defaults)
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -187,7 +187,7 @@ def test_execute_turn_preserves_terminated_status(user, mocker):
             refresh_count[0] += 1
             if refresh_count[0] >= 2:
                 self.status = "terminated"
-                return
+                return None
         return original_refresh(self, *args, **kwargs)
 
     mocker.patch.object(AgentSession, "refresh_from_db", fake_refresh)


### PR DESCRIPTION
## Summary
- Auto-fix 4 violations: 1 C4 (dict() → {}) and 3 RET505 (unnecessary elif after return)
- Add `C4` and `RET` to `[tool.ruff.lint].select`

## Why
Pairs with #145 (B/ASYNC/PIE/TID). C4 catches the `dict()`/`list()`-instead-of-literal antipattern that's both slower and less idiomatic. RET505 catches dead `elif` branches after `return` — they don't run, but readers have to mentally re-prove that, and they trip up control-flow refactors.

After the fixes, both rule families are zero-violation, so adding them to `select` is purely a forward-protection move (same shape as the original ruff PR #145).

## Test plan
- [x] All 533 tests pass post-fix
- [x] `make lint` clean
- [x] `make fmt-check` clean
- [x] Coverage unchanged (no test removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)