### PR TITLE
Cover create-path env_vars and networking validators

### DIFF
--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -748,6 +748,47 @@ class TestEnvironmentErrorPaths:
         )
         assert resp.status_code == 422
 
+    def test_create_env_vars_invalid_key_returns_422(self, client: Client, auth_headers):
+        """env_vars keys must match [A-Za-z_][A-Za-z0-9_]*. Hyphens or
+        leading digits would corrupt the /tmp/aod-env shell file when
+        written as `KEY=value` lines and could be sourced into the
+        agent's process environment as a different name. Pin the
+        rejection on the create path — the update path is already
+        tested but this validator runs on both."""
+        resp = client.post(
+            "/environments",
+            data=json.dumps(
+                {
+                    "name": "bad",
+                    "env_vars": {"BAD-KEY": "v"},
+                }
+            ),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 422
+        assert "BAD-KEY" in str(resp.json()["detail"])
+
+    def test_create_limited_networking_with_non_list_hosts_returns_422(
+        self, client: Client, auth_headers
+    ):
+        """allowed_hosts must be a list — a string would silently bypass
+        the firewall config for limited networking. The update path is
+        already tested; pin the create path too so a refactor that
+        diverges the two validators fails loudly."""
+        resp = client.post(
+            "/environments",
+            data=json.dumps(
+                {
+                    "name": "bad",
+                    "networking": {"type": "limited", "allowed_hosts": "evil.example.com"},
+                }
+            ),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 422
+
     def test_update_env_vars_change_increments_version(
         self, client: Client, auth_headers, environment
     ):


### PR DESCRIPTION
## Summary

- Branched directly off main (no more stacking — flat PRs going forward to avoid the orphan-merge mishap from the previous batch).
- `CreateEnvironmentRequest` and `UpdateEnvironmentRequest` each carry their own validator copy for `env_vars` regex and `networking.allowed_hosts` shape. The update path was already tested; the create path was not.
- Two new tests pin the create path so a refactor that diverges the two validators fails loudly:
  - **`env_vars` keys with hyphens / leading digits → 422** (line 64). The shell-assignment write to `/tmp/aod-env` would corrupt with such keys, and the resulting variable could land in the agent process under a different name.
  - **limited networking with non-list `allowed_hosts` → 422** (line 76). A string would silently bypass the firewall config for limited networking.
- `views/environments.py` 96.96% → 97.83%; total 98.72% → 98.81%.

## Note on remaining gaps

Lines 56 and 99 (`packages.<mgr> must be a list of strings`) are unreachable from HTTP — pydantic v2 strictly validates the `dict[str, list[str]]` annotation before the explicit field validator runs. I'll file a follow-up to remove that dead validator code (mirrors the `if script is None` cleanup from #177 in the prior batch).

## Test plan

- [x] `make test` passes (569 passed, +2)
- [x] `make coverage` reports `views/environments.py` 97.83%
- [x] `make lint`, `make fmt-check` clean
- [x] CI: lint, typecheck, test, coverage, mutation-test, migration-lint, e2e-scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)