### PR TITLE
Extract compute_final_status + mutation tests (#214)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ paths_to_mutate = [
     "src/agent_on_demand/session_service/provision_script.py",
     "src/agent_on_demand/session_service/turn_argv.py",
     "src/agent_on_demand/session_service/env_file.py",
+    "src/agent_on_demand/session_service/turn_outcome.py",
 ]
 tests_dir = [
     "tests/test_auth.py",
@@ -181,6 +182,7 @@ tests_dir = [
     "tests/test_provision_script.py",
     "tests/test_turn_argv.py",
     "tests/test_env_file.py",
+    "tests/test_turn_outcome.py",
 ]
 # mutmut copies its working tree to ./mutants/ and runs pytest from there;
 # without these, the rest of the src/ tree isn't available to the test runner.

--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -56,6 +56,7 @@ from .provisioning import (
 )
 from .spec_factory import build_spec_for_session
 from .turn_argv import build_turn_argv
+from .turn_outcome import compute_final_status
 
 logger = logging.getLogger(__name__)
 
@@ -464,17 +465,7 @@ def _execute_turn_body(session, turn, spec, sprite, prompt, mode, timeout, span)
                 },
             )
 
-    if result_holder:
-        kind, value = result_holder[0]
-        if kind == "exit":
-            final_status = "completed" if value == 0 else "failed"
-            exit_code = value
-        else:
-            final_status = "failed"
-            exit_code = None
-    else:
-        final_status = "failed"
-        exit_code = None
+    final_status, exit_code = compute_final_status(result_holder)
 
     ended = timezone.now()
     try:

--- a/src/agent_on_demand/session_service/turn_outcome.py
+++ b/src/agent_on_demand/session_service/turn_outcome.py
@@ -27,9 +27,12 @@ def compute_final_status(
     if not result_holder:
         return "failed", None
     kind, value = result_holder[0]
-    if kind == "exit" and value == 0:
+    if kind != "exit" or not isinstance(value, int):
+        # Non-"exit" kind covers the documented `("error", str)` shape;
+        # the isinstance check defends against a malformed tuple where
+        # the inner thread populated `value` with the wrong type. We
+        # can't `assert` here because asserts are stripped under -O.
+        return "failed", None
+    if value == 0:
         return "completed", 0
-    if kind == "exit":
-        assert isinstance(value, int)
-        return "failed", value
-    return "failed", None
+    return "failed", value

--- a/src/agent_on_demand/session_service/turn_outcome.py
+++ b/src/agent_on_demand/session_service/turn_outcome.py
@@ -1,0 +1,35 @@
+"""Resolve the inner worker thread's result tuple into a final session status.
+
+Extracted from `_execute_turn_body` so the success/failure branching gets
+direct, sync-only coverage under mutmut. The "completed" branch must be
+guarded by `kind == "exit" AND value == 0` — any drift here either marks
+real failures as success or vice versa, and integration tests don't fan
+out across enough exit codes to catch every mutant.
+"""
+
+from __future__ import annotations
+
+
+def compute_final_status(
+    result_holder: list[tuple[str, int | str]],
+) -> tuple[str, int | None]:
+    """Resolve the worker thread's result tuple into (status, exit_code).
+
+    `result_holder` carries at most one entry, set by the inner
+    `_run_command` thread:
+      - ``("exit", N)``: process exited with code N. status="completed"
+        iff N == 0; otherwise "failed". exit_code is N.
+      - ``("error", str)``: thread raised before recording an exit.
+        status="failed", exit_code=None.
+      - ``[]``: thread crashed before populating; treat as failure with
+        no exit code.
+    """
+    if not result_holder:
+        return "failed", None
+    kind, value = result_holder[0]
+    if kind == "exit" and value == 0:
+        return "completed", 0
+    if kind == "exit":
+        assert isinstance(value, int)
+        return "failed", value
+    return "failed", None

--- a/tests/test_turn_outcome.py
+++ b/tests/test_turn_outcome.py
@@ -1,0 +1,48 @@
+"""Direct unit tests for `compute_final_status`.
+
+Mutation-tested. Each test pins one mutation-killable property of the
+worker-thread result resolution:
+
+  - `("exit", 0)` is the *only* path to ``"completed"`` — both the
+    ``kind == "exit"`` and ``value == 0`` halves of the guard matter.
+  - Non-zero exit codes (positive, negative-signal-style, OOM-style)
+    must all map to ``"failed"`` while preserving the integer code.
+  - Thread-error tuples (``("error", ...)``) drop the message and
+    surface as ``("failed", None)``.
+  - An empty holder (thread crashed before populating) is treated
+    identically to ``("error", ...)``.
+
+Tests are sync, no Django imports — required so hammett (mutmut's
+runner) can execute them.
+"""
+
+from agent_on_demand.session_service.turn_outcome import compute_final_status
+
+
+def test_clean_exit_is_completed():
+    assert compute_final_status([("exit", 0)]) == ("completed", 0)
+
+
+def test_nonzero_exit_is_failed():
+    assert compute_final_status([("exit", 1)]) == ("failed", 1)
+
+
+def test_negative_exit_code_is_failed():
+    # Signal-style negative exit codes must not be confused with success.
+    # Pins the `value == 0` half of the completed-guard against `!= 0`
+    # and `or`-style mutants.
+    assert compute_final_status([("exit", -15)]) == ("failed", -15)
+
+
+def test_oom_style_exit_is_failed():
+    assert compute_final_status([("exit", 137)]) == ("failed", 137)
+
+
+def test_error_tuple_is_failed_with_no_exit_code():
+    # Pins the `kind == "exit"` half of the completed-guard — a "drop
+    # the kind check" mutant would let this return ("completed", ...).
+    assert compute_final_status([("error", "boom")]) == ("failed", None)
+
+
+def test_empty_holder_is_failed_with_no_exit_code():
+    assert compute_final_status([]) == ("failed", None)

--- a/tests/test_turn_outcome.py
+++ b/tests/test_turn_outcome.py
@@ -46,3 +46,12 @@ def test_error_tuple_is_failed_with_no_exit_code():
 
 def test_empty_holder_is_failed_with_no_exit_code():
     assert compute_final_status([]) == ("failed", None)
+
+
+def test_malformed_exit_tuple_with_string_value_is_failed_with_no_exit_code():
+    # If the inner thread ever populated ``("exit", <non-int>)`` (a
+    # programming error), the non-int must not flow through to the
+    # IntegerField on the session/turn row. Pins the runtime
+    # isinstance guard, which is what defends the contract under
+    # ``python -O`` (where ``assert`` would be stripped).
+    assert compute_final_status([("exit", "not-an-int")]) == ("failed", None)


### PR DESCRIPTION
## Summary

- Closes #214. Extracts the 11-line `if result_holder` block out of `_execute_turn_body` into a pure `compute_final_status` helper at `src/agent_on_demand/session_service/turn_outcome.py`, then wires it back into `tasks.py` as a single call.
- Adds `tests/test_turn_outcome.py` (sync, no-Django, hammett-runnable) and registers both files with mutmut. Tests cover `("exit", 0)` → `("completed", 0)`; `("exit", 1)`, `("exit", -15)`, `("exit", 137)` → `("failed", N)`; `("error", "boom")` and `[]` → `("failed", None)`. Negative-exit-code and error-tuple cases pin both halves of the `kind == "exit" and value == 0` guard.

Part of the session-service quality pass (step 4 of 7 — independent of the others).

## Test plan

- [x] `make lint`
- [x] `make fmt-check`
- [x] `make test` — 934 passed, including all 25 in `tests/test_tasks.py` (existing turn-finalization paths unchanged)
- [x] `make mutation-test` — 752/761 killed; all 9 survivors are pre-existing entries on the `KNOWN_EQUIVALENT` allowlist (none from `turn_outcome.py`)
- [x] `make typecheck` — no new errors (4 pre-existing `posthog.capture` errors in `tasks.py` are present on `main` too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)