### PR TITLE
Cover env_file and git_credentials write-error paths

### DIFF
--- a/tests/fakes/sprite.py
+++ b/tests/fakes/sprite.py
@@ -35,15 +35,31 @@ class _FSPath:
         return _FSPath(self.fs, joined)
 
     def write_text(self, text: str) -> None:
-        self.fs.writes.append(RecordedWrite(path="/" + self.path.lstrip("/"), text=text))
+        normalized = "/" + self.path.lstrip("/")
+        self.fs._maybe_raise_on_write(normalized)
+        self.fs.writes.append(RecordedWrite(path=normalized, text=text))
 
 
 @dataclass
 class _Filesystem:
     writes: list[RecordedWrite] = field(default_factory=list)
+    _write_raise_predicates: list[tuple] = field(default_factory=list)
 
     def __truediv__(self, other: str) -> _FSPath:
         return _FSPath(self, str(other).lstrip("/"))
+
+    def raise_on_write(self, path_predicate, exc: Exception) -> None:
+        """Arrange for the next write_text whose normalized path matches
+        `path_predicate(path)` to raise `exc`. Predicate can also be a
+        substring; matches paths containing it."""
+        self._write_raise_predicates.append((path_predicate, exc))
+
+    def _maybe_raise_on_write(self, path: str) -> None:
+        for i, (pred, exc) in enumerate(self._write_raise_predicates):
+            matched = pred(path) if callable(pred) else pred in path
+            if matched:
+                del self._write_raise_predicates[i]
+                raise exc
 
 
 class _CommandHandle:

--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -189,6 +189,53 @@ class TestProvisionSessionFailureHandling:
             provision_session(user, _spec(user, environment=env))
         assert ei.value.stage == "network_policy"
 
+    def test_write_env_file_sprite_error_tags_stage(self, user, fake_sprites):
+        """A SpriteError raised during the env-file write must surface as
+        ProvisionError(stage=env_file). Without this branch covered, a
+        refactor that didn't wrap SpriteError here would leak it as an
+        opaque 500 from the worker."""
+        original_create = fake_sprites.create_sprite
+
+        def wrapped(name):
+            sprite = original_create(name)
+            sprite.filesystem().raise_on_write("aod-env", SpriteError("disk fail"))
+            return sprite
+
+        fake_sprites.create_sprite = wrapped
+
+        with pytest.raises(ProvisionError) as ei:
+            provision_session(user, _spec(user))
+        assert ei.value.stage == "env_file"
+        assert fake_sprites.deleted == ["sprite-x"]
+
+    def test_write_git_credentials_sprite_error_tags_stage(self, user, fake_sprites):
+        """A SpriteError raised during the .git-credentials write must
+        surface as stage=git_credentials. Reaches this branch by giving
+        the spec a repo with a token — without a token, no creds file
+        is written and the branch is skipped."""
+        from agent_on_demand.session_service.specs import RepoSpec
+
+        original_create = fake_sprites.create_sprite
+
+        def wrapped(name):
+            sprite = original_create(name)
+            sprite.filesystem().raise_on_write(".git-credentials", SpriteError("disk fail"))
+            return sprite
+
+        fake_sprites.create_sprite = wrapped
+
+        repos = [
+            RepoSpec(
+                url="https://github.com/owner/repo",
+                mount_path="/repos/repo",
+                token="ghp_fake",
+            )
+        ]
+        with pytest.raises(ProvisionError) as ei:
+            provision_session(user, _spec(user, repos=repos))
+        assert ei.value.stage == "git_credentials"
+        assert fake_sprites.deleted == ["sprite-x"]
+
 
 class TestDestroyAndResumeSession:
     """destroy_session is a best-effort cleanup; resume_session is the


### PR DESCRIPTION
## Summary
- Extend `tests/fakes/sprite.py` with `_Filesystem.raise_on_write` (mirrors the existing `RecordingSprite.raise_on` for commands)
- Two new tests: env_file SpriteError → stage=env_file; git_credentials SpriteError → stage=git_credentials
- `session_service/provisioning.py` 90.91% → ~92.5%; project 96.66% → 96.84%

## Why
The env_file and git_credentials writes happen during provisioning. A SpriteError there (Sprite filesystem outage, disk full, etc.) must surface as `ProvisionError` with the right stage tag so failed-stage telemetry attributes the outage correctly.

Both branches were uncovered. A refactor that dropped the SpriteError wrapper would silently leak a 500 from the worker — caught now at PR time.

The `raise_on_write` extension is small infrastructure investment that unlocks future coverage of any other fs.write-based error path in provisioning.

## Test plan
- [x] All 535 tests pass (2 new + 533 existing)
- [x] `make lint`, `make fmt-check`, `make test` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)