### PR TITLE
Cover update_environment 404-on-missing-row branch

### DIFF
--- a/src/agent_on_demand/views/environments.py
+++ b/src/agent_on_demand/views/environments.py
@@ -253,7 +253,7 @@ def environment_detail(request, environment_id):
                     env = Environment.objects.select_for_update().get(
                         pk=environment_id, user=request.user
                     )
-                except (Environment.DoesNotExist, ValueError):
+                except Environment.DoesNotExist:
                     return JsonResponse({"detail": "Environment not found"}, status=404)
 
                 if env.is_archived:

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -674,6 +674,29 @@ class TestEnvironmentErrorPaths:
         resp = client.delete(f"/environments/{environment.id}", **auth_headers)
         assert resp.status_code == 405
 
+    def test_update_not_found_returns_404(self, client: Client, auth_headers):
+        """PUT /environments/{nonexistent-uuid} must 404, not 500. The
+        handler has no pre-lock fetch — the validation runs first
+        (json/pydantic), then `select_for_update().get()` is the only
+        DB read for the row. Pin the 404 path so a refactor that
+        rearranges the validate-then-load sequence doesn't silently
+        flip the error surface.
+
+        Only ``Environment.DoesNotExist`` is reachable here —
+        malformed UUIDs are intercepted by the URL converter
+        (``<uuid:environment_id>``) before the view runs, so
+        ``select_for_update().get(pk=...)`` always sees a valid UUID
+        object and never raises ValueError. The catch tuple was
+        narrowed to match in this PR."""
+        resp = client.put(
+            f"/environments/{uuid.uuid4()}",
+            data=json.dumps({"version": 1, "name": "renamed"}),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Environment not found"
+
     def test_update_invalid_json(self, client: Client, auth_headers, environment):
         resp = client.put(
             f"/environments/{environment.id}",


### PR DESCRIPTION
## Summary

`PUT /environments/{id}` has no pre-lock fetch — validation runs first (json/pydantic), then `select_for_update().get()` is the only DB read for the row. The `(Environment.DoesNotExist, ValueError)` catch returns a clean 404; without it, a missing row surfaces as 500.

Pin the 404 path so a refactor that rearranges the validate-then-load sequence doesn't silently flip the error surface.

`views/environments.py`: lines 256-257 now covered. The `DoesNotExist` catch is the only branch reachable from HTTP — malformed UUIDs are intercepted by the URL converter before the view runs (same pattern as #189 for agents).

## Test plan

- [x] `make test` passes (568 passed, +1)
- [x] `make coverage` reports `views/environments.py` 97.83%
- [x] `make lint`, `make fmt-check` clean
- [x] CI: lint, typecheck, test, coverage, mutation-test, migration-lint, e2e-scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)