### PR TITLE
Mutation-test Gemini MCP-config rendering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ paths_to_mutate = [
     "src/agent_on_demand/session_state.py",
     "src/agent_on_demand/metadata_merge.py",
     "src/agent_on_demand/runtimes/codex_config.py",
+    "src/agent_on_demand/runtimes/gemini_config.py",
 ]
 tests_dir = [
     "tests/test_auth.py",
@@ -155,6 +156,7 @@ tests_dir = [
     "tests/test_session_state.py",
     "tests/test_metadata_merge.py",
     "tests/test_codex_config.py",
+    "tests/test_gemini_config.py",
 ]
 # mutmut copies its working tree to ./mutants/ and runs pytest from there;
 # without these, the rest of the src/ tree isn't available to the test runner.

--- a/src/agent_on_demand/runtimes/gemini.py
+++ b/src/agent_on_demand/runtimes/gemini.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Literal
 
 from sprites import Sprite
 
+from agent_on_demand.runtimes.gemini_config import render_gemini_mcp_config
+
 if TYPE_CHECKING:
     from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
 
@@ -31,19 +33,8 @@ class GeminiRuntime:
         spec: "SessionSpec",
         mcp_servers: list["McpServerSpec"],
     ) -> None:
-        config: dict[str, dict] = {}
-        for s in mcp_servers:
-            if s.type == "url":
-                entry: dict = {"httpUrl": s.url, "trust": True}
-                if s.headers:
-                    entry["headers"] = s.headers
-                config[s.name] = entry
-            elif s.type == "stdio":
-                entry = {"command": s.command, "args": s.args, "trust": True}
-                if s.env:
-                    entry["env"] = s.env
-                config[s.name] = entry
-        if not config:
+        config = render_gemini_mcp_config(mcp_servers)
+        if config is None:
             return
         fs = sprite.filesystem()
         (fs / "home/sprite/.gemini/settings.json").write_text(

--- a/src/agent_on_demand/runtimes/gemini_config.py
+++ b/src/agent_on_demand/runtimes/gemini_config.py
@@ -1,0 +1,53 @@
+"""Build Gemini's MCP-server config dict from a list of `McpServerSpec`.
+
+Extracted from `runtimes/gemini.py` so the mapping logic can be
+mutation-tested in isolation. The original `GeminiRuntime.write_config`
+keeps the JSON encode + sprite filesystem write; this module is pure.
+
+Gemini's MCP config has two quirks worth pinning:
+
+  - URL servers land under ``httpUrl`` (not ``url`` like Codex/Claude).
+  - Every server entry — URL or stdio — carries ``trust: true``. This
+    is the bit that authorizes the agent to invoke the server's tools
+    without per-call confirmation; if a refactor drops it, every tool
+    call would silently start prompting for confirmation and break the
+    headless agent flow.
+
+Like Claude (and unlike Codex), Gemini is permissive about unknown
+header shapes — they're written verbatim — and unknown server types
+are silently skipped.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent_on_demand.session_service.specs import McpServerSpec
+
+
+def render_gemini_mcp_config(mcp_servers: list[McpServerSpec]) -> dict[str, dict] | None:
+    """Build the ``{server_name: entry}`` mapping that lands under the
+    ``"mcpServers"`` key in Gemini's ``.gemini/settings.json``.
+
+    Returns ``None`` when there's nothing to write — either an empty
+    input list, or only unknown-type servers (which are silently
+    skipped, matching the existing behavior). The empty-list case is
+    handled by the same final ``if not config`` guard, since iterating
+    an empty list never enters the loop body.
+    """
+    config: dict[str, dict] = {}
+    for s in mcp_servers:
+        if s.type == "url":
+            entry: dict = {"httpUrl": s.url, "trust": True}
+            if s.headers:
+                entry["headers"] = s.headers
+            config[s.name] = entry
+        elif s.type == "stdio":
+            entry = {"command": s.command, "args": s.args, "trust": True}
+            if s.env:
+                entry["env"] = s.env
+            config[s.name] = entry
+    if not config:
+        return None
+    return config

--- a/tests/test_gemini_config.py
+++ b/tests/test_gemini_config.py
@@ -1,0 +1,160 @@
+"""Direct unit tests for `render_gemini_mcp_config`.
+
+Mutation-tested. Each test isolates one mutation-killable branch:
+
+  - URL servers → ``{"httpUrl": ..., "trust": true}`` (NOT ``"url"``,
+    NOT ``"trust": false``)
+  - stdio servers → ``{"command": ..., "args": ..., "trust": true}``
+  - Optional ``headers`` / ``env`` only appear when truthy
+  - Unknown-type servers are skipped silently
+  - Empty input → None (caller skips the file write)
+
+Tests are sync, no Django fixtures, no parametrize — required so
+hammett (mutmut's runner, which doesn't load pytest plugins) can
+execute them. ``McpServerSpec`` is duck-typed via ``SimpleNamespace``
+so this module doesn't pull Django-dependent imports.
+"""
+
+from types import SimpleNamespace
+
+from agent_on_demand.runtimes.gemini_config import render_gemini_mcp_config
+
+
+def _url_server(name="srv", url="https://x/mcp", headers=None):
+    # ``headers if headers is not None else {}`` rather than
+    # ``headers or {}`` — the falsy form treats an empty-dict input the
+    # same as None, which masks intent in tests like
+    # test_url_server_omits_headers_when_empty that pass {} explicitly.
+    return SimpleNamespace(
+        name=name,
+        type="url",
+        url=url,
+        headers=headers if headers is not None else {},
+        command="",
+        args=[],
+        env={},
+    )
+
+
+def _stdio_server(name="srv", command="my-cmd", args=None, env=None):
+    return SimpleNamespace(
+        name=name,
+        type="stdio",
+        url="",
+        headers={},
+        command=command,
+        args=args if args is not None else [],
+        env=env if env is not None else {},
+    )
+
+
+# ---------- empty-input handling ----------
+
+
+def test_empty_list_returns_none():
+    """Caller skips the file write when nothing to render."""
+    assert render_gemini_mcp_config([]) is None
+
+
+def test_only_unknown_types_returns_none():
+    """All-unknown-type servers also yield None — config dict stays
+    empty, the second guard catches it."""
+    server = SimpleNamespace(
+        name="ghost", type="future-shape", url="", headers={}, command="", args=[], env={}
+    )
+    assert render_gemini_mcp_config([server]) is None
+
+
+# ---------- URL servers: the httpUrl quirk + trust flag ----------
+
+
+def test_url_server_uses_httpUrl_field_not_url():
+    """Gemini's MCP config calls the URL field ``httpUrl`` (not ``url``
+    like Codex/Claude). A refactor that "normalizes" this back to
+    ``url`` would silently break MCP for every Gemini session — pin it."""
+    cfg = render_gemini_mcp_config([_url_server(url="https://x/mcp")])
+    entry = cfg["srv"]
+    assert "httpUrl" in entry
+    assert entry["httpUrl"] == "https://x/mcp"
+    assert "url" not in entry
+
+
+def test_url_server_carries_trust_true():
+    """``trust: True`` authorizes the agent to invoke server tools
+    without per-call confirmation. Drop this and every tool call
+    silently starts prompting — broken in headless mode."""
+    cfg = render_gemini_mcp_config([_url_server()])
+    assert cfg["srv"]["trust"] is True
+
+
+def test_url_server_omits_headers_when_empty():
+    cfg = render_gemini_mcp_config([_url_server(headers={})])
+    assert "headers" not in cfg["srv"]
+
+
+def test_url_server_includes_headers_when_present():
+    cfg = render_gemini_mcp_config(
+        [_url_server(headers={"Authorization": "Bearer X", "X-Trace": "1"})]
+    )
+    assert cfg["srv"]["headers"] == {"Authorization": "Bearer X", "X-Trace": "1"}
+
+
+# ---------- stdio servers: also need trust ----------
+
+
+def test_stdio_server_carries_trust_true():
+    """Same trust requirement applies to stdio servers."""
+    cfg = render_gemini_mcp_config([_stdio_server()])
+    assert cfg["srv"]["trust"] is True
+
+
+def test_stdio_server_emits_command_and_args():
+    """stdio servers carry both ``command`` and ``args``; ``args`` is
+    unconditional (even an empty list lands in the config)."""
+    cfg = render_gemini_mcp_config([_stdio_server(command="npx", args=["-y", "pkg"])])
+    assert cfg["srv"]["command"] == "npx"
+    assert cfg["srv"]["args"] == ["-y", "pkg"]
+
+
+def test_stdio_server_with_empty_args_still_includes_args_key():
+    cfg = render_gemini_mcp_config([_stdio_server(args=[])])
+    assert "args" in cfg["srv"]
+    assert cfg["srv"]["args"] == []
+
+
+def test_stdio_server_omits_env_when_empty():
+    cfg = render_gemini_mcp_config([_stdio_server(env={})])
+    assert "env" not in cfg["srv"]
+
+
+def test_stdio_server_includes_env_when_present():
+    cfg = render_gemini_mcp_config([_stdio_server(env={"K": "V"})])
+    assert cfg["srv"]["env"] == {"K": "V"}
+
+
+# ---------- mixed / multi-server ----------
+
+
+def test_multiple_servers_each_get_their_own_entry():
+    """Pins iteration over the input list."""
+    cfg = render_gemini_mcp_config(
+        [
+            _url_server(name="alpha", url="https://x/mcp"),
+            _stdio_server(name="beta", command="bcmd"),
+        ]
+    )
+    assert set(cfg.keys()) == {"alpha", "beta"}
+    assert "httpUrl" in cfg["alpha"]
+    assert "command" in cfg["beta"]
+
+
+def test_unknown_type_in_mixed_list_is_skipped():
+    """Unlike Codex (which now raises on unknown types), Gemini follows
+    Claude's permissive pattern — unknown types silently drop."""
+    unknown = SimpleNamespace(
+        name="ghost", type="future-shape", url="", headers={}, command="", args=[], env={}
+    )
+    known = _url_server(name="real", url="https://x")
+    cfg = render_gemini_mcp_config([unknown, known])
+    assert "ghost" not in cfg
+    assert cfg["real"]["httpUrl"] == "https://x"


### PR DESCRIPTION
## Summary

Extracts the Gemini-specific MCP config mapping from `runtimes/gemini.py` into a new pure module `runtimes/gemini_config.py` — same pattern as #196 (codex) and #197 (claude). **`gemini_config.py`: 32/32 mutants killed (100%).**

## Why this is worth a mutmut slot

Gemini's MCP config has two quirks that look easy to "normalize" during a refactor:

- **URL servers land under `httpUrl`** (not `url` like Codex/Claude). Renaming this field would silently break MCP for every Gemini session.
- **Every server entry — URL or stdio — carries `trust: true`**. This authorizes the agent to invoke server tools without per-call confirmation; drop it and every tool call silently starts prompting, and the headless agent flow breaks.

Both are the kind of thing a future refactor can quietly flip; mutmut catches it.

## What changed

- New `src/agent_on_demand/runtimes/gemini_config.py` with `render_gemini_mcp_config(servers) -> dict | None`.
- `runtimes/gemini.py.write_config` calls it and only does the JSON encode + filesystem write.
- `pyproject.toml` extends `[tool.mutmut].paths_to_mutate` and `tests_dir`.
- 13 sync-only tests in `tests/test_gemini_config.py` covering each projection branch, both quirks (httpUrl naming, trust flag), and optional `headers` / `env` conditionals.

## Numbers

|  | Pre #196 | After #197 (claude) | This PR |
|---|---|---|---|
| mutmut scope | 4/39 (10.3%) | 6/41 (14.6%) | **7/42 (16.7%)** |
| kill rate | 98.2% | 98.5% | **98.8%** |
| total mutants | 219 | 266 | 332 |
| survivors | 4 known-eq | 4 known-eq | **4 known-eq (unchanged)** |

## Test plan

- [x] `make mutation-test` reports 328/332 killed; `gemini_config.py` 32/32 (100%)
- [x] `make test` passes — existing `tests/runtimes/test_gemini.py` still exercises the integration via `write_config`
- [x] `make lint`, `make fmt-check`, `make typecheck` clean
- [x] CI: lint, typecheck, test, coverage, mutation-test, migration-lint, e2e-scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)