### PR TITLE
Fix Render deploy: gate django_migration_linter on availability

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,3 +1,4 @@
+import importlib.util
 import os
 from pathlib import Path
 
@@ -25,9 +26,15 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "corsheaders",
     "procrastinate.contrib.django",
-    "django_migration_linter",
     "agent_on_demand.apps.AgentOnDemandConfig",
 ]
+
+# django-migration-linter is a dev-only dependency (used by `make
+# check-migrations` in CI). Render's prod build runs `uv sync` without
+# `--all-extras`, so the package isn't present at runtime — list it only
+# when importable to avoid AppConfig.create() crashing on startup.
+if importlib.util.find_spec("django_migration_linter") is not None:
+    INSTALLED_APPS.append("django_migration_linter")
 
 MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",


### PR DESCRIPTION
## Summary

Render deploys are failing on Django startup with:

```
ModuleNotFoundError: No module named 'django_migration_linter'
  File ".../django/apps/config.py", line 193, in create
    import_module(entry)
```

`django-migration-linter` is a **dev-only** dep (declared under
`[project.optional-dependencies].dev` in `pyproject.toml`, used by
`make check-migrations` in CI). But `INSTALLED_APPS` listed it
unconditionally, and Render's `buildCommand` runs `uv sync` *without*
`--all-extras`, so prod tried to import a package it never installed.

The fix gates the `INSTALLED_APPS` entry on `importlib.util.find_spec(...)`:

- Dev (`make install` → `uv sync --all-extras`) → the package is
  installed → entry is appended → `lintmigrations` works as before.
- Prod (Render `uv sync`) → the package isn't installed → entry is
  skipped → Django boots cleanly.

## Verification

- [x] `make lint` clean
- [x] `make test` — 545 passed
- [x] `make check-migrations` — still finds the `lintmigrations` command
- [x] Simulated Render's exact build path: `uv sync` (no extras) followed
  by `manage.py check`, `collectstatic --noinput`, and `migrate --noinput`
  — all succeed. Without this fix, every one of those commands would have
  raised the same `ModuleNotFoundError` seen in the failing deploy logs.

## Test plan

- [ ] CI green
- [ ] Render redeploys cleanly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)