### PR TITLE
Pin opencode write_config skip-on-unknown-MCP-type behavior

### DIFF
--- a/tests/runtimes/test_opencode.py
+++ b/tests/runtimes/test_opencode.py
@@ -157,3 +157,48 @@ def test_write_config_empty_mcp_servers_writes_nothing(user):
     sprite = RecordingSprite("s")
     OpencodeRuntime().write_config(sprite, _spec(user), [])
     assert "/home/sprite/.config/opencode/opencode.json" not in sprite.write_map()
+
+
+@pytest.mark.django_db
+def test_write_config_skips_unknown_type_server(user):
+    """The API validator (`VALID_MCP_SERVER_TYPES`) blocks anything but
+    `url`/`stdio` at request time, so this defensive `else: continue`
+    branch only fires if a future spec drift introduces a new MCP type
+    without an opencode builder. Pin the skip-don't-crash behavior so a
+    refactor can't silently turn unknown types into `entry`-undefined
+    NameError 500s.
+
+    Mixed list — the unknown is skipped, the valid one is still written."""
+    sprite = RecordingSprite("s")
+    OpencodeRuntime().write_config(
+        sprite,
+        _spec(user),
+        [
+            McpServerSpec(name="ghost", type="future-shape"),
+            McpServerSpec(name="real", type="url", url="https://example.com/mcp"),
+        ],
+    )
+    cfg = json.loads(sprite.write_map()["/home/sprite/.config/opencode/opencode.json"])
+    assert "ghost" not in cfg["mcp"]
+    assert cfg["mcp"]["real"]["url"] == "https://example.com/mcp"
+
+
+@pytest.mark.django_db
+def test_write_config_all_unknown_types_writes_nothing(user):
+    """Sibling case to the empty-list test: when *every* server is an
+    unknown type, every iteration takes the `else: continue` branch,
+    `config` stays empty, and the early `if not config: return` prevents
+    the file from being written at all. Pins the file-not-written
+    behavior so a refactor that drops the `if not config` guard would
+    surface as a regression here rather than a stray empty-mcp file
+    landing on every Sprite."""
+    sprite = RecordingSprite("s")
+    OpencodeRuntime().write_config(
+        sprite,
+        _spec(user),
+        [
+            McpServerSpec(name="ghost-1", type="future-shape"),
+            McpServerSpec(name="ghost-2", type="another-future-shape"),
+        ],
+    )
+    assert "/home/sprite/.config/opencode/opencode.json" not in sprite.write_map()


### PR DESCRIPTION
## Summary

`opencode.write_config` has a defensive `else: continue` branch for MCP servers whose `type` isn't `url` or `stdio`. The API validator (`VALID_MCP_SERVER_TYPES`) blocks anything else at request time, so the branch only fires if a future spec drift introduces a new MCP type without an opencode builder.

Without this branch tested, a refactor that drops the `else: continue` and lets `entry` stay undefined would 500 the next session that happens to carry such a server (rare today, but the failure would be indistinguishable from a generic worker crash). Pin the skip-don't-crash behavior so the next reader knows it's intentional.

`runtimes/opencode.py` 97.06% → 100.00%; total 98.72% → 98.76%.

## Followup note

Claude/codex/gemini share the same silent-skip-on-unknown-type pattern (no explicit `else`, so unknown types fall off the if/elif). When we run mutmut against runtime code, the survivors will surface — at that point worth either hardening all four runtimes to fail loudly (matching #175) or making the skip explicit everywhere.

## Test plan

- [x] `make test` passes (568 passed, +1)
- [x] `make coverage` reports `runtimes/opencode.py` 100%
- [x] `make lint`, `make fmt-check` clean
- [x] CI: lint, typecheck, test, coverage, mutation-test, migration-lint, e2e-scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)