### PR TITLE
Raise on unknown manager in _package_commands

### DIFF
--- a/src/agent_on_demand/session_service/provisioning.py
+++ b/src/agent_on_demand/session_service/provisioning.py
@@ -388,7 +388,15 @@ def _directories_for_post_script_writes(spec: SessionSpec) -> list[str]:
 def _package_commands(manager: str, pkgs: list[str]) -> list[str]:
     """Shell command strings for a single package manager, inlined into the
     provision script. They rely on login-shell PATH (script is invoked with
-    `bash -l`)."""
+    `bash -l`).
+
+    The API validator (`VALID_PACKAGE_MANAGERS` in `views/environments.py`)
+    blocks unknown managers at request time, and the caller iterates
+    `PACKAGE_MANAGER_ORDER`, so in practice this only sees the six managers
+    branched on below. Raising on a mismatch turns a future drift bug
+    (manager added to ORDER but not to this dispatch, or vice versa) into a
+    loud provision-time failure instead of silently dropping the user's
+    packages."""
     quoted = " ".join(shlex.quote(p) for p in pkgs)
     if manager == "apt":
         return [f"apt-get update -qq && apt-get install -y {quoted}"]
@@ -402,7 +410,7 @@ def _package_commands(manager: str, pkgs: list[str]) -> list[str]:
         return [f"gem install {quoted}"]
     if manager == "go":
         return [f"go install {shlex.quote(p)}" for p in pkgs]
-    return []
+    raise ValueError(f"Unsupported package manager: {manager!r}")
 
 
 def _write_runtime_config(

--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -420,6 +420,22 @@ class TestProvisionStageEvents:
         assert AgentSessionLog.objects.count() == 0
 
 
+class TestPackageCommands:
+    """`_package_commands` translates a (manager, packages) pair into shell
+    install commands inlined in the provision script. The dispatch is
+    keyed on six known managers; an unrecognized one must raise loudly so
+    a future drift between `PACKAGE_MANAGER_ORDER` and the dispatch (or
+    a new manager added to `VALID_PACKAGE_MANAGERS` without a builder)
+    fails at provision time instead of silently dropping the user's
+    packages."""
+
+    def test_unknown_manager_raises(self):
+        from agent_on_demand.session_service.provisioning import _package_commands
+
+        with pytest.raises(ValueError, match="Unsupported package manager: 'yarn'"):
+            _package_commands("yarn", ["express"])
+
+
 class TestProvisionSessionEnvFileShape:
     def test_env_vars_sorted_and_quoted(self, user, fake_sprites):
         env = Environment.objects.create(


### PR DESCRIPTION
## Summary

- Stacked on top of #174 (which is stacked on #173).
- `_package_commands` previously fell through to `return []` when handed a manager outside the six branched on. Today that path is unreachable — `VALID_PACKAGE_MANAGERS` in `views/environments.py` rejects unknown managers at request time and `_build_provision_script` iterates `PACKAGE_MANAGER_ORDER`, which lists the same six. But the silent fallback is a footgun: a future agent that adds a manager to `PACKAGE_MANAGER_ORDER` (or to the API allowlist) without adding a builder branch here would silently drop the user's packages. The session would still come up "successfully" — just without the requested install.
- Replace with an explicit `raise ValueError(...)` so a drift between the lists fails loudly at provision time, before the session ever reaches the user.
- Adds a unit test pinning the raise.

## Why this is safe

No existing call path can hit the `return []`: API validation (request-schema-snapshotted) blocks unknown managers, and the loop iterates the canonical order list. The behavior change only surfaces if a future change desyncs the three places — exactly when we want the loud failure.

## Test plan

- [x] `make test` passes (552 passed, +1)
- [x] `make coverage` reports `provisioning.py` 96.84% (was 96.44%); total 97.89%
- [x] `make lint`, `make fmt-check`, `make typecheck`, `make check-schemas`, `validate_openapi` clean
- [x] CI: lint, typecheck, test, coverage, mutation-test, migration-lint, e2e-scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)