### PR TITLE
Silence OTel 401 noise from BatchProcessors in tests

### DIFF
--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -97,8 +97,36 @@ def test_init_otel_short_circuits_when_already_initialized(monkeypatch):
 @pytest.fixture
 def reset_otel(monkeypatch):
     """Reset OTel global state for tests that exercise init_otel's full body.
-    Each test is responsible for cleaning up loggers it attached."""
+    Each test is responsible for cleaning up loggers it attached.
+
+    Also patches the OTLP exporters with no-ops so the lingering
+    BatchSpanProcessor / BatchLogRecordProcessor inside the global providers
+    don't try to flush to api.honeycomb.io with the fake key at session
+    teardown — that produces noisy 401 errors in CI logs even though the
+    tests themselves pass.
+    """
     import logging
+
+    class _NoopExporter:
+        def export(self, _records):
+            return 0  # SUCCESS
+
+        def shutdown(self):
+            return None
+
+        def force_flush(self, _timeout_millis=30000):
+            return True
+
+    # The exporters are imported lazily inside init_otel, so patch the
+    # source modules rather than `observability.<name>`.
+    monkeypatch.setattr(
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter",
+        lambda **_kw: _NoopExporter(),
+    )
+    monkeypatch.setattr(
+        "opentelemetry.exporter.otlp.proto.http._log_exporter.OTLPLogExporter",
+        lambda **_kw: _NoopExporter(),
+    )
 
     monkeypatch.setattr(observability, "_otel_initialized", False)
     root = logging.getLogger()


### PR DESCRIPTION
## Summary
The `reset_otel` fixture I added in #148 wired up real OTel `BatchSpanProcessor` / `BatchLogRecordProcessor` pointing at `api.honeycomb.io`. With the fake `HONEYCOMB_API_KEY` the tests set, the processors queue records successfully but then try to flush to Honeycomb at session teardown — producing two harmless-but-noisy CI log lines:

```
Failed to export logs batch code: 401, reason: Unauthorized
Failed to export span batch code: 401, reason: Unauthorized
```

This PR patches `OTLPSpanExporter` and `OTLPLogExporter` with a no-op exporter inside `reset_otel`, so the BatchProcessors flush a no-op at teardown and no network call fires.

## Why
- Cleaner `make coverage` output locally and in CI
- Avoids accidental log-grep matches on the false-positive 401 lines (bug-triage noise)
- The patch is in the fixture, not in production code — `init_otel` itself still uses the real exporters

A follow-up will apply the same fix to `tests/test_observability_streamhandler.py` once #168 merges (the same noise originates from that file's single `init_otel` call).

## Test plan
- [x] `pytest tests/test_observability.py` — clean output (no 401 lines)
- [x] Full suite still passes (536 tests)
- [x] `make lint`, `make fmt-check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)