### PR TITLE
Remove dead packages list-of-strings validator branches

### DIFF
--- a/src/agent_on_demand/views/environments.py
+++ b/src/agent_on_demand/views/environments.py
@@ -46,14 +46,15 @@ class CreateEnvironmentRequest(BaseModel):
     @field_validator("packages")
     @classmethod
     def validate_packages(cls, v: dict) -> dict:
-        for manager, pkgs in v.items():
+        # The list[str] shape check is enforced by pydantic's
+        # `dict[str, list[str]]` annotation; we only need to validate the
+        # manager name here.
+        for manager in v:
             if manager not in VALID_PACKAGE_MANAGERS:
                 raise ValueError(
                     f"Unknown package manager: {manager}. "
                     f"Must be one of: {sorted(VALID_PACKAGE_MANAGERS)}"
                 )
-            if not isinstance(pkgs, list) or not all(isinstance(p, str) for p in pkgs):
-                raise ValueError(f"packages.{manager} must be a list of strings")
         return v
 
     @field_validator("env_vars")
@@ -88,15 +89,16 @@ class UpdateEnvironmentRequest(BaseModel):
     @field_validator("packages")
     @classmethod
     def validate_packages(cls, v: dict | None) -> dict | None:
+        # The list[str] shape check is enforced by pydantic's
+        # `dict[str, list[str]] | None` annotation; we only need to validate
+        # the manager name here.
         if v is not None:
-            for manager, pkgs in v.items():
+            for manager in v:
                 if manager not in VALID_PACKAGE_MANAGERS:
                     raise ValueError(
                         f"Unknown package manager: {manager}. "
                         f"Must be one of: {sorted(VALID_PACKAGE_MANAGERS)}"
                     )
-                if not isinstance(pkgs, list) or not all(isinstance(p, str) for p in pkgs):
-                    raise ValueError(f"packages.{manager} must be a list of strings")
         return v
 
     @field_validator("env_vars")


### PR DESCRIPTION
## Summary

The explicit `if not isinstance(pkgs, list) or not all(isinstance(p, str) for p in pkgs)` check in `CreateEnvironmentRequest` and `UpdateEnvironmentRequest` validators is unreachable from HTTP under pydantic v2 — the field annotation `dict[str, list[str]]` is strictly validated by pydantic before any `field_validator` runs.

Probed empirically:
- `{"pip": "not-a-list"}` → `ValidationError: Input should be a valid list [type=list_type]` (pydantic, before validator)
- `{"pip": [123]}` → `ValidationError: Input should be a valid string [type=string_type]` (pydantic, before validator)

Drop the dead branches; keep the manager-name allowlist check (which the type annotation can't express). Mirrors the `if script is None` cleanup in #177.

`views/environments.py`: 230 → 226 statements. Behavior unchanged — the existing `test_create_packages_non_string_list_returns_422` still passes via pydantic's type validation.

## Test plan

- [x] `make test` passes (567 passed, no regression)
- [x] `make coverage` clean
- [x] `make lint`, `make fmt-check`, `make typecheck` clean
- [x] CI: lint, typecheck, test, coverage, mutation-test, migration-lint, e2e-scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)