### PR TITLE
Kill 2 of the 4 known-equivalent mutants in auth + crypto

### DIFF
--- a/scripts/check_mutmut.py
+++ b/scripts/check_mutmut.py
@@ -5,7 +5,7 @@ Fails if:
   - any mutant times out (indicates async/test runner trouble), or
   - any mutant is marked suspicious.
 
-The four KNOWN_EQUIVALENT mutants below are semantically identical to the
+The KNOWN_EQUIVALENT mutants below are semantically identical to the
 original code under any input — see the explanations alongside each entry.
 They cannot be killed by tests; the only way to remove them from this list
 is to change the production code.
@@ -24,17 +24,12 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 STATS_PATH = REPO_ROOT / "mutants" / "mutmut-cicd-stats.json"
 
 KNOWN_EQUIVALENT: set[str] = {
-    # getattr default arg dropped; FIELD_ENCRYPTION_KEY is always defined in
-    # settings (possibly None), so getattr-without-default still resolves.
-    "agent_on_demand.crypto.x__get_fernet__mutmut_7",
     # Header default "" -> "XXXX". Both fail startswith("Bearer "), so the
-    # missing-header path returns the same 401 response either way.
+    # missing-header path returns the same 401 response either way. There
+    # is no way to distinguish these without rewriting the check (e.g. into
+    # a try/except KeyError), which is worse code for no real benefit.
     "agent_on_demand.auth.x__check_api_key_sync__mutmut_8",
     "agent_on_demand.auth.x__check_api_key_async__mutmut_8",
-    # select_related("user") -> select_related(None). The latter clears the
-    # join hint, but request.user = api_key.user still resolves via lazy load,
-    # so behavior is identical (one extra query in the failure case).
-    "agent_on_demand.auth.x__check_api_key_sync__mutmut_30",
 }
 
 

--- a/src/agent_on_demand/crypto.py
+++ b/src/agent_on_demand/crypto.py
@@ -6,7 +6,7 @@ from django.conf import settings
 
 
 def _get_fernet() -> Fernet:
-    material = getattr(settings, "FIELD_ENCRYPTION_KEY", None) or settings.SECRET_KEY
+    material = settings.FIELD_ENCRYPTION_KEY or settings.SECRET_KEY
     key = hashlib.sha256(material.encode()).digest()
     return Fernet(base64.urlsafe_b64encode(key))
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -11,8 +11,10 @@ from datetime import timedelta
 import pytest
 from asgiref.sync import async_to_sync
 from django.contrib.auth import get_user_model
+from django.db import connection
 from django.http import JsonResponse
 from django.test import RequestFactory
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone as tz
 
 from agent_on_demand.auth import require_api_key
@@ -213,3 +215,36 @@ def test_async_valid_key_attaches_user(factory, user, api_key):
     payload = body(resp)
     assert payload["user_id"] == user.id
     assert payload["key_id"] == instance.id
+
+
+# === select_related("user") pin (auth N+1 guard) ===
+#
+# `_check_api_key_{sync,async}` use `APIKey.objects.select_related("user").get(...)`
+# so `request.user = api_key.user` in the wrapper doesn't trigger a second
+# query. Drop the `select_related("user")` and the auth check goes from one
+# query to two — these tests fail in that case, killing the mutation that
+# replaces the join hint with `None`.
+
+
+def test_sync_auth_select_related_keeps_user_load_to_one_query(factory, api_key):
+    _, raw = api_key
+    request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {raw}")
+    with CaptureQueriesContext(connection) as ctx:
+        resp = _make_sync_view()(request)
+    assert resp.status_code == 200
+    assert len(ctx.captured_queries) == 1, (
+        f"expected 1 query (select_related join), got {len(ctx.captured_queries)}: "
+        f"{[q['sql'] for q in ctx.captured_queries]}"
+    )
+
+
+def test_async_auth_select_related_keeps_user_load_to_one_query(factory, api_key):
+    _, raw = api_key
+    request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {raw}")
+    with CaptureQueriesContext(connection) as ctx:
+        resp = call_async(_make_async_view(), request)
+    assert resp.status_code == 200
+    assert len(ctx.captured_queries) == 1, (
+        f"expected 1 query (select_related join), got {len(ctx.captured_queries)}: "
+        f"{[q['sql'] for q in ctx.captured_queries]}"
+    )


### PR DESCRIPTION
## Summary

Two of the four entries in `KNOWN_EQUIVALENT` were equivalent only by accident of how the production code was written. This PR removes them by tightening the code:

1. **`crypto.x__get_fernet__mutmut_7`** (getattr default arg dropped). `getattr(settings, \"FIELD_ENCRYPTION_KEY\", None)` was equivalent to `getattr(settings, \"FIELD_ENCRYPTION_KEY\")` because `settings.py` always defines the attribute. Replaced with direct attribute access — same behavior, no `getattr` to mutate, and the change documents the always-defined invariant.
2. **`auth.x__check_api_key_sync__mutmut_30`** (select_related arg dropped). The mutation was a *query count* difference, not a behavioral one — the sync path silently did one extra query. Added two new tests using `CaptureQueriesContext` that assert exactly one query for both sync and async paths. Verified by sed-mutating production locally: both new tests fail.

## Why the asymmetry (sync survived, async didn't)

In an async context, `request.user = api_key.user` triggers a sync DB query that Django forbids — it raises `SynchronousOnlyOperation`. The existing `test_async_valid_key_attaches_user` already caught this, so the async version of mutmut_30 was always being killed. The sync path silently did the extra query — nothing caught it. The new sync test does.

## Why the remaining two are kept

`auth.x__check_api_key_{sync,async}__mutmut_8` — the `request.META.get(\"HTTP_AUTHORIZATION\", \"\")` default. Any non-Bearer string default fails the `startswith(\"Bearer \")` check identically. Killing these would require restructuring (e.g. try/except KeyError), which is worse code for no real benefit. The allowlist comment now explains this explicitly.

## Test plan

- [ ] Read the diff in `tests/test_auth.py` — the two new tests use `CaptureQueriesContext` and assert exactly one query.
- [ ] Read the diff in `src/agent_on_demand/crypto.py` — the only behavioral question is whether `settings.FIELD_ENCRYPTION_KEY` is always defined. Verified at `src/config/settings.py:14` (`FIELD_ENCRYPTION_KEY = os.environ.get(\"FIELD_ENCRYPTION_KEY\")` — unconditional, possibly None).
- [ ] Read the diff in `scripts/check_mutmut.py` — two entries removed, comment on the remaining two clarified.
- [ ] CI mutation-test job passes — should report 0 new survivors. The two removed entries are no longer in the survivors list (mutmut_7 because the getattr is gone, mutmut_30 because the new test kills it).
- [ ] Locally verified: `make lint`, `make fmt-check`, `make test` (697 passed, including 2 new). Sed-mutated `select_related(\"user\")` → `select_related(None)` and confirmed both new tests fail; restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)