### PR TITLE
Cover update_agent 404-on-missing-row branch

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -205,6 +205,27 @@ def test_create_agent_mcp_servers_entry_must_be_object(client: Client, auth_head
 
 
 @pytest.mark.django_db
+def test_update_agent_not_found_returns_404(client: Client, auth_headers):
+    """A PUT to /agents/{nonexistent-uuid} must 404, not 500. The handler
+    has no pre-lock fetch — the validate-then-load sequence runs first
+    (json/pydantic/runtime/env), then `select_for_update().get()` is
+    expected to be the only DB read for the agent. Pin the 404 path so
+    a refactor that adds a pre-lock fetch (and changes the error
+    surface) doesn't silently break the contract.
+
+    Sends a complete payload (version + a real change) so we know the
+    response came from the DoesNotExist catch, not earlier validation."""
+    resp = client.put(
+        f"/agents/{uuid.uuid4()}",
+        data=json.dumps({"version": 1, "name": "renamed"}),
+        content_type="application/json",
+        **auth_headers,
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Agent not found"
+
+
+@pytest.mark.django_db
 def test_update_agent_with_unknown_model_returns_422(client: Client, auth_headers, user):
     """UpdateAgentRequest validates the new model the same way
     CreateAgentRequest does — an update that flips an agent to a


### PR DESCRIPTION
## Summary

The `PUT /agents/{id}` handler has no pre-lock fetch — it goes straight into `transaction.atomic()` where `select_for_update().get()` is the first DB read. The `(Agent.DoesNotExist, ValueError)` catch returns a clean 404; without it, a missing row surfaces as a 500.

Pin the 404 path so a refactor that adds a pre-lock fetch (changing the error surface) doesn't silently break the contract for non-existent agent ids.

**Note**: `ValueError` in the catch tuple is defensive against malformed UUIDs reaching `select_for_update.get()`. In practice the URL converter `<uuid:agent_id>` 404s malformed UUIDs at routing time before the view runs, so only the `DoesNotExist` path is reachable from HTTP. One test is enough to cover the line.

`views/agents.py` 99.34% → 99.67% (only line 241 — the `ModelDef.runtimes` allowlist branch covered in #188 — remains uncovered).

## Test plan

- [x] `make test` passes (568 passed, +1)
- [x] `make coverage` reports `views/agents.py` 99.67%
- [x] `make lint`, `make fmt-check` clean
- [x] CI: lint, typecheck, test, coverage, mutation-test, migration-lint, e2e-scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)