### PR TITLE
Remove dead `if script is None` branch in _run_provision_setup

### DIFF
--- a/src/agent_on_demand/session_service/provisioning.py
+++ b/src/agent_on_demand/session_service/provisioning.py
@@ -267,12 +267,6 @@ def _run_provision_setup(sprite: Sprite, spec: SessionSpec, session_id: str | No
     is the single expensive round trip — everything shell-flavoured
     (chmod, package install, git clone, user setup) runs inside it."""
     script = _build_provision_script(spec)
-    if script is None:
-        # Nothing to do (no packages, no repos, no user setup, no /tmp files
-        # to chmod... actually chmod on /tmp/aod-env always needs running).
-        # _build_provision_script always returns non-None because chmod on
-        # ENV_FILE_PATH is unconditional, so we shouldn't hit this.
-        return
     with stage_timer(session_id, STAGE_PROVISION_SETUP):
         try:
             fs = sprite.filesystem()


### PR DESCRIPTION
## Summary

- Stacked on top of #176 (#176 → #175 → #174 → #173).
- `_build_provision_script` is typed `-> str` and unconditionally chmods `ENV_FILE_PATH`, so it cannot return `None`. The `if script is None: return` guard in `_run_provision_setup` was already documented as unreachable in a comment ("we shouldn't hit this") and never fired in coverage. Drop it — dead defensive code rots and confuses future readers.
- `provisioning.py` 97.23% → 97.61%; total 97.94% → 97.98%.

## Test plan

- [x] `make test` passes (553 passed, no change)
- [x] `make coverage` reports `provisioning.py` 97.61%
- [x] `make lint`, `make fmt-check`, `make typecheck` clean
- [x] CI: lint, typecheck, test, coverage, mutation-test, migration-lint, e2e-scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)