### PR TITLE
Drop dead ValueError catches across views/

### DIFF
--- a/src/agent_on_demand/views/agents.py
+++ b/src/agent_on_demand/views/agents.py
@@ -383,7 +383,7 @@ def agent_detail(request, agent_id):
     if request.method == "GET":
         try:
             agent = Agent.objects.get(pk=agent_id, user=request.user)
-        except (Agent.DoesNotExist, ValueError):
+        except Agent.DoesNotExist:
             return JsonResponse({"detail": "Agent not found"}, status=404)
         return JsonResponse(_serialize_agent(agent))
 
@@ -521,7 +521,7 @@ def agent_archive(request, agent_id):
     """Archive an agent (read-only, no new sessions)."""
     try:
         agent = Agent.objects.get(pk=agent_id, user=request.user)
-    except (Agent.DoesNotExist, ValueError):
+    except Agent.DoesNotExist:
         return JsonResponse({"detail": "Agent not found"}, status=404)
 
     if agent.is_archived:
@@ -543,7 +543,7 @@ def agent_versions(request, agent_id):
     """List all versions of an agent."""
     try:
         agent = Agent.objects.get(pk=agent_id, user=request.user)
-    except (Agent.DoesNotExist, ValueError):
+    except Agent.DoesNotExist:
         return JsonResponse({"detail": "Agent not found"}, status=404)
 
     versions = AgentVersion.objects.filter(agent=agent).order_by("-version")

--- a/src/agent_on_demand/views/environments.py
+++ b/src/agent_on_demand/views/environments.py
@@ -231,7 +231,7 @@ def environment_detail(request, environment_id):
     if request.method == "GET":
         try:
             env = Environment.objects.get(pk=environment_id, user=request.user)
-        except (Environment.DoesNotExist, ValueError):
+        except Environment.DoesNotExist:
             return JsonResponse({"detail": "Environment not found"}, status=404)
         return JsonResponse(_serialize_environment(env))
 
@@ -330,7 +330,7 @@ def environment_archive(request, environment_id):
     """Archive an environment (read-only, no new sessions)."""
     try:
         env = Environment.objects.get(pk=environment_id, user=request.user)
-    except (Environment.DoesNotExist, ValueError):
+    except Environment.DoesNotExist:
         return JsonResponse({"detail": "Environment not found"}, status=404)
 
     if env.is_archived:
@@ -370,7 +370,7 @@ def environment_delete(request, environment_id):
                 )
             env_id_str = str(env.id)
             env.delete()
-    except (Environment.DoesNotExist, ValueError):
+    except Environment.DoesNotExist:
         return JsonResponse({"detail": "Environment not found"}, status=404)
 
     with posthog.new_context():
@@ -386,7 +386,7 @@ def environment_versions(request, environment_id):
     """List all versions of an environment."""
     try:
         env = Environment.objects.get(pk=environment_id, user=request.user)
-    except (Environment.DoesNotExist, ValueError):
+    except Environment.DoesNotExist:
         return JsonResponse({"detail": "Environment not found"}, status=404)
 
     versions = EnvironmentVersion.objects.filter(environment=env).order_by("-version")

--- a/src/agent_on_demand/views/sessions.py
+++ b/src/agent_on_demand/views/sessions.py
@@ -348,7 +348,7 @@ def get_session(request, session_id):
     """Return session metadata."""
     try:
         session = AgentSession.objects.get(pk=session_id, user=request.user)
-    except (AgentSession.DoesNotExist, ValueError):
+    except AgentSession.DoesNotExist:
         return JsonResponse({"detail": "Session not found"}, status=404)
 
     return JsonResponse(_serialize_session(session))
@@ -360,7 +360,7 @@ async def stream_session(request, session_id):
     """Stream session logs via SSE (live tail + full replay)."""
     try:
         session = await AgentSession.objects.aget(pk=session_id, user=request.user)
-    except (AgentSession.DoesNotExist, ValueError):
+    except AgentSession.DoesNotExist:
         return JsonResponse({"detail": "Session not found"}, status=404)
 
     raw = request.META.get("HTTP_LAST_EVENT_ID") or request.GET.get("since", "0")
@@ -403,7 +403,7 @@ def send_prompt(request, session_id):
     """
     try:
         session = AgentSession.objects.get(pk=session_id, user=request.user)
-    except (AgentSession.DoesNotExist, ValueError):
+    except AgentSession.DoesNotExist:
         return JsonResponse({"detail": "Session not found"}, status=404)
 
     # A `failed` session may have left its Sprite mid-execution (see Muddy
@@ -503,7 +503,7 @@ def list_session_turns(request, session_id):
     """Return the full turn history for a session, ordered by turn_number."""
     try:
         session = AgentSession.objects.get(pk=session_id, user=request.user)
-    except (AgentSession.DoesNotExist, ValueError):
+    except AgentSession.DoesNotExist:
         return JsonResponse({"detail": "Session not found"}, status=404)
 
     turns = session.turns.order_by("turn_number")
@@ -525,7 +525,7 @@ def terminate_session(request, session_id):
             session.status = "terminated"
             session.sprite_name = ""
             session.save(update_fields=["status", "sprite_name", "updated_at"])
-    except (AgentSession.DoesNotExist, ValueError):
+    except AgentSession.DoesNotExist:
         return JsonResponse({"detail": "Session not found"}, status=404)
 
     if sprite_name:
@@ -561,7 +561,7 @@ def delete_session(request, session_id):
                 return err
             session_id_str = str(session.id)
             session.delete()  # pre_delete signal handles Sprite cleanup
-    except (AgentSession.DoesNotExist, ValueError):
+    except AgentSession.DoesNotExist:
         return JsonResponse({"detail": "Session not found"}, status=404)
 
     with posthog.new_context():


### PR DESCRIPTION
## Summary

Every Django URL converter on this project uses `<uuid:...>` for `agent_id` / `environment_id` / `session_id`, which means malformed UUIDs 404 at the routing layer before the view body runs. So `Model.objects.get(pk=<url-param>)` never sees a non-UUID string and never raises `ValueError` — the `(Model.DoesNotExist, ValueError)` catch tuples were dead code.

Reviewer flagged this on #190; this PR closes the gap everywhere else (#189 and #190 carry the same fix in their own scope).

## What's narrowed (13 catches)

`pk=` argument is a URL-converter-validated UUID — `ValueError` unreachable:

- **`views/agents.py`** (3): `agent_detail` GET, `agent_archive`, `agent_versions`
- **`views/environments.py`** (4): `environment_detail` GET, `environment_archive`, `environment_delete`, `environment_versions`
- **`views/sessions.py`** (6): `get_session`, `stream_session`, `send_prompt` pre-lock, `list_session_turns`, `terminate_session`, `delete_session`

## What's intentionally left intact (4 catches)

`pk=` comes from request body, where pydantic accepts any string and a malformed UUID would raise `ValueError` when Django parses it for the WHERE clause:

- `views/sessions.py:176` (`Agent.get` from `req.agent_id`)
- `views/sessions.py:186` (`Environment.get` from `env_id`)
- `views/agents.py:328` (`Environment.get` from `req.environment_id` — create)
- `views/agents.py:416` (`Environment.get` from `req.environment_id` — update)

## Pattern

Mirrors the dead-code-removal pattern from #177 (`if script is None`) and #186 (pydantic-shadowed validator branches).

## Test plan

- [x] `make test` passes (567, no regression)
- [x] `make lint`, `make fmt-check`, `make typecheck` clean
- [x] CI: lint, typecheck, test, coverage, mutation-test, migration-lint, e2e-scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)