### PR TITLE
Pause auto-revert cron

### DIFF
--- a/.github/workflows/auto-revert.yml
+++ b/.github/workflows/auto-revert.yml
@@ -13,10 +13,18 @@ name: Auto-revert failed deploys
 #
 # See docs/runbook.md "Auto-revert (failed deploys)" for operator guidance.
 
-# PAUSED: cron trigger commented out so this workflow does not run on
-# schedule. Manual `workflow_dispatch` is intentionally left active so
-# operators can dry-run while the workflow is paused. To re-enable
-# automatic revert PRs, uncomment the `schedule:` block below.
+# PAUSED 2026-04-26: cron trigger commented out so this workflow does
+# not run on schedule. Default-off until the workflow has been validated
+# end-to-end against at least one real failed deploy (the polling logic,
+# `gh pr list` dedup, and revert PR creation were all unit-tested in
+# #200, but never exercised against the live Render API + GitHub
+# combination). Manual `workflow_dispatch` is intentionally left active
+# so operators can dry-run for that validation.
+#
+# Exit criteria: a successful manual dry-run on a real `build_failed` /
+# `update_failed` deploy, followed by a non-dry-run that opens a single
+# revert PR and isn't duplicated on subsequent ticks. Once that's done,
+# uncomment the `schedule:` block below to re-enable.
 on:
   # schedule:
   #   # Every 5 minutes. Render auto-rollback handles user impact in ~30s,

--- a/.github/workflows/auto-revert.yml
+++ b/.github/workflows/auto-revert.yml
@@ -13,12 +13,16 @@ name: Auto-revert failed deploys
 #
 # See docs/runbook.md "Auto-revert (failed deploys)" for operator guidance.
 
+# PAUSED: cron trigger commented out so this workflow does not run on
+# schedule. Manual `workflow_dispatch` is intentionally left active so
+# operators can dry-run while the workflow is paused. To re-enable
+# automatic revert PRs, uncomment the `schedule:` block below.
 on:
-  schedule:
-    # Every 5 minutes. Render auto-rollback handles user impact in ~30s,
-    # so a 5-min revert latency only affects the time `main` carries the
-    # bad commit — fine for v1.
-    - cron: "*/5 * * * *"
+  # schedule:
+  #   # Every 5 minutes. Render auto-rollback handles user impact in ~30s,
+  #   # so a 5-min revert latency only affects the time `main` carries the
+  #   # bad commit — fine for v1.
+  #   - cron: "*/5 * * * *"
   workflow_dispatch:
     inputs:
       dry-run:

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -187,7 +187,7 @@ Do **not** rollback past a migration without checking `migrations/` — the work
 
 ### Auto-revert (failed deploys)
 
-> **Status: paused.** The cron trigger in `.github/workflows/auto-revert.yml` is currently commented out, so no automatic revert PRs are opened. Manual `workflow_dispatch` runs still work for testing. To re-enable, uncomment the `schedule:` block in the workflow file.
+> **Status: paused (2026-04-26).** The cron trigger in `.github/workflows/auto-revert.yml` is commented out — default-off until the workflow has been validated end-to-end against at least one real failed deploy. #200 added unit-test coverage but the live Render-API + GitHub-API path was never exercised. Manual `workflow_dispatch` runs still work for that validation. **Exit criteria:** a successful manual dry-run on a real `build_failed`/`update_failed` deploy, followed by a non-dry-run that opens a single revert PR without being duplicated on the next tick. Once both conditions are met, uncomment the `schedule:` block in the workflow file to re-enable.
 
 `.github/workflows/auto-revert.yml` polls Render every 5 min for failed deploys of `agent-on-demand-api`. When it finds one, it opens a `git revert` PR on the offending commit so `main` doesn't keep building on poison. **Render's auto-rollback handles the running image** — this workflow only handles the source-of-truth (`main`).
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -187,6 +187,8 @@ Do **not** rollback past a migration without checking `migrations/` — the work
 
 ### Auto-revert (failed deploys)
 
+> **Status: paused.** The cron trigger in `.github/workflows/auto-revert.yml` is currently commented out, so no automatic revert PRs are opened. Manual `workflow_dispatch` runs still work for testing. To re-enable, uncomment the `schedule:` block in the workflow file.
+
 `.github/workflows/auto-revert.yml` polls Render every 5 min for failed deploys of `agent-on-demand-api`. When it finds one, it opens a `git revert` PR on the offending commit so `main` doesn't keep building on poison. **Render's auto-rollback handles the running image** — this workflow only handles the source-of-truth (`main`).
 
 **What you'll see when it fires.** A new PR titled `Auto-revert: <short-sha> (<status>)` from `github-actions[bot]`, base `main`. The body has the deploy ID, commit SHA, and instructions. CI runs against it like any other PR.


### PR DESCRIPTION
## Summary

- Comments out the `schedule:` trigger in `.github/workflows/auto-revert.yml` so the auto-revert workflow no longer runs every 5 min on cron.
- Leaves `workflow_dispatch` active so operators can still trigger manual runs (with the dry-run toggle) for testing.
- Adds a "Status: paused" note at the top of the runbook's "Auto-revert (failed deploys)" section so anyone reading the runbook knows automatic reverts aren't happening right now.

To re-enable: uncomment the `schedule:` block in the workflow file. No other changes needed — the existing `if: ${{ vars.RENDER_SERVICE_ID_API != '' }}` guard remains in place.

## Test plan

- [ ] Read the workflow diff — `schedule:` block is fully commented (cron + comments), `workflow_dispatch:` is untouched.
- [ ] After merge: confirm the "Auto-revert failed deploys" workflow no longer appears in the scheduled-runs list under the Actions tab. Manual "Run workflow" should still be available.
- [ ] Read the runbook update — the status banner is unambiguous about the workflow being paused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)