### PR TITLE
Extract build_turn_argv into its own module + mutation tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ paths_to_mutate = [
     "src/agent_on_demand/skill_validation.py",
     "src/agent_on_demand/github_resource_validation.py",
     "src/agent_on_demand/session_service/provision_script.py",
+    "src/agent_on_demand/session_service/turn_argv.py",
 ]
 tests_dir = [
     "tests/test_auth.py",
@@ -177,6 +178,7 @@ tests_dir = [
     "tests/test_skill_validation.py",
     "tests/test_github_resource_validation.py",
     "tests/test_provision_script.py",
+    "tests/test_turn_argv.py",
 ]
 # mutmut copies its working tree to ./mutants/ and runs pytest from there;
 # without these, the rest of the src/ tree isn't available to the test runner.

--- a/scripts/check_mutmut.py
+++ b/scripts/check_mutmut.py
@@ -40,6 +40,19 @@ KNOWN_EQUIVALENT: set[str] = {
     # Keeping the guard.
     "agent_on_demand.session_service.provision_script.x_build_provision_script__mutmut_29",
     "agent_on_demand.session_service.provision_script.x_build_provision_script__mutmut_31",
+    # `cast(Literal["run", "continue"], mode)` -> any mutation of the type
+    # literal (None, "XXrunXX", "RUN", "XXcontinueXX", "CONTINUE"). At runtime
+    # `typing.cast(typ, val)` is `return val` — the type expression is never
+    # evaluated, so every mutation produces identical bytes. The cast exists
+    # only to satisfy mypy's narrowing of `mode: str` to the Literal that
+    # `Runtime.build_command` requires; removing it would just push the cast
+    # to the caller in `tasks.py` (which is not mutation-tested), gaining
+    # nothing.
+    "agent_on_demand.session_service.turn_argv.x_build_turn_argv__mutmut_6",
+    "agent_on_demand.session_service.turn_argv.x_build_turn_argv__mutmut_10",
+    "agent_on_demand.session_service.turn_argv.x_build_turn_argv__mutmut_11",
+    "agent_on_demand.session_service.turn_argv.x_build_turn_argv__mutmut_12",
+    "agent_on_demand.session_service.turn_argv.x_build_turn_argv__mutmut_13",
 }
 
 

--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -31,7 +31,6 @@ import logging
 import queue
 import threading
 import time
-from typing import Literal, cast
 
 import posthog
 from django.contrib.auth import get_user_model
@@ -46,7 +45,6 @@ from agent_on_demand.models import (
     SessionTurn,
 )
 from agent_on_demand.observability import get_tracer
-from agent_on_demand.runtimes import Runtime
 
 from .errors import NoSpritesKeyError, ProvisionError, SessionHandleNotFound
 from .provisioning import (
@@ -57,6 +55,7 @@ from .provisioning import (
     resume_session,
 )
 from .spec_factory import build_spec_for_session
+from .turn_argv import build_turn_argv
 
 logger = logging.getLogger(__name__)
 
@@ -99,25 +98,6 @@ class TaggingQueueWriter(io.RawIOBase):
             if self.drop_count == 1:
                 logger.warning("TaggingQueueWriter: output queue full, dropping chunks")
         return len(data)
-
-
-_ENV_SOURCE_SHIM = 'set -a; source /tmp/aod-env; set +a; exec "$@"'
-
-
-def build_turn_argv(runtime: Runtime, spec, mode: str) -> list[str]:
-    """Return the full argv for the per-turn `sprite.command`.
-
-    The first three elements are a thin `bash -lc` shim that sources
-    `/tmp/aod-env` (so credential and Environment env vars reach the
-    runtime CLI's process) and then execs the runtime argv verbatim. No
-    template substitution — the runtime's `build_command` already inlined
-    any session-id or model values from the spec.
-
-    Prompt delivery is out of band: callers attach `cmd.stdin` with the
-    prompt bytes so it flows through the bash shim into the runtime CLI.
-    """
-    argv = runtime.build_command(spec, cast(Literal["run", "continue"], mode))
-    return ["bash", "-lc", _ENV_SOURCE_SHIM, "--", *argv]
 
 
 @procrastinate_app.task(queue="sessions", name="provision_session", pass_context=False)

--- a/src/agent_on_demand/session_service/turn_argv.py
+++ b/src/agent_on_demand/session_service/turn_argv.py
@@ -1,0 +1,31 @@
+"""Build the per-turn argv handed to `sprite.command(...)`.
+
+A quoting or ordering bug here silently breaks env-var sourcing for every
+turn against every runtime, so the function lives in its own module so it
+can be direct-tested under mutmut's hammett runner (which can't load the
+Procrastinate task decorators in tasks.py).
+"""
+
+from __future__ import annotations
+
+from typing import Literal, cast
+
+from agent_on_demand.runtimes import Runtime
+
+_ENV_SOURCE_SHIM = 'set -a; source /tmp/aod-env; set +a; exec "$@"'
+
+
+def build_turn_argv(runtime: Runtime, spec, mode: str) -> list[str]:
+    """Return the full argv for the per-turn `sprite.command`.
+
+    The first three elements are a thin `bash -lc` shim that sources
+    `/tmp/aod-env` (so credential and Environment env vars reach the
+    runtime CLI's process) and then execs the runtime argv verbatim. No
+    template substitution — the runtime's `build_command` already inlined
+    any session-id or model values from the spec.
+
+    Prompt delivery is out of band: callers attach `cmd.stdin` with the
+    prompt bytes so it flows through the bash shim into the runtime CLI.
+    """
+    argv = runtime.build_command(spec, cast(Literal["run", "continue"], mode))
+    return ["bash", "-lc", _ENV_SOURCE_SHIM, "--", *argv]

--- a/src/agent_on_demand/session_service/turn_argv.py
+++ b/src/agent_on_demand/session_service/turn_argv.py
@@ -8,14 +8,17 @@ Procrastinate task decorators in tasks.py).
 
 from __future__ import annotations
 
-from typing import Literal, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from agent_on_demand.runtimes import Runtime
+
+if TYPE_CHECKING:
+    from .specs import SessionSpec
 
 _ENV_SOURCE_SHIM = 'set -a; source /tmp/aod-env; set +a; exec "$@"'
 
 
-def build_turn_argv(runtime: Runtime, spec, mode: str) -> list[str]:
+def build_turn_argv(runtime: Runtime, spec: SessionSpec, mode: str) -> list[str]:
     """Return the full argv for the per-turn `sprite.command`.
 
     The first three elements are a thin `bash -lc` shim that sources

--- a/tests/test_turn_argv.py
+++ b/tests/test_turn_argv.py
@@ -1,0 +1,148 @@
+"""Direct unit tests for `build_turn_argv`.
+
+Mutation-tested. Each test pins one mutation-killable property of the
+per-turn argv construction:
+
+  - The first four elements are the bash-shim prologue, in exact order.
+  - The shim string sources ``/tmp/aod-env`` with the precise
+    ``set -a; source ...; set +a; exec "$@"`` sequence — a quoting or
+    word-order bug here silently breaks env-var sourcing for every
+    turn against every runtime.
+  - The runtime's ``build_command(spec, mode)`` return is appended
+    verbatim after the ``--`` separator, in order.
+  - ``mode`` is forwarded to ``runtime.build_command`` literally
+    (``"run"`` and ``"continue"`` both reach the runtime).
+  - An empty ``build_command`` return → argv is exactly the 4-element
+    shim with no trailing items.
+
+Tests are sync, no Django imports — required so hammett (mutmut's
+runner) can execute them. ``Runtime`` and ``SessionSpec`` are
+duck-typed via ``SimpleNamespace``.
+"""
+
+from types import SimpleNamespace
+
+from agent_on_demand.session_service.turn_argv import (
+    _ENV_SOURCE_SHIM,
+    build_turn_argv,
+)
+
+
+def _runtime(argv=None, recorder=None):
+    """Stub Runtime whose ``build_command`` returns ``argv`` and records
+    its call args into ``recorder`` (if provided)."""
+
+    def build_command(spec, mode):
+        if recorder is not None:
+            recorder.append((spec, mode))
+        return list(argv) if argv is not None else []
+
+    return SimpleNamespace(build_command=build_command)
+
+
+def _spec():
+    return SimpleNamespace()
+
+
+# ---------- shim prologue ----------
+
+
+def test_argv_begins_with_bash_lc_shim_and_separator():
+    """The first four elements are exactly ``["bash", "-lc",
+    _ENV_SOURCE_SHIM, "--"]`` in that order. Pin so a refactor that
+    reorders them, drops the ``--``, or substitutes a different shell
+    would have to be a deliberate change."""
+    argv = build_turn_argv(_runtime(argv=["claude", "--print"]), _spec(), "run")
+    assert argv[0] == "bash"
+    assert argv[1] == "-lc"
+    assert argv[2] == _ENV_SOURCE_SHIM
+    assert argv[3] == "--"
+
+
+def test_shim_string_is_exact():
+    """Full-string assertion to kill wrapper mutants like ``XXset
+    -aXX...``. The exact bytes matter — ``set -a`` exports every
+    sourced var, and ``exec "$@"`` replaces the bash process with the
+    runtime CLI so signals propagate."""
+    assert _ENV_SOURCE_SHIM == 'set -a; source /tmp/aod-env; set +a; exec "$@"'
+
+
+def test_shim_constant_is_used_in_argv():
+    """The third element of the argv must BE the module-level shim
+    constant, not a copy that has drifted. Identity-of-string check
+    pins the indirection."""
+    argv = build_turn_argv(_runtime(argv=["x"]), _spec(), "run")
+    assert argv[2] == _ENV_SOURCE_SHIM
+
+
+# ---------- runtime argv pass-through ----------
+
+
+def test_runtime_argv_appended_verbatim_after_separator():
+    """The runtime's argv lands after ``--`` in the order it returned
+    them. Pin so a mutant that reverses the splat or wraps each item
+    has nothing to hide behind."""
+    argv = build_turn_argv(
+        _runtime(argv=["claude", "--print", "--model", "sonnet"]),
+        _spec(),
+        "run",
+    )
+    assert argv[4:] == ["claude", "--print", "--model", "sonnet"]
+
+
+def test_full_argv_shape_with_runtime_argv():
+    """End-to-end shape: the prologue + runtime argv concatenate to
+    exactly what gets handed to ``sprite.command(...)``."""
+    argv = build_turn_argv(_runtime(argv=["codex", "exec"]), _spec(), "run")
+    assert argv == [
+        "bash",
+        "-lc",
+        _ENV_SOURCE_SHIM,
+        "--",
+        "codex",
+        "exec",
+    ]
+
+
+def test_empty_runtime_argv_yields_only_shim():
+    """A runtime that returns ``[]`` from ``build_command`` produces
+    exactly the 4-element shim with no trailing items. Distinguishes a
+    mutant that injects a stray empty string or duplicates the
+    separator."""
+    argv = build_turn_argv(_runtime(argv=[]), _spec(), "run")
+    assert argv == ["bash", "-lc", _ENV_SOURCE_SHIM, "--"]
+    assert len(argv) == 4
+
+
+# ---------- mode forwarding ----------
+
+
+def test_mode_run_is_forwarded_literally():
+    """``mode="run"`` reaches ``runtime.build_command`` as the literal
+    string ``"run"`` — no rewrite, no fall-through to a default."""
+    calls: list = []
+    argv = build_turn_argv(_runtime(argv=["x"], recorder=calls), _spec(), "run")
+    assert argv == ["bash", "-lc", _ENV_SOURCE_SHIM, "--", "x"]
+    assert len(calls) == 1
+    assert calls[0][1] == "run"
+
+
+def test_mode_continue_is_forwarded_literally():
+    """``mode="continue"`` reaches ``runtime.build_command`` as the
+    literal string ``"continue"`` — pin both legal mode values so a
+    mutant that hard-codes one is caught."""
+    calls: list = []
+    argv = build_turn_argv(_runtime(argv=["x"], recorder=calls), _spec(), "continue")
+    assert argv == ["bash", "-lc", _ENV_SOURCE_SHIM, "--", "x"]
+    assert len(calls) == 1
+    assert calls[0][1] == "continue"
+
+
+def test_spec_is_forwarded_to_build_command():
+    """The exact spec object passed in is what ``build_command``
+    receives — no copy, no rewrap. Pin so a mutant that swaps spec for
+    None or a sentinel is caught."""
+    calls: list = []
+    spec = _spec()
+    build_turn_argv(_runtime(argv=[], recorder=calls), spec, "run")
+    assert calls[0][0] is spec

--- a/tests/test_turn_argv.py
+++ b/tests/test_turn_argv.py
@@ -67,14 +67,6 @@ def test_shim_string_is_exact():
     assert _ENV_SOURCE_SHIM == 'set -a; source /tmp/aod-env; set +a; exec "$@"'
 
 
-def test_shim_constant_is_used_in_argv():
-    """The third element of the argv must BE the module-level shim
-    constant, not a copy that has drifted. Identity-of-string check
-    pins the indirection."""
-    argv = build_turn_argv(_runtime(argv=["x"]), _spec(), "run")
-    assert argv[2] == _ENV_SOURCE_SHIM
-
-
 # ---------- runtime argv pass-through ----------
 
 


### PR DESCRIPTION
Closes #212. Step 1 of 7 in the session-service quality pass.

## Summary

- Move `_ENV_SOURCE_SHIM` and `build_turn_argv` verbatim from `tasks.py` into a new `session_service/turn_argv.py`. The shim constant becomes private to the new module — `tasks.py` was the only consumer.
- New `tests/test_turn_argv.py` is sync-only (no Django imports, `SimpleNamespace` stubs for `Runtime`/`SessionSpec`) so it runs under mutmut's `hammett` runner.
- Add `turn_argv.py` to `[tool.mutmut].paths_to_mutate` and the test to `tests_dir`.

## Mutation coverage

`make mutation-test`: 714/723 killed, 9 survived — 4 pre-existing equivalents + 5 new equivalents documented in `KNOWN_EQUIVALENT` (`scripts/check_mutmut.py`). All five new ones mutate the type literal inside `cast(Literal["run", "continue"], mode)`. `typing.cast` is a runtime no-op (it returns its second argument unchanged regardless of the type expression), so any mutation of the type literal is behaviorally identical to the original. Removing the cast would just push it to `tasks.py` (which is not mutation-tested), gaining nothing.

The new tests pin: shim prologue order, exact shim string, runtime argv pass-through, mode literal forwarding (`"run"` and `"continue"` both reach `runtime.build_command`), and the empty-argv case.

## Test plan

- [x] `make test` (903 passed)
- [x] `make lint` (clean)
- [x] `make fmt-check` (clean)
- [x] `make typecheck` (clean)
- [x] `make mutation-test` (passed; 5 documented equivalents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)