### PR TITLE
Cover provision-setup stderr-tail capture in ProvisionError detail

### DIFF
--- a/tests/fakes/sprite.py
+++ b/tests/fakes/sprite.py
@@ -66,11 +66,15 @@ class _CommandHandle:
     def __init__(self, recorder: "RecordingSprite", argv: tuple[str, ...]):
         self._recorder = recorder
         self._argv = argv
+        # Production callers may assign a writable bytes-like buffer to
+        # `cmd.stderr` to capture stderr from the run. _maybe_raise honors it
+        # when a predicate provides stderr_text.
+        self.stderr: Any = None
 
     def run(self) -> None:
         recorded = RecordedCommand(argv=self._argv, ran=True)
         self._recorder.commands.append(recorded)
-        self._recorder._maybe_raise(self._argv)
+        self._recorder._maybe_raise(self._argv, stderr_buf=self.stderr)
 
 
 class RecordingSprite:
@@ -125,22 +129,27 @@ class RecordingSprite:
                         out.append(stripped)
         return out
 
-    def raise_on(self, predicate, exc: Exception) -> None:
+    def raise_on(self, predicate, exc: Exception, *, stderr: bytes = b"") -> None:
         """Arrange for the next command matching `predicate(argv_tuple)` to
         raise `exc` instead of succeeding. Predicate can also be the string
-        'update_network_policy' to target the policy call."""
-        self._raise_on_predicates.append((predicate, exc))
+        'update_network_policy' to target the policy call.
 
-    def _maybe_raise(self, argv: tuple[str, ...]) -> None:
-        for i, (pred, exc) in enumerate(self._raise_on_predicates):
-            if callable(pred):
-                if pred(argv):
-                    del self._raise_on_predicates[i]
-                    raise exc
-            else:
-                if argv and argv[0] == pred:
-                    del self._raise_on_predicates[i]
-                    raise exc
+        When `stderr` is non-empty and the matched call is a
+        `_CommandHandle` whose caller assigned a writable buffer to
+        `cmd.stderr`, those bytes are written to that buffer just before
+        the exception is raised — mirroring the real Sprites SDK, which
+        flushes captured stderr to the buffer before surfacing
+        SpriteError."""
+        self._raise_on_predicates.append((predicate, exc, stderr))
+
+    def _maybe_raise(self, argv: tuple[str, ...], stderr_buf: Any = None) -> None:
+        for i, (pred, exc, stderr) in enumerate(self._raise_on_predicates):
+            matched = pred(argv) if callable(pred) else (bool(argv) and argv[0] == pred)
+            if matched:
+                del self._raise_on_predicates[i]
+                if stderr and stderr_buf is not None:
+                    stderr_buf.write(stderr)
+                raise exc
 
 
 class RecordingSpritesClient:

--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -271,6 +271,39 @@ class TestProvisionSessionFailureHandling:
         assert ei.value.stage == "git_credentials"
         assert fake_sprites.deleted == ["sprite-x"]
 
+    def test_provision_setup_failure_includes_stderr_tail_in_detail(
+        self, user, fake_sprites, mocker
+    ):
+        """When the provision script fails, ProvisionError.detail must
+        include the captured stderr tail. Without that branch, operators
+        see only "Provisioning script failed: <SpriteError msg>" — apt or
+        git errors that are critical to triage stay hidden behind the
+        opaque transport error.
+
+        Reaches the branch by arranging for the bash invocation to raise
+        SpriteError after the fake writes a stderr blob to the buffer
+        the provisioning code assigned to `cmd.stderr`."""
+        original_create = fake_sprites.create_sprite
+
+        def wrapped(name):
+            sprite = original_create(name)
+            sprite.raise_on(
+                lambda argv: argv[:2] == ("bash", "-l"),
+                SpriteError("exit 1"),
+                stderr=b"E: Unable to locate package not-a-real-pkg\n",
+            )
+            return sprite
+
+        mocker.patch.object(fake_sprites, "create_sprite", side_effect=wrapped)
+
+        with pytest.raises(ProvisionError) as ei:
+            provision_session(user, _spec(user))
+        assert ei.value.stage == "provision_setup"
+        # Both the SpriteError message and the captured stderr tail must
+        # appear in the detail — operators rely on the stderr to triage.
+        assert "Provisioning script failed: exit 1" in str(ei.value)
+        assert "stderr:\nE: Unable to locate package not-a-real-pkg" in str(ei.value)
+
     def test_write_runtime_config_sprite_error_tags_stage(self, user, fake_sprites):
         """A SpriteError raised while the runtime writes its config (claude's
         ``.claude.json`` with mcp_servers) must surface as stage=runtime_config.


### PR DESCRIPTION
## Summary

- Stacked on top of #175 (#175 → #174 → #173).
- When the provision script fails, `_run_provision_setup` decodes up to 2000 bytes of captured stderr and appends `stderr:\n<tail>` to the `ProvisionError` detail. Without that branch, operators see only the opaque `Provisioning script failed: <SpriteError msg>` — losing apt / git / setup-script errors that are critical to triage.
- Extends the recording sprite's `raise_on` to accept an optional `stderr` bytes payload that is written to whatever buffer the production code assigned to `cmd.stderr` just before the exception is raised — mirroring how the real Sprites SDK flushes captured stderr before surfacing SpriteError.
- Pins line 295. `provisioning.py` 96.84% → 97.23%; total 97.89% → 97.94%.

## Test plan

- [x] `make test` passes (553 passed, +1)
- [x] `make coverage` reports `provisioning.py` 97.23%
- [x] `make lint`, `make fmt-check`, `make typecheck` clean
- [x] Existing fake-using tests still pass (no regression from the `raise_on` signature extension)
- [x] CI: lint, typecheck, test, coverage, mutation-test, migration-lint, e2e-scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)