### PR TITLE
Cover per-runtime MCP-server mkdir paths in provision script

### DIFF
--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -62,6 +62,41 @@ class TestProvisionSessionOrder:
         script = sprite.write_map()["/tmp/aod-provision.sh"]
         assert "chmod 600 /tmp/aod-env" in script
 
+    @pytest.mark.parametrize(
+        "runtime_name,expected_dir",
+        [
+            ("codex", "/home/sprite/.codex"),
+            ("gemini", "/home/sprite/.gemini"),
+            ("opencode", "/home/sprite/.config/opencode"),
+        ],
+    )
+    def test_mcp_servers_mkdir_in_provision_script_per_runtime(
+        self, user, fake_sprites, runtime_name, expected_dir
+    ):
+        """Runtimes whose MCP config file lives under a non-default directory
+        need that directory created before the post-script ``fs.write``.
+        Without the mkdir, the runtime config write fails with stage=
+        runtime_config and the session never reaches running. Claude is
+        excluded — its config goes to ``/home/sprite/.claude.json`` and the
+        parent already exists."""
+        from agent_on_demand.session_service.specs import McpServerSpec
+
+        mcp_servers = [McpServerSpec(name="srv", type="url", url="https://example.com/mcp")]
+        provision_session(
+            user,
+            _spec(user, runtime=RUNTIMES[runtime_name], mcp_servers=mcp_servers),
+        )
+        script = fake_sprites.last_sprite().write_map()["/tmp/aod-provision.sh"]
+        assert f"mkdir -p {expected_dir}" in script
+
+    def test_no_mcp_servers_no_runtime_mkdir(self, user, fake_sprites):
+        """Without MCP servers, the runtime-specific config dirs are not
+        created — the mkdir line is only emitted for post-script writes that
+        actually need the parent dir to exist."""
+        provision_session(user, _spec(user, runtime=RUNTIMES["codex"]))
+        script = fake_sprites.last_sprite().write_map()["/tmp/aod-provision.sh"]
+        assert "/home/sprite/.codex" not in script
+
     def test_single_bash_command_invokes_provision_script(self, user, fake_sprites):
         provision_session(user, _spec(user))
         sprite = fake_sprites.last_sprite()


### PR DESCRIPTION
## Summary

- Stacked on top of #173.
- `_directories_for_post_script_writes` emits an `mkdir -p` line for runtimes whose MCP config file lives in a non-default directory (codex → `.codex`, gemini → `.gemini`, opencode → `.config/opencode`). Without it, the post-script `fs.write` of the runtime config fails and the session never reaches `running`. Claude is excluded — its config goes to `/home/sprite/.claude.json` and the parent already exists.
- Adds a parametrized test asserting the `mkdir` line is present in the rendered provision script for each non-claude runtime when `mcp_servers` are set, plus a negative test confirming the line is omitted when `mcp_servers` are empty. Pins lines 371/373/375.
- `provisioning.py` 95.26% → 96.44%; total 97.71% → 97.85%.

## Test plan

- [x] `make test` passes (551 passed, +4)
- [x] `make coverage` reports `provisioning.py` 96.44%
- [x] `make lint`, `make fmt-check`, `make typecheck` clean
- [x] CI: lint, typecheck, test, coverage, mutation-test, migration-lint, e2e-scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)