### PR TITLE
Auto-revert failed deploys via Render API polling

### DIFF
--- a/.github/workflows/auto-revert.yml
+++ b/.github/workflows/auto-revert.yml
@@ -1,0 +1,77 @@
+name: Auto-revert failed deploys
+
+# Polls Render for failed deploys of the API service every 5 minutes and
+# opens a revert PR when one is found that hasn't already been handled.
+# Render auto-rolls-forward the running image; this workflow is what kicks
+# the bad commit out of `main` so subsequent PRs don't build on it.
+#
+# Setup (one-time):
+#   - Repo secret RENDER_API_KEY (from https://dashboard.render.com/u/settings → API Keys)
+#   - Repo variable RENDER_SERVICE_ID_API set to the api service's `srv-...` ID
+#   - Optional repo label `needs-human-review` (the script tries to add it
+#     to draft PRs and tolerates absence)
+#
+# See docs/runbook.md "Auto-revert (failed deploys)" for operator guidance.
+
+on:
+  schedule:
+    # Every 5 minutes. Render auto-rollback handles user impact in ~30s,
+    # so a 5-min revert latency only affects the time `main` carries the
+    # bad commit — fine for v1.
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Print intended actions without opening PRs"
+        type: boolean
+        default: false
+
+# Only one auto-revert run at a time so we don't race on PR creation.
+concurrency:
+  group: auto-revert
+  cancel-in-progress: false
+
+permissions:
+  contents: write       # push revert branches
+  pull-requests: write  # gh pr create / edit
+
+jobs:
+  poll-and-revert:
+    runs-on: ubuntu-latest
+    # Skip if the repo hasn't configured the required secrets yet —
+    # avoids noisy failures on forks and during initial setup.
+    if: ${{ vars.RENDER_SERVICE_ID_API != '' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so `git revert <sha>` can find arbitrary old commits.
+          fetch-depth: 0
+          # Use a token that can push branches. The default GITHUB_TOKEN works;
+          # the only caveat is that PRs opened by it won't auto-trigger other
+          # workflows (a known GitHub safety feature). See runbook.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - run: uv sync --all-extras
+
+      - name: Configure git identity for revert commits
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Poll Render and open revert PRs
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          uv run python -m scripts.auto_revert \
+            --service-id "${{ vars.RENDER_SERVICE_ID_API }}" \
+            --repo "${{ github.repository }}" \
+            ${{ inputs.dry-run && '--dry-run' || '' }}

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -203,6 +203,7 @@ Do **not** rollback past a migration without checking `migrations/` — the work
 - Only the API service is monitored. Worker failures don't trigger auto-revert. (Worker deploys rarely fail in isolation since they share the same commit.)
 - PRs created by `GITHUB_TOKEN` don't trigger downstream workflows. If CI doesn't appear on the auto-revert PR, push an empty commit (`git commit --allow-empty -m "trigger CI" && git push`) or re-run checks manually.
 - Reverts of reverts are skipped (subject starts with `Revert `) so a botched revert can't loop.
+- Dedup is via `gh pr list --search`, which routes through GitHub's search API and can lag by seconds to minutes. In rare cases, two consecutive cron ticks against the same still-failing commit may both miss the existing PR and open a duplicate. If you see two open auto-revert PRs for the same SHA, close the newer one — the script won't crash on the duplicate, just wastes a PR slot.
 
 **Disabling.** Comment out the `schedule` trigger in `.github/workflows/auto-revert.yml`, or remove the `RENDER_SERVICE_ID_API` repo variable (the workflow `if:` short-circuits without it).
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -185,6 +185,34 @@ Render → `agent-on-demand-api` → Deploys → find the last green deploy → 
 
 Do **not** rollback past a migration without checking `migrations/` — the worker and web must agree on schema.
 
+### Auto-revert (failed deploys)
+
+`.github/workflows/auto-revert.yml` polls Render every 5 min for failed deploys of `agent-on-demand-api`. When it finds one, it opens a `git revert` PR on the offending commit so `main` doesn't keep building on poison. **Render's auto-rollback handles the running image** — this workflow only handles the source-of-truth (`main`).
+
+**What you'll see when it fires.** A new PR titled `Auto-revert: <short-sha> (<status>)` from `github-actions[bot]`, base `main`. The body has the deploy ID, commit SHA, and instructions. CI runs against it like any other PR.
+
+**Decide and act.**
+- **Merge** if the revert is correct (you don't have a hotfix in flight).
+- **Close** if the failure was a Render flake or you've already pushed a forward-fix.
+- **Don't ignore.** Until merged or closed, every subsequent failure on the same commit is silently deduped against this PR.
+
+**Migration warning.** If the failed commit touched `src/agent_on_demand/migrations/`, the PR opens as a **draft** with the `needs-human-review` label. Code revert alone does **not** undo a migration. Either add a rollback migration to the PR before merging, or close the PR and resolve forward.
+
+**Limitations.**
+- Detection latency is up to 5 min (cron interval). Fine for `main`-cleanup; user-impact is already handled by Render auto-rollback in ~30s.
+- Only the API service is monitored. Worker failures don't trigger auto-revert. (Worker deploys rarely fail in isolation since they share the same commit.)
+- PRs created by `GITHUB_TOKEN` don't trigger downstream workflows. If CI doesn't appear on the auto-revert PR, push an empty commit (`git commit --allow-empty -m "trigger CI" && git push`) or re-run checks manually.
+- Reverts of reverts are skipped (subject starts with `Revert `) so a botched revert can't loop.
+
+**Disabling.** Comment out the `schedule` trigger in `.github/workflows/auto-revert.yml`, or remove the `RENDER_SERVICE_ID_API` repo variable (the workflow `if:` short-circuits without it).
+
+**Manual run.** Actions tab → "Auto-revert failed deploys" → "Run workflow" → toggle "Dry run" to preview without opening PRs.
+
+**Setup (one-time).**
+1. Repo Settings → Secrets → add `RENDER_API_KEY` (Render dashboard → Account Settings → API Keys).
+2. Repo Settings → Variables → add `RENDER_SERVICE_ID_API` set to the `srv-...` ID of `agent-on-demand-api` (visible in the Render dashboard URL for the service).
+3. (Optional) Repo Labels → create `needs-human-review` so draft PRs get tagged. The script tolerates absence.
+
 ---
 
 ## Scheduled / rare operations

--- a/scripts/auto_revert.py
+++ b/scripts/auto_revert.py
@@ -1,0 +1,319 @@
+"""Auto-open revert PRs for failed Render deploys.
+
+Polls Render's deploys API for the configured service, finds deploys that
+finished as failed, and opens a `git revert` PR for each unique failing
+commit. Idempotent: skips a commit if a revert PR already exists for it,
+and skips reverts of reverts so a botched revert can't loop on itself.
+
+If the failing commit modified files under `src/agent_on_demand/migrations/`,
+the PR is opened as a **draft** with the `needs-human-review` label —
+reverting code alone does not undo a migration, so a human has to decide
+whether to add a follow-up rollback migration or merge as-is.
+
+Designed to run from a GitHub Actions cron. Render API key + GitHub token
+come from env vars (`RENDER_API_KEY`, `GH_TOKEN`); no cursor file is needed
+because dedup is driven by the existing-PR check.
+
+Usage
+-----
+    uv run python -m scripts.auto_revert \
+        --service-id srv-XXXXXXXXXXXX \
+        --repo ravi-hq/fairy
+
+    # Dry run (no PRs opened, no branches pushed):
+    uv run python -m scripts.auto_revert \
+        --service-id srv-XXXXXXXXXXXX \
+        --repo ravi-hq/fairy --dry-run
+
+Required env: RENDER_API_KEY. GH_TOKEN required when not --dry-run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+RENDER_API = "https://api.render.com/v1"
+
+# Render deploy lifecycle terminal states we treat as "this commit is bad."
+# Render auto-rolls-forward to the previous live commit on failure, but
+# `main` still has the offending SHA — that's what we're here to fix.
+FAILED_STATUSES = frozenset({"build_failed", "update_failed", "canceled"})
+
+# Path prefix that identifies a migration file. Matches the layout pinned
+# in CLAUDE.md "Danger zones": migrations are forward-only in prod.
+MIGRATIONS_PREFIX = "src/agent_on_demand/migrations/"
+
+PR_TITLE_PREFIX = "Auto-revert:"
+NEEDS_HUMAN_LABEL = "needs-human-review"
+
+
+@dataclass(frozen=True)
+class FailedDeploy:
+    deploy_id: str
+    commit_sha: str
+    status: str
+    finished_at: str
+    service_id: str
+
+
+def fetch_failed_deploys(service_id: str, api_key: str, limit: int = 20) -> list[FailedDeploy]:
+    """Hit Render's deploys endpoint and return the recent failed ones.
+
+    Render returns deploys newest-first; we filter to terminal-failure
+    states and drop anything without a commit SHA (e.g. manual
+    redeploys triggered before a commit existed).
+    """
+    resp = requests.get(
+        f"{RENDER_API}/services/{service_id}/deploys",
+        params={"limit": limit},
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Accept": "application/json",
+        },
+        timeout=30,
+    )
+    resp.raise_for_status()
+    out: list[FailedDeploy] = []
+    for entry in resp.json():
+        # Render wraps each item as {"deploy": {...}, "cursor": "..."}.
+        deploy = entry["deploy"] if "deploy" in entry else entry
+        if deploy.get("status") not in FAILED_STATUSES:
+            continue
+        commit = deploy.get("commit") or {}
+        sha = commit.get("id")
+        if not sha:
+            continue
+        out.append(
+            FailedDeploy(
+                deploy_id=deploy["id"],
+                commit_sha=sha,
+                status=deploy["status"],
+                finished_at=deploy.get("finishedAt") or deploy.get("createdAt", ""),
+                service_id=service_id,
+            )
+        )
+    return out
+
+
+def is_revert_commit(sha: str) -> bool:
+    """A commit whose subject starts with 'Revert ' shouldn't be reverted again."""
+    msg = subprocess.run(
+        ["git", "log", "-1", "--pretty=%s", sha],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return msg.startswith("Revert ")
+
+
+def commit_touches_migrations(sha: str) -> bool:
+    """True if the commit changed any file under MIGRATIONS_PREFIX."""
+    result = subprocess.run(
+        ["git", "show", "--name-only", "--pretty=", sha],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return any(line.startswith(MIGRATIONS_PREFIX) for line in result.stdout.splitlines())
+
+
+def existing_revert_pr_exists(sha: str, repo: str) -> bool:
+    """True if any open or merged PR has our auto-revert title for this SHA.
+
+    The 12-char short SHA in the title is the dedup key; the existence
+    check covers both still-open PRs and already-landed reverts.
+    """
+    short = sha[:12]
+    result = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "all",
+            "--search",
+            f"in:title {PR_TITLE_PREFIX} {short}",
+            "--json",
+            "number",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return bool(json.loads(result.stdout))
+
+
+def render_pr_body(deploy: FailedDeploy, *, migrations_touched: bool) -> str:
+    """Format the PR body. Pure function — easy to pin in tests."""
+    short = deploy.commit_sha[:12]
+    lines = [
+        f"Auto-opened by `scripts/auto_revert.py` after Render deploy "
+        f"`{deploy.deploy_id}` finished as `{deploy.status}`.",
+        "",
+        f"- **Service**: `{deploy.service_id}`",
+        f"- **Failed commit**: `{short}` (full: `{deploy.commit_sha}`)",
+        f"- **Finished at**: {deploy.finished_at}",
+        "",
+    ]
+    if migrations_touched:
+        lines += [
+            "## ⚠️ Migration touched",
+            "",
+            "This commit modified files under "
+            f"`{MIGRATIONS_PREFIX}`. Reverting the code alone does **not** "
+            "undo the migration. Decide on a follow-up:",
+            "",
+            "- If the migration was additive and harmless, merge this PR as-is.",
+            "- If the migration must be reversed, add a new rollback migration "
+            "to this PR before merging.",
+            "- If the deploy is acceptable and the failure was transient, close this PR.",
+            "",
+        ]
+    lines += [
+        "## What to do",
+        "",
+        "1. Verify the failed deploy in the Render dashboard.",
+        "2. If the revert is correct, **merge** this PR.",
+        "3. If the failure was a flake or you've already hotfixed forward, **close** this PR.",
+        "",
+        "Generated by `.github/workflows/auto-revert.yml`.",
+    ]
+    return "\n".join(lines)
+
+
+def open_revert_pr(deploy: FailedDeploy, *, draft: bool, repo: str) -> str:
+    """Create a branch, run git revert, push, open PR. Returns PR URL."""
+    short = deploy.commit_sha[:12]
+    branch = f"auto-revert/{short}"
+
+    subprocess.run(["git", "fetch", "origin", "main"], check=True)
+    subprocess.run(["git", "checkout", "-B", branch, "origin/main"], check=True)
+    subprocess.run(
+        ["git", "revert", "--no-edit", deploy.commit_sha],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "push", "-u", "origin", branch, "--force-with-lease"],
+        check=True,
+    )
+
+    title = f"{PR_TITLE_PREFIX} {short} ({deploy.status})"
+    body = render_pr_body(deploy, migrations_touched=draft)
+
+    cmd = [
+        "gh",
+        "pr",
+        "create",
+        "--repo",
+        repo,
+        "--base",
+        "main",
+        "--head",
+        branch,
+        "--title",
+        title,
+        "--body",
+        body,
+    ]
+    if draft:
+        cmd.append("--draft")
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    pr_url = result.stdout.strip()
+
+    if draft:
+        # Label may not exist in the repo yet; don't crash if so.
+        subprocess.run(
+            ["gh", "pr", "edit", pr_url, "--repo", repo, "--add-label", NEEDS_HUMAN_LABEL],
+            check=False,
+        )
+    return pr_url
+
+
+def process_deploy(deploy: FailedDeploy, *, repo: str, dry_run: bool) -> str | None:
+    """Decide and act on a single deploy. Returns PR URL if one was opened."""
+    if is_revert_commit(deploy.commit_sha):
+        return None
+    if existing_revert_pr_exists(deploy.commit_sha, repo):
+        return None
+    migrations_touched = commit_touches_migrations(deploy.commit_sha)
+    if dry_run:
+        marker = "draft " if migrations_touched else ""
+        print(
+            f"[dry-run] would open {marker}revert PR for "
+            f"{deploy.commit_sha[:12]} (deploy {deploy.deploy_id})"
+        )
+        return None
+    return open_revert_pr(deploy, draft=migrations_touched, repo=repo)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Open revert PRs for failed Render deploys.")
+    parser.add_argument("--service-id", required=True, help="Render service ID, e.g. srv-XXXX")
+    parser.add_argument("--repo", required=True, help="GitHub repo, e.g. ravi-hq/fairy")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="How many recent deploys to inspect (default: 20)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print intended actions without opening PRs",
+    )
+    args = parser.parse_args()
+
+    api_key = os.environ.get("RENDER_API_KEY")
+    if not api_key:
+        print("error: RENDER_API_KEY env var not set", file=sys.stderr)
+        return 1
+
+    deploys = fetch_failed_deploys(args.service_id, api_key, limit=args.limit)
+    if not deploys:
+        print("no failed deploys in the recent window")
+        return 0
+
+    # Dedup by commit SHA — Render often retries the same commit, and we
+    # want one PR per bad commit, not one per deploy attempt.
+    seen: set[str] = set()
+    opened: list[str] = []
+    for deploy in deploys:
+        if deploy.commit_sha in seen:
+            continue
+        seen.add(deploy.commit_sha)
+        try:
+            url = process_deploy(deploy, repo=args.repo, dry_run=args.dry_run)
+        except subprocess.CalledProcessError as exc:
+            # One bad deploy shouldn't block the others. Surface the
+            # failure in the action log; cron will retry next interval.
+            print(
+                f"error processing deploy {deploy.deploy_id} ({deploy.commit_sha[:12]}): {exc}",
+                file=sys.stderr,
+            )
+            continue
+        if url:
+            opened.append(url)
+
+    if opened:
+        print(f"opened {len(opened)} revert PR(s):")
+        for url in opened:
+            print(f"  {url}")
+    else:
+        print(f"checked {len(seen)} unique failed commit(s); no new reverts to open")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/auto_revert.py
+++ b/scripts/auto_revert.py
@@ -47,7 +47,11 @@ RENDER_API = "https://api.render.com/v1"
 # Render deploy lifecycle terminal states we treat as "this commit is bad."
 # Render auto-rolls-forward to the previous live commit on failure, but
 # `main` still has the offending SHA — that's what we're here to fix.
-FAILED_STATUSES = frozenset({"build_failed", "update_failed", "canceled"})
+#
+# `canceled` is intentionally excluded: Render marks a deploy `canceled`
+# when a newer deploy supersedes it — the normal result of pushing two
+# commits in quick succession — and the earlier commit isn't actually bad.
+FAILED_STATUSES = frozenset({"build_failed", "update_failed"})
 
 # Path prefix that identifies a migration file. Matches the layout pinned
 # in CLAUDE.md "Danger zones": migrations are forward-only in prod.
@@ -193,8 +197,16 @@ def render_pr_body(deploy: FailedDeploy, *, migrations_touched: bool) -> str:
     return "\n".join(lines)
 
 
-def open_revert_pr(deploy: FailedDeploy, *, draft: bool, repo: str) -> str:
-    """Create a branch, run git revert, push, open PR. Returns PR URL."""
+def open_revert_pr(
+    deploy: FailedDeploy, *, draft: bool, migrations_touched: bool, repo: str
+) -> str:
+    """Create a branch, run git revert, push, open PR. Returns PR URL.
+
+    `draft` and `migrations_touched` happen to coincide today (a touched
+    migration is the only reason we draft), but they're passed
+    independently so the PR-body warning stays tied to its actual cause
+    if a future change adds another reason to draft.
+    """
     short = deploy.commit_sha[:12]
     branch = f"auto-revert/{short}"
 
@@ -210,7 +222,7 @@ def open_revert_pr(deploy: FailedDeploy, *, draft: bool, repo: str) -> str:
     )
 
     title = f"{PR_TITLE_PREFIX} {short} ({deploy.status})"
-    body = render_pr_body(deploy, migrations_touched=draft)
+    body = render_pr_body(deploy, migrations_touched=migrations_touched)
 
     cmd = [
         "gh",
@@ -255,7 +267,9 @@ def process_deploy(deploy: FailedDeploy, *, repo: str, dry_run: bool) -> str | N
             f"{deploy.commit_sha[:12]} (deploy {deploy.deploy_id})"
         )
         return None
-    return open_revert_pr(deploy, draft=migrations_touched, repo=repo)
+    return open_revert_pr(
+        deploy, draft=migrations_touched, migrations_touched=migrations_touched, repo=repo
+    )
 
 
 def main() -> int:
@@ -278,6 +292,12 @@ def main() -> int:
     api_key = os.environ.get("RENDER_API_KEY")
     if not api_key:
         print("error: RENDER_API_KEY env var not set", file=sys.stderr)
+        return 1
+    if not args.dry_run and not os.environ.get("GH_TOKEN"):
+        print(
+            "error: GH_TOKEN env var not set (required for git push and gh pr create)",
+            file=sys.stderr,
+        )
         return 1
 
     deploys = fetch_failed_deploys(args.service_id, api_key, limit=args.limit)

--- a/tests/test_auto_revert.py
+++ b/tests/test_auto_revert.py
@@ -59,8 +59,21 @@ def test_fetch_failed_deploys_filters_to_failed_statuses(mocker):
 
     out = fetch_failed_deploys("srv-x", "tok")
 
-    assert {d.deploy_id for d in out} == {"dep-bf", "dep-uf", "dep-cancel"}
+    # `canceled` is excluded — Render uses it for superseded deploys, which
+    # are not bad commits. See FAILED_STATUSES comment.
+    assert {d.deploy_id for d in out} == {"dep-bf", "dep-uf"}
     assert all(d.status in FAILED_STATUSES for d in out)
+
+
+def test_fetch_failed_deploys_excludes_canceled(mocker):
+    """Pin: superseded-deploy `canceled` is NOT actionable — would open
+    spurious revert PRs whenever two commits land in quick succession."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = [_deploy_entry(status="canceled", deploy_id="dep-cancel")]
+    mocker.patch("scripts.auto_revert.requests.get", return_value=mock_resp)
+
+    assert fetch_failed_deploys("srv-x", "tok") == []
+    assert "canceled" not in FAILED_STATUSES
 
 
 def test_fetch_failed_deploys_skips_entries_without_commit_sha(mocker):
@@ -283,7 +296,7 @@ def test_open_revert_pr_passes_draft_flag_to_gh(mocker):
 
     from scripts.auto_revert import open_revert_pr
 
-    open_revert_pr(_deploy(), draft=True, repo="owner/repo")
+    open_revert_pr(_deploy(), draft=True, migrations_touched=True, repo="owner/repo")
 
     # Find the gh pr create invocation.
     pr_create_calls = [
@@ -299,7 +312,7 @@ def test_open_revert_pr_omits_draft_flag_when_not_draft(mocker):
 
     from scripts.auto_revert import open_revert_pr
 
-    open_revert_pr(_deploy(), draft=False, repo="owner/repo")
+    open_revert_pr(_deploy(), draft=False, migrations_touched=False, repo="owner/repo")
 
     pr_create_calls = [
         c for c in run.call_args_list if c.args and c.args[0][:3] == ["gh", "pr", "create"]
@@ -313,7 +326,7 @@ def test_open_revert_pr_labels_draft_with_needs_human_review(mocker):
 
     from scripts.auto_revert import open_revert_pr
 
-    open_revert_pr(_deploy(), draft=True, repo="owner/repo")
+    open_revert_pr(_deploy(), draft=True, migrations_touched=True, repo="owner/repo")
 
     label_calls = [
         c for c in run.call_args_list if c.args and c.args[0][:3] == ["gh", "pr", "edit"]
@@ -328,12 +341,31 @@ def test_open_revert_pr_does_not_label_when_not_draft(mocker):
 
     from scripts.auto_revert import open_revert_pr
 
-    open_revert_pr(_deploy(), draft=False, repo="owner/repo")
+    open_revert_pr(_deploy(), draft=False, migrations_touched=False, repo="owner/repo")
 
     label_calls = [
         c for c in run.call_args_list if c.args and c.args[0][:3] == ["gh", "pr", "edit"]
     ]
     assert label_calls == []
+
+
+def test_open_revert_pr_migration_warning_decoupled_from_draft(mocker):
+    """Pin: the migration warning in the body is driven by
+    `migrations_touched`, not by `draft`. If a future change adds another
+    reason to draft, the body must NOT show a misleading migration warning."""
+    run = mocker.patch("scripts.auto_revert.subprocess.run")
+    run.return_value = MagicMock(stdout="https://github.com/owner/repo/pull/9\n")
+
+    from scripts.auto_revert import open_revert_pr
+
+    open_revert_pr(_deploy(), draft=True, migrations_touched=False, repo="owner/repo")
+
+    pr_create_call = next(
+        c for c in run.call_args_list if c.args and c.args[0][:3] == ["gh", "pr", "create"]
+    )
+    body_idx = pr_create_call.args[0].index("--body")
+    body = pr_create_call.args[0][body_idx + 1]
+    assert "Migration touched" not in body
 
 
 # === Sanity: subprocess.CalledProcessError survives the per-deploy try/except ===

--- a/tests/test_auto_revert.py
+++ b/tests/test_auto_revert.py
@@ -1,0 +1,350 @@
+"""Tests for scripts/auto_revert.py.
+
+Covers the decision logic and PR-body shape. Network and shell calls are
+mocked — the script's only side effects are HTTP to Render and shell-out
+to git/gh, both of which we don't want hitting real systems in CI.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.auto_revert import (
+    FAILED_STATUSES,
+    MIGRATIONS_PREFIX,
+    NEEDS_HUMAN_LABEL,
+    PR_TITLE_PREFIX,
+    FailedDeploy,
+    commit_touches_migrations,
+    existing_revert_pr_exists,
+    fetch_failed_deploys,
+    is_revert_commit,
+    process_deploy,
+    render_pr_body,
+)
+
+
+# === fetch_failed_deploys ===
+
+
+def _deploy_entry(*, status: str, sha: str | None = "abc123def456", deploy_id: str = "dep-1"):
+    """Build a Render API deploy entry. Wrapped under "deploy" like the real API."""
+    return {
+        "deploy": {
+            "id": deploy_id,
+            "status": status,
+            "commit": {"id": sha} if sha else None,
+            "finishedAt": "2026-04-26T20:00:00Z",
+            "createdAt": "2026-04-26T19:55:00Z",
+        },
+        "cursor": "opaque-cursor",
+    }
+
+
+def test_fetch_failed_deploys_filters_to_failed_statuses(mocker):
+    api_response = [
+        _deploy_entry(status="live", deploy_id="dep-live"),
+        _deploy_entry(status="build_failed", deploy_id="dep-bf"),
+        _deploy_entry(status="update_failed", deploy_id="dep-uf"),
+        _deploy_entry(status="canceled", deploy_id="dep-cancel"),
+        _deploy_entry(status="created", deploy_id="dep-created"),
+    ]
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = api_response
+    mocker.patch("scripts.auto_revert.requests.get", return_value=mock_resp)
+
+    out = fetch_failed_deploys("srv-x", "tok")
+
+    assert {d.deploy_id for d in out} == {"dep-bf", "dep-uf", "dep-cancel"}
+    assert all(d.status in FAILED_STATUSES for d in out)
+
+
+def test_fetch_failed_deploys_skips_entries_without_commit_sha(mocker):
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = [
+        _deploy_entry(status="build_failed", sha=None, deploy_id="dep-no-sha"),
+        _deploy_entry(status="build_failed", sha="abcdef123456", deploy_id="dep-with-sha"),
+    ]
+    mocker.patch("scripts.auto_revert.requests.get", return_value=mock_resp)
+
+    out = fetch_failed_deploys("srv-x", "tok")
+
+    assert [d.deploy_id for d in out] == ["dep-with-sha"]
+
+
+def test_fetch_failed_deploys_sends_bearer_auth_and_limit(mocker):
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = []
+    get = mocker.patch("scripts.auto_revert.requests.get", return_value=mock_resp)
+
+    fetch_failed_deploys("srv-X", "secret-token", limit=5)
+
+    args, kwargs = get.call_args
+    assert args[0].endswith("/services/srv-X/deploys")
+    assert kwargs["params"] == {"limit": 5}
+    assert kwargs["headers"]["Authorization"] == "Bearer secret-token"
+
+
+# === is_revert_commit ===
+
+
+@pytest.mark.parametrize(
+    "subject,expected",
+    [
+        ('Revert "Add session quota"', True),
+        ("Revert auth.py rename", True),
+        ("revert auth.py rename", False),  # case-sensitive
+        ("Add session quota", False),
+        ("Reverted typo in README", False),  # different prefix
+    ],
+)
+def test_is_revert_commit_recognises_revert_subjects(mocker, subject, expected):
+    mock_run = mocker.patch("scripts.auto_revert.subprocess.run")
+    mock_run.return_value = MagicMock(stdout=subject + "\n")
+
+    assert is_revert_commit("abc") is expected
+
+
+# === commit_touches_migrations ===
+
+
+def test_commit_touches_migrations_true_when_migration_changed(mocker):
+    mock_run = mocker.patch("scripts.auto_revert.subprocess.run")
+    mock_run.return_value = MagicMock(
+        stdout=(
+            "src/agent_on_demand/views/agents.py\n"
+            "src/agent_on_demand/migrations/0017_new_field.py\n"
+            "tests/test_agents.py\n"
+        )
+    )
+
+    assert commit_touches_migrations("abc") is True
+
+
+def test_commit_touches_migrations_false_for_code_only_change(mocker):
+    mock_run = mocker.patch("scripts.auto_revert.subprocess.run")
+    mock_run.return_value = MagicMock(
+        stdout=("src/agent_on_demand/views/agents.py\ntests/test_agents.py\n")
+    )
+
+    assert commit_touches_migrations("abc") is False
+
+
+def test_migrations_prefix_matches_claude_md_danger_zone():
+    """Sanity check: the prefix must match the project's actual migration dir.
+
+    If someone moves migrations, this test fails loudly so they update both.
+    """
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parent.parent
+    assert (repo_root / MIGRATIONS_PREFIX).is_dir(), (
+        f"{MIGRATIONS_PREFIX} no longer exists; update auto_revert.py"
+    )
+
+
+# === existing_revert_pr_exists ===
+
+
+def test_existing_revert_pr_exists_true_when_gh_returns_match(mocker):
+    mock_run = mocker.patch("scripts.auto_revert.subprocess.run")
+    mock_run.return_value = MagicMock(stdout=json.dumps([{"number": 42}]))
+
+    assert existing_revert_pr_exists("abc123def456789", "owner/repo") is True
+
+    # Search uses the 12-char short SHA + the title prefix.
+    cmd = mock_run.call_args[0][0]
+    search_idx = cmd.index("--search")
+    search_value = cmd[search_idx + 1]
+    assert "abc123def456" in search_value
+    assert PR_TITLE_PREFIX in search_value
+
+
+def test_existing_revert_pr_exists_false_when_gh_returns_empty(mocker):
+    mock_run = mocker.patch("scripts.auto_revert.subprocess.run")
+    mock_run.return_value = MagicMock(stdout="[]")
+
+    assert existing_revert_pr_exists("abc", "owner/repo") is False
+
+
+# === render_pr_body ===
+
+
+def _deploy(sha: str = "abc123def4567890", status: str = "build_failed") -> FailedDeploy:
+    return FailedDeploy(
+        deploy_id="dep-1",
+        commit_sha=sha,
+        status=status,
+        finished_at="2026-04-26T20:00:00Z",
+        service_id="srv-test",
+    )
+
+
+def test_render_pr_body_includes_deploy_metadata():
+    body = render_pr_body(_deploy(), migrations_touched=False)
+
+    assert "dep-1" in body
+    assert "srv-test" in body
+    assert "build_failed" in body
+    assert "abc123def456" in body  # short SHA
+    assert "abc123def4567890" in body  # full SHA
+    assert "2026-04-26T20:00:00Z" in body
+
+
+def test_render_pr_body_omits_migration_warning_when_no_migrations():
+    body = render_pr_body(_deploy(), migrations_touched=False)
+
+    assert "Migration touched" not in body
+
+
+def test_render_pr_body_includes_migration_warning_when_migrations_touched():
+    body = render_pr_body(_deploy(), migrations_touched=True)
+
+    assert "Migration touched" in body
+    assert MIGRATIONS_PREFIX in body
+    assert "rollback migration" in body
+
+
+# === process_deploy ===
+
+
+def test_process_deploy_skips_revert_of_revert(mocker):
+    mocker.patch("scripts.auto_revert.is_revert_commit", return_value=True)
+    open_pr = mocker.patch("scripts.auto_revert.open_revert_pr")
+
+    result = process_deploy(_deploy(), repo="owner/repo", dry_run=False)
+
+    assert result is None
+    open_pr.assert_not_called()
+
+
+def test_process_deploy_skips_when_revert_pr_already_exists(mocker):
+    mocker.patch("scripts.auto_revert.is_revert_commit", return_value=False)
+    mocker.patch("scripts.auto_revert.existing_revert_pr_exists", return_value=True)
+    open_pr = mocker.patch("scripts.auto_revert.open_revert_pr")
+
+    result = process_deploy(_deploy(), repo="owner/repo", dry_run=False)
+
+    assert result is None
+    open_pr.assert_not_called()
+
+
+def test_process_deploy_dry_run_does_not_open_pr(mocker, capsys):
+    mocker.patch("scripts.auto_revert.is_revert_commit", return_value=False)
+    mocker.patch("scripts.auto_revert.existing_revert_pr_exists", return_value=False)
+    mocker.patch("scripts.auto_revert.commit_touches_migrations", return_value=False)
+    open_pr = mocker.patch("scripts.auto_revert.open_revert_pr")
+
+    result = process_deploy(_deploy(), repo="owner/repo", dry_run=True)
+
+    assert result is None
+    open_pr.assert_not_called()
+    out = capsys.readouterr().out
+    assert "[dry-run]" in out
+    assert "abc123def456" in out
+
+
+def test_process_deploy_opens_normal_pr_when_no_migrations(mocker):
+    mocker.patch("scripts.auto_revert.is_revert_commit", return_value=False)
+    mocker.patch("scripts.auto_revert.existing_revert_pr_exists", return_value=False)
+    mocker.patch("scripts.auto_revert.commit_touches_migrations", return_value=False)
+    open_pr = mocker.patch("scripts.auto_revert.open_revert_pr", return_value="https://pr/123")
+
+    result = process_deploy(_deploy(), repo="owner/repo", dry_run=False)
+
+    assert result == "https://pr/123"
+    open_pr.assert_called_once()
+    assert open_pr.call_args.kwargs["draft"] is False
+
+
+def test_process_deploy_opens_draft_pr_when_migrations_touched(mocker):
+    mocker.patch("scripts.auto_revert.is_revert_commit", return_value=False)
+    mocker.patch("scripts.auto_revert.existing_revert_pr_exists", return_value=False)
+    mocker.patch("scripts.auto_revert.commit_touches_migrations", return_value=True)
+    open_pr = mocker.patch("scripts.auto_revert.open_revert_pr", return_value="https://pr/124")
+
+    result = process_deploy(_deploy(), repo="owner/repo", dry_run=False)
+
+    assert result == "https://pr/124"
+    assert open_pr.call_args.kwargs["draft"] is True
+
+
+# === open_revert_pr ===
+
+
+def test_open_revert_pr_passes_draft_flag_to_gh(mocker):
+    """Sanity check the `--draft` flag is added when draft=True."""
+    run = mocker.patch("scripts.auto_revert.subprocess.run")
+    run.return_value = MagicMock(stdout="https://github.com/owner/repo/pull/9\n")
+
+    from scripts.auto_revert import open_revert_pr
+
+    open_revert_pr(_deploy(), draft=True, repo="owner/repo")
+
+    # Find the gh pr create invocation.
+    pr_create_calls = [
+        c for c in run.call_args_list if c.args and c.args[0][:3] == ["gh", "pr", "create"]
+    ]
+    assert len(pr_create_calls) == 1
+    assert "--draft" in pr_create_calls[0].args[0]
+
+
+def test_open_revert_pr_omits_draft_flag_when_not_draft(mocker):
+    run = mocker.patch("scripts.auto_revert.subprocess.run")
+    run.return_value = MagicMock(stdout="https://github.com/owner/repo/pull/9\n")
+
+    from scripts.auto_revert import open_revert_pr
+
+    open_revert_pr(_deploy(), draft=False, repo="owner/repo")
+
+    pr_create_calls = [
+        c for c in run.call_args_list if c.args and c.args[0][:3] == ["gh", "pr", "create"]
+    ]
+    assert "--draft" not in pr_create_calls[0].args[0]
+
+
+def test_open_revert_pr_labels_draft_with_needs_human_review(mocker):
+    run = mocker.patch("scripts.auto_revert.subprocess.run")
+    run.return_value = MagicMock(stdout="https://github.com/owner/repo/pull/9\n")
+
+    from scripts.auto_revert import open_revert_pr
+
+    open_revert_pr(_deploy(), draft=True, repo="owner/repo")
+
+    label_calls = [
+        c for c in run.call_args_list if c.args and c.args[0][:3] == ["gh", "pr", "edit"]
+    ]
+    assert len(label_calls) == 1
+    assert NEEDS_HUMAN_LABEL in label_calls[0].args[0]
+
+
+def test_open_revert_pr_does_not_label_when_not_draft(mocker):
+    run = mocker.patch("scripts.auto_revert.subprocess.run")
+    run.return_value = MagicMock(stdout="https://github.com/owner/repo/pull/9\n")
+
+    from scripts.auto_revert import open_revert_pr
+
+    open_revert_pr(_deploy(), draft=False, repo="owner/repo")
+
+    label_calls = [
+        c for c in run.call_args_list if c.args and c.args[0][:3] == ["gh", "pr", "edit"]
+    ]
+    assert label_calls == []
+
+
+# === Sanity: subprocess.CalledProcessError survives the per-deploy try/except ===
+
+
+def test_process_deploy_propagates_called_process_error(mocker):
+    """process_deploy itself doesn't catch — main() does. Pin the boundary."""
+    mocker.patch(
+        "scripts.auto_revert.is_revert_commit",
+        side_effect=subprocess.CalledProcessError(1, "git"),
+    )
+
+    with pytest.raises(subprocess.CalledProcessError):
+        process_deploy(_deploy(), repo="owner/repo", dry_run=False)


### PR DESCRIPTION
## Summary

- New cron-driven GitHub Actions workflow (`auto-revert.yml`) polls Render every 5 min for failed deploys of `agent-on-demand-api` and opens a `git revert` PR for each unique offending commit. Closes the gap where Render's auto-rollback fixes the running image but leaves the bad commit on `main` for the next PR to build on.
- If the failing commit touched `src/agent_on_demand/migrations/`, the PR is opened as a **draft** with `needs-human-review` because code revert alone doesn't undo a migration.
- Idempotency is driven by searching existing PRs for the auto-revert title prefix + short SHA — no cursor file. Reverts of reverts are skipped so a botched revert can't loop.
- 26 mocked unit tests covering Render API parsing, migration detection, idempotency, dry-run, and PR-body shape.
- Workflow's `if:` guards on the `RENDER_SERVICE_ID_API` repo variable, so this PR is safe to merge before secrets/variables are configured — it's a no-op until someone wires them up.

## Setup (after merge)

1. Repo Settings → Secrets → add `RENDER_API_KEY` (Render dashboard → Account Settings → API Keys).
2. Repo Settings → Variables → add `RENDER_SERVICE_ID_API` set to the `srv-...` ID for `agent-on-demand-api`.
3. (Optional) Repo → Labels → create `needs-human-review`. The script tolerates absence.

The runbook section under \"Auto-revert (failed deploys)\" has the full operator guide: what an auto-revert PR looks like, how to decide between merge/close, the migration warning behaviour, and how to disable.

## Known limitations (documented in runbook)

- Up to 5 min detection latency (cron interval). Render's ~30s auto-rollback already handles user impact, so this only delays \`main\`-cleanup.
- API service only — worker isn't monitored. Worker deploys rarely fail in isolation since they share the commit.
- PRs from \`GITHUB_TOKEN\` don't trigger downstream workflows (GitHub safety feature). If CI doesn't appear on the auto-revert PR, push an empty commit or re-run checks.

## Test plan

- [ ] Read \`scripts/auto_revert.py\` — sanity check the decision logic and the Render API shape.
- [ ] Read \`tests/test_auto_revert.py\` — confirm coverage matches the production-relevant decisions (revert-of-revert skip, existing-PR dedup, draft-on-migrations, dry-run).
- [ ] \`make lint\` + \`make fmt-check\` + \`make test\` all green (verified locally: 603 passed including the 26 new tests).
- [ ] Read the runbook subsection \"Auto-revert (failed deploys)\" — instructions are clear enough for an oncall to act on a new auto-revert PR without context.
- [ ] After merge: configure \`RENDER_API_KEY\` secret + \`RENDER_SERVICE_ID_API\` variable, then trigger the workflow manually with the dry-run toggle to verify Render API connectivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)