### PR TITLE
Fix .bakery.yml gates and add migration/schema checks

### DIFF
--- a/.bakery.yml
+++ b/.bakery.yml
@@ -20,16 +20,31 @@ gates:
 
   # --- Security tier (preflight, no DB needed) ---
   - name: security-deps
-    command: uv run pip-audit
+    # CVE-2026-3219: pip itself, no fix version available as of 2026-04-26.
+    # Mirrors `make security`; revisit when pip publishes a fix.
+    command: uv run pip-audit --ignore-vuln CVE-2026-3219
     preflight: true
 
   - name: security-code
     command: uv run bandit -r src/ -ll
     preflight: true
 
+  # --- Static contract checks (danger-zone gates per CLAUDE.md) ---
+  - name: migrations
+    command: BASE_SHA=$(git merge-base origin/main HEAD 2>/dev/null || git merge-base main HEAD) make check-migrations
+    preflight: true
+
+  - name: schemas
+    command: make check-schemas
+    preflight: true
+
   # --- Coverage-gated test tier ---
+  # DATABASE_URL forces SQLite so Django doesn't try to reach the dev Postgres
+  # (port 5460) which doesn't exist in the bakery sandbox. Coverage floor comes
+  # from [tool.coverage.report].fail_under in pyproject.toml (96 today) — do
+  # not pin --cov-fail-under here or it will drift from the ratchet.
   - name: test
-    command: uv run pytest --cov=agent_on_demand --cov-report=term-missing --cov-fail-under=85
+    command: env DATABASE_URL=sqlite:///test.db uv run pytest --cov=agent_on_demand --cov-report=term-missing
     preflight: false
 
   # --- Duplication check (catch AI copy-paste drift) ---


### PR DESCRIPTION
## Summary

Bakery runs have been failing on every PR for reasons unrelated to PR contents. Three drifts between `.bakery.yml` and the `Makefile` (the canonical command source) plus two missing danger-zone gates.

**Fixes:**
- `security-deps`: add `--ignore-vuln CVE-2026-3219`. The Makefile already ignores this unfixable pip CVE; bakery has been failing on it since the CVE landed.
- `test`: prepend `env DATABASE_URL=sqlite:///test.db`. Without it Django reaches for the dev Postgres on port 5460, which doesn't exist in the bakery sandbox, and every test fails at connection time.
- `test`: drop `--cov-fail-under=85`. `[tool.coverage.report].fail_under` in `pyproject.toml` is 96 — the bakery's hardcoded 85 silently undercut the coverage ratchet that CLAUDE.md calls out as load-bearing. With the flag removed, pytest-cov falls back to the pyproject value, matching `make coverage`.

**New gates** (both flagged as danger-zone in CLAUDE.md, both already enforced in CI — adding here gives bakery PRs the same coverage):
- `migrations`: `make check-migrations` against `git merge-base origin/main HEAD` (with a fallback to local `main`).
- `schemas`: `make check-schemas` to pin pydantic request shapes against `docs/request_schemas.json`.

## Test plan

- [x] `uv run pip-audit --ignore-vuln CVE-2026-3219` runs clean locally
- [x] `make check-schemas` runs clean locally (7 models verified)
- [x] `make check-migrations` runs clean locally against `origin/main` merge-base
- [ ] Bakery run on this PR reaches a green or "real failure" state — i.e., no more spurious connection-refused / pip-CVE failures
- [ ] Coverage gate now enforces 96, not 85

🤖 Generated with [Claude Code](https://claude.com/claude-code)