### PR TITLE
Extract build_env_file_body into its own module + mutation tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ paths_to_mutate = [
     "src/agent_on_demand/github_resource_validation.py",
     "src/agent_on_demand/session_service/provision_script.py",
     "src/agent_on_demand/session_service/turn_argv.py",
+    "src/agent_on_demand/session_service/env_file.py",
 ]
 tests_dir = [
     "tests/test_auth.py",
@@ -179,6 +180,7 @@ tests_dir = [
     "tests/test_github_resource_validation.py",
     "tests/test_provision_script.py",
     "tests/test_turn_argv.py",
+    "tests/test_env_file.py",
 ]
 # mutmut copies its working tree to ./mutants/ and runs pytest from there;
 # without these, the rest of the src/ tree isn't available to the test runner.

--- a/src/agent_on_demand/session_service/env_file.py
+++ b/src/agent_on_demand/session_service/env_file.py
@@ -29,12 +29,15 @@ def build_env_file_body(spec: "SessionSpec", credentials: list[tuple[str, str]])
     lines: list[str] = []
     for env_name, value in credentials:
         lines.append(f"{env_name}={shlex.quote(value)}")
+    # Falsy session_id / model mean "not set yet" and skip the line; a falsy
+    # env_vars value is a deliberate user-supplied empty override and is
+    # always emitted (e.g. `FOO=''`).
     if spec.runtime_session_id:
         lines.append(f"AOD_SESSION_ID={shlex.quote(spec.runtime_session_id)}")
     if spec.model:
         lines.append(f"AOD_MODEL={shlex.quote(spec.model)}")
     env = spec.environment
     if env is not None:
-        for key in sorted(env.env_vars or {}):
-            lines.append(f"{key}={shlex.quote(env.env_vars[key])}")
+        for key, value in sorted((env.env_vars or {}).items()):
+            lines.append(f"{key}={shlex.quote(value)}")
     return "\n".join(lines) + "\n"

--- a/src/agent_on_demand/session_service/env_file.py
+++ b/src/agent_on_demand/session_service/env_file.py
@@ -1,0 +1,40 @@
+"""Compose the body of `/tmp/aod-env`.
+
+The file is sourced (with `set -a`) by the per-turn dispatcher so every
+runtime CLI inherits the credential, session, and Environment env vars.
+A quoting or precedence bug here silently leaks raw shell metacharacters
+into the runtime's process environment, so the body builder lives in its
+own pure module — direct-testable under mutmut's hammett runner without
+pulling in the Sprite or ORM dependencies that `_write_env_file` carries.
+"""
+
+from __future__ import annotations
+
+import shlex
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .specs import SessionSpec
+
+
+def build_env_file_body(spec: "SessionSpec", credentials: list[tuple[str, str]]) -> str:
+    """Render the body of /tmp/aod-env.
+
+    `credentials` is a list of ``(env_var_name, value)`` pairs already
+    resolved from the ORM by the caller. Each value is ``shlex.quote``-d
+    before emission. Precedence: credentials → AOD_SESSION_ID → AOD_MODEL
+    → sorted ``spec.environment.env_vars`` (per-environment overrides
+    win). Body always ends with exactly one trailing newline.
+    """
+    lines: list[str] = []
+    for env_name, value in credentials:
+        lines.append(f"{env_name}={shlex.quote(value)}")
+    if spec.runtime_session_id:
+        lines.append(f"AOD_SESSION_ID={shlex.quote(spec.runtime_session_id)}")
+    if spec.model:
+        lines.append(f"AOD_MODEL={shlex.quote(spec.model)}")
+    env = spec.environment
+    if env is not None:
+        for key in sorted(env.env_vars or {}):
+            lines.append(f"{key}={shlex.quote(env.env_vars[key])}")
+    return "\n".join(lines) + "\n"

--- a/src/agent_on_demand/session_service/provisioning.py
+++ b/src/agent_on_demand/session_service/provisioning.py
@@ -31,6 +31,7 @@ from agent_on_demand.models import Environment
 from agent_on_demand.observability import get_tracer
 
 from .client import best_effort_delete, require_client
+from .env_file import build_env_file_body
 from .errors import ProvisionError
 from .provision_script import (
     ENV_FILE_PATH,
@@ -223,20 +224,12 @@ def _write_env_file(sprite: Sprite, spec: SessionSpec, session_id: str | None) -
     Environment.env_vars last — per-environment overrides win."""
     from agent_on_demand.models.auth import CREDENTIAL_ENV_VAR, UserCredential
 
-    lines: list[str] = []
+    credentials: list[tuple[str, str]] = []
     for cred in UserCredential.objects.filter(user=spec.user):
         env_name = CREDENTIAL_ENV_VAR.get(cred.kind)
         if env_name:
-            lines.append(f"{env_name}={shlex.quote(cred.get_value())}")
-    if spec.runtime_session_id:
-        lines.append(f"AOD_SESSION_ID={shlex.quote(spec.runtime_session_id)}")
-    if spec.model:
-        lines.append(f"AOD_MODEL={shlex.quote(spec.model)}")
-    env = spec.environment
-    if env is not None:
-        for key in sorted(env.env_vars or {}):
-            lines.append(f"{key}={shlex.quote(env.env_vars[key])}")
-    body = "\n".join(lines) + "\n"
+            credentials.append((env_name, cred.get_value()))
+    body = build_env_file_body(spec, credentials)
     with stage_timer(session_id, STAGE_ENV_FILE):
         try:
             fs = sprite.filesystem()

--- a/tests/test_env_file.py
+++ b/tests/test_env_file.py
@@ -1,0 +1,224 @@
+"""Direct unit tests for `build_env_file_body`.
+
+Mutation-tested. Each test pins one mutation-killable property of the
+`/tmp/aod-env` body:
+
+  - Precedence: credentials → AOD_SESSION_ID → AOD_MODEL → sorted
+    Environment.env_vars. A swap or drop here silently breaks env-var
+    overrides on every session.
+  - `shlex.quote` is applied to every value — payloads with spaces,
+    single quotes, and dollar signs verify quoting is active.
+  - Falsy `runtime_session_id` (None or "") and `model` (None or "") are
+    omitted entirely.
+  - `env_vars` keys are emitted in alphabetical order regardless of
+    dict insertion order.
+  - The body always ends with exactly one trailing newline (not zero,
+    not two).
+  - Empty inputs across the board → body is exactly ``"\\n"``.
+
+Tests are sync, no Django imports — required so hammett (mutmut's
+runner) can execute them. ``SessionSpec`` and ``Environment`` are
+duck-typed via ``SimpleNamespace``.
+"""
+
+from types import SimpleNamespace
+
+from agent_on_demand.session_service.env_file import build_env_file_body
+
+
+def _spec(runtime_session_id=None, model="", environment=None):
+    return SimpleNamespace(
+        runtime_session_id=runtime_session_id,
+        model=model,
+        environment=environment,
+    )
+
+
+def _env(env_vars=None):
+    return SimpleNamespace(env_vars=env_vars or {})
+
+
+# ---------- empty inputs ----------
+
+
+def test_empty_inputs_produces_single_newline():
+    assert build_env_file_body(_spec(), []) == "\n"
+
+
+def test_none_environment_produces_no_env_var_lines():
+    assert build_env_file_body(_spec(environment=None), []) == "\n"
+
+
+# ---------- ordering: credentials → AOD_SESSION_ID → AOD_MODEL → env_vars ----------
+
+
+def test_credential_precedes_session_id():
+    spec = _spec(runtime_session_id="sess-1")
+    body = build_env_file_body(spec, [("ANTHROPIC_API_KEY", "key123")])
+    lines = body.rstrip("\n").splitlines()
+    cred_idx = next(i for i, ln in enumerate(lines) if ln.startswith("ANTHROPIC_API_KEY="))
+    sid_idx = next(i for i, ln in enumerate(lines) if ln.startswith("AOD_SESSION_ID="))
+    assert cred_idx < sid_idx
+
+
+def test_session_id_precedes_model():
+    spec = _spec(runtime_session_id="sess-1", model="claude-3")
+    body = build_env_file_body(spec, [])
+    lines = body.rstrip("\n").splitlines()
+    sid_idx = next(i for i, ln in enumerate(lines) if ln.startswith("AOD_SESSION_ID="))
+    model_idx = next(i for i, ln in enumerate(lines) if ln.startswith("AOD_MODEL="))
+    assert sid_idx < model_idx
+
+
+def test_model_precedes_env_vars():
+    spec = _spec(model="claude-3", environment=_env({"ZKEY": "z"}))
+    body = build_env_file_body(spec, [])
+    lines = body.rstrip("\n").splitlines()
+    model_idx = next(i for i, ln in enumerate(lines) if ln.startswith("AOD_MODEL="))
+    env_idx = next(i for i, ln in enumerate(lines) if ln.startswith("ZKEY="))
+    assert model_idx < env_idx
+
+
+def test_credentials_precede_env_vars():
+    spec = _spec(environment=_env({"AKEY": "val"}))
+    body = build_env_file_body(spec, [("OPENAI_API_KEY", "sk-xyz")])
+    lines = body.rstrip("\n").splitlines()
+    cred_idx = next(i for i, ln in enumerate(lines) if ln.startswith("OPENAI_API_KEY="))
+    env_idx = next(i for i, ln in enumerate(lines) if ln.startswith("AKEY="))
+    assert cred_idx < env_idx
+
+
+def test_full_body_emits_in_documented_order():
+    spec = _spec(
+        runtime_session_id="sess-1",
+        model="claude-3",
+        environment=_env({"ZZZ": "z", "AAA": "a"}),
+    )
+    body = build_env_file_body(spec, [("CRED1", "v1"), ("CRED2", "v2")])
+    keys = [ln.split("=", 1)[0] for ln in body.rstrip("\n").splitlines()]
+    assert keys == ["CRED1", "CRED2", "AOD_SESSION_ID", "AOD_MODEL", "AAA", "ZZZ"]
+
+
+# ---------- shlex.quote applied to all values ----------
+
+
+def test_quote_applied_to_credential_with_spaces():
+    body = build_env_file_body(_spec(), [("MY_KEY", "hello world")])
+    assert "MY_KEY='hello world'" in body
+
+
+def test_quote_applied_to_credential_with_single_quote():
+    body = build_env_file_body(_spec(), [("MY_KEY", "it's")])
+    # shlex.quote escapes single quotes — bare unquoted form must not appear.
+    assert "MY_KEY=it's\n" not in body
+    assert "MY_KEY=" in body
+
+
+def test_quote_applied_to_credential_with_dollar_sign():
+    body = build_env_file_body(_spec(), [("MY_KEY", "$SECRET")])
+    assert "MY_KEY='$SECRET'" in body
+
+
+def test_quote_applied_to_session_id_with_spaces():
+    body = build_env_file_body(_spec(runtime_session_id="has space"), [])
+    assert "AOD_SESSION_ID='has space'" in body
+
+
+def test_quote_applied_to_model_with_dollar_sign():
+    body = build_env_file_body(_spec(model="$MODEL"), [])
+    assert "AOD_MODEL='$MODEL'" in body
+
+
+def test_quote_applied_to_env_var_value_with_spaces():
+    body = build_env_file_body(_spec(environment=_env({"FOO": "bar baz"})), [])
+    assert "FOO='bar baz'" in body
+
+
+# ---------- omission of falsy session_id / model ----------
+
+
+def test_none_session_id_omitted():
+    body = build_env_file_body(_spec(runtime_session_id=None, model="claude-3"), [])
+    assert "AOD_SESSION_ID" not in body
+
+
+def test_empty_string_session_id_omitted():
+    body = build_env_file_body(_spec(runtime_session_id=""), [])
+    assert "AOD_SESSION_ID" not in body
+
+
+def test_empty_model_omitted():
+    body = build_env_file_body(_spec(runtime_session_id="s1", model=""), [])
+    assert "AOD_MODEL" not in body
+
+
+def test_none_model_omitted():
+    body = build_env_file_body(_spec(model=None), [])
+    assert "AOD_MODEL" not in body
+
+
+# ---------- env_vars alphabetical ordering ----------
+
+
+def test_env_vars_emitted_in_alphabetical_order():
+    spec = _spec(environment=_env({"BETA": "2", "ALPHA": "1"}))
+    body = build_env_file_body(spec, [])
+    keys = [ln.split("=", 1)[0] for ln in body.rstrip("\n").splitlines()]
+    assert keys == ["ALPHA", "BETA"]
+
+
+def test_env_vars_three_keys_alphabetical():
+    spec = _spec(environment=_env({"ZZZ": "z", "AAA": "a", "MMM": "m"}))
+    body = build_env_file_body(spec, [])
+    keys = [ln.split("=", 1)[0] for ln in body.rstrip("\n").splitlines()]
+    assert keys == ["AAA", "MMM", "ZZZ"]
+
+
+# ---------- credentials preserve caller-supplied order ----------
+
+
+def test_multiple_credentials_order_preserved():
+    creds = [("FIRST", "a"), ("SECOND", "b"), ("THIRD", "c")]
+    body = build_env_file_body(_spec(), creds)
+    keys = [ln.split("=", 1)[0] for ln in body.rstrip("\n").splitlines()]
+    assert keys == ["FIRST", "SECOND", "THIRD"]
+
+
+# ---------- trailing-newline invariant ----------
+
+
+def test_body_ends_with_single_newline_when_empty():
+    body = build_env_file_body(_spec(), [])
+    assert body.endswith("\n")
+    assert not body.endswith("\n\n")
+
+
+def test_body_ends_with_single_newline_with_content():
+    spec = _spec(runtime_session_id="s", model="m", environment=_env({"K": "v"}))
+    body = build_env_file_body(spec, [("X", "y")])
+    assert body.endswith("\n")
+    assert not body.endswith("\n\n")
+
+
+def test_body_ends_with_single_newline_credential_only():
+    body = build_env_file_body(_spec(), [("K", "v")])
+    assert body.endswith("\n")
+    assert not body.endswith("\n\n")
+
+
+# ---------- value-side correctness for individual lines ----------
+
+
+def test_session_id_value_is_quoted_simple():
+    body = build_env_file_body(_spec(runtime_session_id="abc"), [])
+    assert "AOD_SESSION_ID=abc\n" in body
+
+
+def test_model_value_is_quoted_simple():
+    body = build_env_file_body(_spec(model="claude-3"), [])
+    assert "AOD_MODEL=claude-3\n" in body
+
+
+def test_env_var_value_is_quoted_simple():
+    body = build_env_file_body(_spec(environment=_env({"FOO": "bar"})), [])
+    assert "FOO=bar\n" in body


### PR DESCRIPTION
## Summary

- Move the `/tmp/aod-env` body composition out of `_write_env_file` into a pure `build_env_file_body(spec, credentials)` in a new `session_service/env_file.py`. The ORM fetch and Sprite write stay in `_write_env_file`; only the body string is built by the new module.
- Add `tests/test_env_file.py` — 25 sync, ORM-free mutation-killing tests covering precedence, `shlex.quote` application, falsy-value omission, alphabetical `env_vars` ordering, and the trailing-newline invariant.
- Wire `env_file.py` and `test_env_file.py` into `[tool.mutmut]`.

Step 2 of 7 in the session-service quality pass. Closes #217.

## Test plan

- [x] `make lint` — clean
- [x] `make fmt-check` — clean
- [x] `make typecheck` — clean
- [x] `make test` — 928 passed
- [x] `make mutation-test` — 731/740 killed, 9 documented known-equivalents (all pre-existing); env_file mutants 100% killed

🤖 Generated with [Claude Code](https://claude.com/claude-code)