### PR TITLE
Extract build_network_policy into its own module + mutation tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ paths_to_mutate = [
     "src/agent_on_demand/session_service/provision_script.py",
     "src/agent_on_demand/session_service/turn_argv.py",
     "src/agent_on_demand/session_service/env_file.py",
+    "src/agent_on_demand/session_service/network_policy.py",
 ]
 tests_dir = [
     "tests/test_auth.py",
@@ -181,6 +182,7 @@ tests_dir = [
     "tests/test_provision_script.py",
     "tests/test_turn_argv.py",
     "tests/test_env_file.py",
+    "tests/test_network_policy.py",
 ]
 # mutmut copies its working tree to ./mutants/ and runs pytest from there;
 # without these, the rest of the src/ tree isn't available to the test runner.

--- a/src/agent_on_demand/session_service/network_policy.py
+++ b/src/agent_on_demand/session_service/network_policy.py
@@ -1,0 +1,32 @@
+"""Build the `NetworkPolicy` for a session.
+
+The deny-all rule must be appended *last* so allow-listed hosts take
+precedence — a reorder would silently let everything through. The pure
+construction lives here so it can be direct-tested under mutmut's
+hammett runner without pulling in the Sprite SDK or ORM dependencies
+that `_apply_network_policy` carries.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sprites import NetworkPolicy, PolicyRule
+
+if TYPE_CHECKING:
+    from agent_on_demand.models import Environment
+
+
+def build_network_policy(env: "Environment | None") -> NetworkPolicy | None:
+    """Build the NetworkPolicy for a session, or None if no policy applies.
+
+    Returns None when env is None or networking_type != 'limited' (the
+    only restricted mode today). When 'limited', emits one allow rule per
+    `networking_config.allowed_hosts`, then a final `*` deny rule.
+    """
+    if env is None or env.networking_type != "limited":
+        return None
+    allowed_hosts = (env.networking_config or {}).get("allowed_hosts", [])
+    rules = [PolicyRule(domain=host, action="allow") for host in allowed_hosts]
+    rules.append(PolicyRule(domain="*", action="deny"))
+    return NetworkPolicy(rules=rules)

--- a/src/agent_on_demand/session_service/provisioning.py
+++ b/src/agent_on_demand/session_service/provisioning.py
@@ -25,7 +25,7 @@ import shlex
 import time
 from typing import Iterator
 
-from sprites import NetworkPolicy, PolicyRule, Sprite, SpriteError
+from sprites import Sprite, SpriteError
 
 from agent_on_demand.models import Environment
 from agent_on_demand.observability import get_tracer
@@ -33,6 +33,7 @@ from agent_on_demand.observability import get_tracer
 from .client import best_effort_delete, require_client
 from .env_file import build_env_file_body
 from .errors import ProvisionError
+from .network_policy import build_network_policy
 from .provision_script import (
     ENV_FILE_PATH,
     GIT_CREDS_PATH,
@@ -199,12 +200,9 @@ def _install_runtime(sprite: Sprite, spec: SessionSpec, session_id: str | None) 
 
 
 def _apply_network_policy(sprite: Sprite, env: Environment | None, session_id: str | None) -> None:
-    if env is None or env.networking_type != "limited":
+    policy = build_network_policy(env)
+    if policy is None:
         return
-    allowed_hosts = (env.networking_config or {}).get("allowed_hosts", [])
-    rules = [PolicyRule(domain=host, action="allow") for host in allowed_hosts]
-    rules.append(PolicyRule(domain="*", action="deny"))
-    policy = NetworkPolicy(rules=rules)
     with stage_timer(session_id, STAGE_NETWORK_POLICY):
         try:
             sprite.update_network_policy(policy)

--- a/tests/test_network_policy.py
+++ b/tests/test_network_policy.py
@@ -1,0 +1,179 @@
+"""Direct unit tests for `build_network_policy`.
+
+Mutation-tested. Each test pins one mutation-killable property of the
+`NetworkPolicy` returned for a session:
+
+  - `env=None` and `env.networking_type != "limited"` skip the policy.
+  - When `networking_type == "limited"`, allow rules come from
+    `networking_config.allowed_hosts` in input order, followed by exactly
+    one `*`/deny rule. A reorder mutant that puts the deny rule first
+    silently lets everything through.
+  - The final rule is always `domain="*", action="deny"` regardless of
+    how many allow-listed hosts are present.
+  - Missing/None `networking_config` collapses to a single `*`/deny rule.
+
+Tests are sync, no Django imports — required so hammett (mutmut's
+runner) can execute them. ``Environment`` is duck-typed via
+``SimpleNamespace``.
+"""
+
+from types import SimpleNamespace
+
+from sprites import NetworkPolicy, PolicyRule
+
+from agent_on_demand.session_service.network_policy import build_network_policy
+
+
+def _env(networking_type="limited", networking_config=None):
+    return SimpleNamespace(
+        networking_type=networking_type,
+        networking_config=networking_config,
+    )
+
+
+# ---------- env=None / non-limited networking ----------
+
+
+def test_none_env_returns_none():
+    assert build_network_policy(None) is None
+
+
+def test_unrestricted_returns_none():
+    assert build_network_policy(_env(networking_type="unrestricted")) is None
+
+
+def test_open_returns_none():
+    # Defensive: any value other than "limited" is treated as no policy.
+    assert build_network_policy(_env(networking_type="open")) is None
+
+
+def test_empty_string_networking_type_returns_none():
+    assert build_network_policy(_env(networking_type="")) is None
+
+
+# ---------- limited networking returns NetworkPolicy ----------
+
+
+def test_limited_returns_network_policy_instance():
+    env = _env(networking_config={"allowed_hosts": ["github.com"]})
+    policy = build_network_policy(env)
+    assert isinstance(policy, NetworkPolicy)
+
+
+def test_limited_with_two_allowed_hosts_emits_three_rules_in_order():
+    env = _env(networking_config={"allowed_hosts": ["github.com", "pypi.org"]})
+    policy = build_network_policy(env)
+    assert policy.rules == [
+        PolicyRule(domain="github.com", action="allow"),
+        PolicyRule(domain="pypi.org", action="allow"),
+        PolicyRule(domain="*", action="deny"),
+    ]
+
+
+def test_limited_preserves_input_order_of_allowed_hosts():
+    env = _env(networking_config={"allowed_hosts": ["pypi.org", "github.com"]})
+    policy = build_network_policy(env)
+    domains = [r.domain for r in policy.rules]
+    # Input order is preserved (no sort applied), and deny is last.
+    assert domains == ["pypi.org", "github.com", "*"]
+
+
+def test_limited_with_one_allowed_host_emits_two_rules():
+    env = _env(networking_config={"allowed_hosts": ["api.anthropic.com"]})
+    policy = build_network_policy(env)
+    assert policy.rules == [
+        PolicyRule(domain="api.anthropic.com", action="allow"),
+        PolicyRule(domain="*", action="deny"),
+    ]
+
+
+# ---------- empty / missing allowed_hosts ----------
+
+
+def test_limited_with_empty_allowed_hosts_emits_only_deny():
+    env = _env(networking_config={"allowed_hosts": []})
+    policy = build_network_policy(env)
+    assert policy.rules == [PolicyRule(domain="*", action="deny")]
+
+
+def test_limited_with_none_networking_config_emits_only_deny():
+    env = _env(networking_config=None)
+    policy = build_network_policy(env)
+    assert policy.rules == [PolicyRule(domain="*", action="deny")]
+
+
+def test_limited_with_empty_networking_config_emits_only_deny():
+    env = _env(networking_config={})
+    policy = build_network_policy(env)
+    assert policy.rules == [PolicyRule(domain="*", action="deny")]
+
+
+# ---------- final rule is always *-deny ----------
+
+
+def test_final_rule_is_deny_all_with_zero_allowed_hosts():
+    env = _env(networking_config={"allowed_hosts": []})
+    policy = build_network_policy(env)
+    assert policy.rules[-1] == PolicyRule(domain="*", action="deny")
+
+
+def test_final_rule_is_deny_all_with_one_allowed_host():
+    env = _env(networking_config={"allowed_hosts": ["github.com"]})
+    policy = build_network_policy(env)
+    assert policy.rules[-1] == PolicyRule(domain="*", action="deny")
+
+
+def test_final_rule_is_deny_all_with_many_allowed_hosts():
+    env = _env(networking_config={"allowed_hosts": ["a.com", "b.com", "c.com", "d.com"]})
+    policy = build_network_policy(env)
+    assert policy.rules[-1] == PolicyRule(domain="*", action="deny")
+
+
+def test_final_rule_action_is_deny_not_allow():
+    env = _env(networking_config={"allowed_hosts": ["github.com"]})
+    policy = build_network_policy(env)
+    assert policy.rules[-1].action == "deny"
+
+
+def test_final_rule_domain_is_star():
+    env = _env(networking_config={"allowed_hosts": ["github.com"]})
+    policy = build_network_policy(env)
+    assert policy.rules[-1].domain == "*"
+
+
+# ---------- allow rules carry action="allow" ----------
+
+
+def test_allow_rules_have_action_allow():
+    env = _env(networking_config={"allowed_hosts": ["github.com", "pypi.org"]})
+    policy = build_network_policy(env)
+    # All rules except the trailing deny are allows.
+    for rule in policy.rules[:-1]:
+        assert rule.action == "allow"
+
+
+def test_allow_rules_carry_host_as_domain():
+    env = _env(networking_config={"allowed_hosts": ["github.com", "pypi.org"]})
+    policy = build_network_policy(env)
+    assert [r.domain for r in policy.rules[:-1]] == ["github.com", "pypi.org"]
+
+
+# ---------- wildcard hosts in allow list pass through unchanged ----------
+
+
+def test_wildcard_allow_host_passes_through():
+    env = _env(networking_config={"allowed_hosts": ["*.github.com"]})
+    policy = build_network_policy(env)
+    assert policy.rules == [
+        PolicyRule(domain="*.github.com", action="allow"),
+        PolicyRule(domain="*", action="deny"),
+    ]
+
+
+# ---------- rule count invariants ----------
+
+
+def test_rule_count_equals_allowed_hosts_plus_one():
+    env = _env(networking_config={"allowed_hosts": ["a", "b", "c"]})
+    policy = build_network_policy(env)
+    assert len(policy.rules) == 4


### PR DESCRIPTION
## Summary

- Move the `NetworkPolicy` construction out of `_apply_network_policy` into a pure `build_network_policy(env)` in a new `session_service/network_policy.py`. The Sprite `update_network_policy` call stays in `_apply_network_policy`; only the policy object is built by the new module.
- Add `tests/test_network_policy.py` — 20 sync, ORM-free mutation-killing tests covering the `env=None` / non-`limited` skip paths, allow-rule preservation in input order, the trailing `*`/deny invariant, and the empty/missing `networking_config` collapses.
- Wire `network_policy.py` and `test_network_policy.py` into `[tool.mutmut]`.

Step 3 of 7 in the session-service quality pass. Closes #213.

## Test plan

- [x] `make lint` — clean
- [x] `make fmt-check` — clean
- [x] `make typecheck` — clean
- [x] `make test` — 948 passed
- [x] `make mutation-test` — 760/769 killed, 9 documented known-equivalents (all pre-existing); network_policy mutants 100% killed

🤖 Generated with [Claude Code](https://claude.com/claude-code)