### PR TITLE
Introduce Backend Protocol + SpritesBackend adapter

### DIFF
--- a/src/agent_on_demand/session_service/backend.py
+++ b/src/agent_on_demand/session_service/backend.py
@@ -18,7 +18,7 @@ in `thoughts/plans/2026-04-27-session-backend-extraction.md`:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import BinaryIO, Protocol
 
 
@@ -59,7 +59,7 @@ class PolicyRule:
 
 @dataclass(frozen=True)
 class NetworkPolicy:
-    rules: list[PolicyRule] = field(default_factory=list)
+    rules: tuple[PolicyRule, ...] = ()
 
 
 class WorkspaceFS(Protocol):

--- a/src/agent_on_demand/session_service/backend.py
+++ b/src/agent_on_demand/session_service/backend.py
@@ -1,0 +1,113 @@
+"""Backend Protocol for session execution hosts.
+
+Sprites is one implementation; future hosts (e.g. Modal sandboxes) will
+plug in by implementing this Protocol. All `session_service/` callers go
+through these types — direct `from sprites import` is confined to
+`sprites_backend.py`.
+
+The shape was designed in
+`thoughts/research/2026-04-18-session-backend-abstraction.md` and refined
+in `thoughts/plans/2026-04-27-session-backend-extraction.md`:
+
+- `Command.run()` returns the exit code directly. Non-zero exits are NOT
+  raised — `ExecutionError` is reserved for transport-layer failures
+  where the command never produced an exit code.
+- `WorkspaceFS.chmod` is a filesystem operation, not a `chmod` shell-out.
+- `set_executable` is omitted from the Protocol; callers use `chmod`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import BinaryIO, Protocol
+
+
+class BackendError(Exception):
+    """Base for all backend-layer failures."""
+
+
+class SessionNotFoundError(BackendError):
+    """The backend has no session with the requested name."""
+
+
+class ExecutionError(BackendError):
+    """A command could not be executed at all (transport failure).
+
+    Non-zero exits are NOT raised — they're returned as the int from
+    `Command.run()`. This exception covers the case where the SDK could
+    not start, monitor, or report the command's exit status.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        exit_code: int = -1,
+        stdout: bytes = b"",
+        stderr: bytes = b"",
+    ):
+        super().__init__(message)
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+@dataclass(frozen=True)
+class PolicyRule:
+    domain: str
+    action: str  # "allow" | "deny"
+
+
+@dataclass(frozen=True)
+class NetworkPolicy:
+    rules: list[PolicyRule] = field(default_factory=list)
+
+
+class WorkspaceFS(Protocol):
+    """Per-handle filesystem operations."""
+
+    def write_text(self, path: str, content: str) -> None: ...
+    def chmod(self, path: str, mode: int) -> None: ...
+
+
+class Command(Protocol):
+    """A command staged for execution on a session handle.
+
+    Configuration via `set_input` / `set_output` happens between
+    construction and `run()`. `run()` blocks until the command exits and
+    returns the exit code; it does NOT raise on non-zero exits.
+    """
+
+    def set_input(self, data: bytes) -> None: ...
+    def set_output(self, stdout: BinaryIO, stderr: BinaryIO) -> None: ...
+    def run(self) -> int: ...
+
+
+class SessionHandle(Protocol):
+    """A live session on the backend."""
+
+    @property
+    def name(self) -> str: ...
+    def workspace(self) -> WorkspaceFS: ...
+    def make_command(
+        self,
+        *args: str,
+        cwd: str | None = None,
+        timeout: float | None = None,
+    ) -> Command: ...
+    def apply_network_policy(self, policy: NetworkPolicy) -> None: ...
+
+
+class BackendClient(Protocol):
+    """An auth-scoped client for one user's sessions on the backend."""
+
+    def provision(self, name: str) -> SessionHandle: ...
+    def get(self, name: str) -> SessionHandle: ...
+    def destroy(self, name: str) -> None: ...
+    def close(self) -> None: ...
+
+
+class Backend(Protocol):
+    """A backend implementation. Stateless — `create_client` returns
+    per-user clients."""
+
+    def create_client(self, token: str) -> BackendClient: ...

--- a/src/agent_on_demand/session_service/sprites_backend.py
+++ b/src/agent_on_demand/session_service/sprites_backend.py
@@ -1,0 +1,174 @@
+"""Sprites adapter for the Backend Protocol.
+
+This is the only module that imports `sprites` directly. It wraps
+`SpritesClient` / `Sprite` / `SpriteFilesystem` / `Cmd` to the
+backend-neutral Protocol in `backend.py` and translates exceptions:
+
+- `sprites.NotFoundError` → `SessionNotFoundError`
+- other `sprites.SpriteError` → `BackendError`
+- `sprites.ExecError` from `cmd.run()` → exit-code int (NOT raised)
+- transport failures (anything else) → `BackendError`
+
+The websocket close-timeout monkeypatch lives in `__init__` and is
+idempotent — repeated `SpritesBackend()` instantiations don't re-patch.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any, BinaryIO
+
+import sprites
+from django.conf import settings
+
+from .backend import (
+    BackendClient,
+    BackendError,
+    Command,
+    NetworkPolicy,
+    SessionHandle,
+    SessionNotFoundError,
+    WorkspaceFS,
+)
+
+
+_PATCH_MARKER = "_aod_close_timeout_patched"
+
+
+def _apply_websocket_patch() -> None:
+    """Lower sprites-py's websocket close_timeout to 0.5s.
+
+    The default 10s makes every `cmd.run()` block for the full timeout
+    on shutdown. Patching `websockets.connect` to default `close_timeout`
+    yields a ~22x speedup. Idempotent — flagged on the module so repeated
+    `SpritesBackend()` instantiations don't re-wrap.
+    """
+    import sprites.websocket as _ws
+
+    if getattr(_ws.websockets, _PATCH_MARKER, False):
+        return
+    _orig_connect = _ws.websockets.connect
+
+    def _patched_connect(*args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("close_timeout", 0.5)
+        return _orig_connect(*args, **kwargs)
+
+    _ws.websockets.connect = _patched_connect  # type: ignore[misc,assignment]
+    setattr(_ws.websockets, _PATCH_MARKER, True)
+
+
+class _SpritesWorkspaceFS:
+    def __init__(self, fs: sprites.SpriteFilesystem):
+        self._fs = fs
+
+    def write_text(self, path: str, content: str) -> None:
+        try:
+            (self._fs / path.lstrip("/")).write_text(content)
+        except sprites.SpriteError as e:
+            raise BackendError(str(e)) from e
+
+    def chmod(self, path: str, mode: int) -> None:
+        try:
+            (self._fs / path.lstrip("/")).chmod(mode)
+        except sprites.SpriteError as e:
+            raise BackendError(str(e)) from e
+
+
+class _SpritesCommand:
+    def __init__(self, cmd: Any):
+        self._cmd = cmd
+
+    def set_input(self, data: bytes) -> None:
+        self._cmd.stdin = io.BytesIO(data)
+
+    def set_output(self, stdout: BinaryIO, stderr: BinaryIO) -> None:
+        self._cmd.stdout = stdout
+        self._cmd.stderr = stderr
+
+    def run(self) -> int:
+        try:
+            self._cmd.run()
+        except sprites.ExecError as e:
+            return e.exit_code()
+        except sprites.SpriteError as e:
+            raise BackendError(str(e)) from e
+        return 0
+
+
+class _SpritesHandle:
+    def __init__(self, sprite: sprites.Sprite):
+        self._sprite = sprite
+
+    @property
+    def name(self) -> str:
+        return self._sprite.name
+
+    def workspace(self) -> WorkspaceFS:
+        return _SpritesWorkspaceFS(self._sprite.filesystem())
+
+    def make_command(
+        self,
+        *args: str,
+        cwd: str | None = None,
+        timeout: float | None = None,
+    ) -> Command:
+        return _SpritesCommand(self._sprite.command(*args, cwd=cwd, timeout=timeout))
+
+    def apply_network_policy(self, policy: NetworkPolicy) -> None:
+        translated = sprites.NetworkPolicy(
+            rules=[sprites.PolicyRule(domain=r.domain, action=r.action) for r in policy.rules]
+        )
+        try:
+            self._sprite.update_network_policy(translated)
+        except sprites.NotFoundError as e:
+            raise SessionNotFoundError(str(e)) from e
+        except sprites.SpriteError as e:
+            raise BackendError(str(e)) from e
+
+
+class _SpritesBackendClient:
+    def __init__(self, client: sprites.SpritesClient):
+        self._client = client
+
+    def provision(self, name: str) -> SessionHandle:
+        try:
+            return _SpritesHandle(self._client.create_sprite(name))
+        except sprites.NotFoundError as e:
+            raise SessionNotFoundError(str(e)) from e
+        except sprites.SpriteError as e:
+            raise BackendError(str(e)) from e
+
+    def get(self, name: str) -> SessionHandle:
+        try:
+            return _SpritesHandle(self._client.get_sprite(name))
+        except sprites.NotFoundError as e:
+            raise SessionNotFoundError(str(e)) from e
+        except sprites.SpriteError as e:
+            raise BackendError(str(e)) from e
+
+    def destroy(self, name: str) -> None:
+        try:
+            self._client.delete_sprite(name)
+        except sprites.NotFoundError as e:
+            raise SessionNotFoundError(str(e)) from e
+        except sprites.SpriteError as e:
+            raise BackendError(str(e)) from e
+
+    def close(self) -> None:
+        self._client.close()
+
+
+class SpritesBackend:
+    """`Backend` implementation for sprites.dev.
+
+    Constructing the backend applies the websocket close-timeout patch.
+    Patch is idempotent — multiple instances do not re-wrap.
+    """
+
+    def __init__(self) -> None:
+        _apply_websocket_patch()
+
+    def create_client(self, token: str) -> BackendClient:
+        return _SpritesBackendClient(
+            sprites.SpritesClient(token=token, base_url=settings.SPRITES_BASE_URL)
+        )

--- a/src/agent_on_demand/session_service/sprites_backend.py
+++ b/src/agent_on_demand/session_service/sprites_backend.py
@@ -116,7 +116,7 @@ class _SpritesHandle:
 
     def apply_network_policy(self, policy: NetworkPolicy) -> None:
         translated = sprites.NetworkPolicy(
-            rules=[sprites.PolicyRule(domain=r.domain, action=r.action) for r in policy.rules]
+            rules=[sprites.PolicyRule(domain=r.domain, action=r.action) for r in policy.rules],
         )
         try:
             self._sprite.update_network_policy(translated)
@@ -131,10 +131,13 @@ class _SpritesBackendClient:
         self._client = client
 
     def provision(self, name: str) -> SessionHandle:
+        # NotFoundError from create_sprite means a referenced pool/template
+        # is missing — the session itself doesn't exist yet, so we don't
+        # surface SessionNotFoundError here. Callers see this as a generic
+        # BackendError, which is what they are already prepared to handle
+        # for any other create failure.
         try:
             return _SpritesHandle(self._client.create_sprite(name))
-        except sprites.NotFoundError as e:
-            raise SessionNotFoundError(str(e)) from e
         except sprites.SpriteError as e:
             raise BackendError(str(e)) from e
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,42 +10,6 @@ def client():
 
 
 @pytest.fixture
-def fake_backend(mocker):
-    """Swap session_service.get_client to return a recording BackendClient.
-
-    Parallel to `fake_sprites` for tests that consume the Backend Protocol
-    directly. The provision/destroy task `.defer` patching mirrors
-    `fake_sprites` so HTTP-layer tests still observe the recorded calls.
-    """
-    # Imported here (not at module top) because the agent_on_demand package
-    # touches Django models at import time, and pytest-django hasn't
-    # configured settings until fixtures run.
-    from tests.fakes.backend import RecordingBackendClient
-
-    fake = RecordingBackendClient()
-    mocker.patch("agent_on_demand.session_service.client.get_client", return_value=fake)
-    mocker.patch("agent_on_demand.session_service.get_client", return_value=fake)
-
-    mocker.patch("agent_on_demand.session_service.tasks.execute_turn.defer")
-    mocker.patch("agent_on_demand.session_service.turn.execute_turn.defer")
-
-    from agent_on_demand.session_service.tasks import (
-        destroy_session_task,
-        provision_session_task,
-    )
-
-    def _inline_provision(**kwargs):
-        provision_session_task(**kwargs)
-
-    def _inline_destroy(**kwargs):
-        destroy_session_task(**kwargs)
-
-    mocker.patch.object(provision_session_task, "defer", side_effect=_inline_provision)
-    mocker.patch.object(destroy_session_task, "defer", side_effect=_inline_destroy)
-    return fake
-
-
-@pytest.fixture
 def fake_sprites(mocker):
     """Swap the real SpritesClient for a recording fake, run the provision
     task inline, and stub the per-turn task enqueue.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,42 @@ def client():
 
 
 @pytest.fixture
+def fake_backend(mocker):
+    """Swap session_service.get_client to return a recording BackendClient.
+
+    Parallel to `fake_sprites` for tests that consume the Backend Protocol
+    directly. The provision/destroy task `.defer` patching mirrors
+    `fake_sprites` so HTTP-layer tests still observe the recorded calls.
+    """
+    # Imported here (not at module top) because the agent_on_demand package
+    # touches Django models at import time, and pytest-django hasn't
+    # configured settings until fixtures run.
+    from tests.fakes.backend import RecordingBackendClient
+
+    fake = RecordingBackendClient()
+    mocker.patch("agent_on_demand.session_service.client.get_client", return_value=fake)
+    mocker.patch("agent_on_demand.session_service.get_client", return_value=fake)
+
+    mocker.patch("agent_on_demand.session_service.tasks.execute_turn.defer")
+    mocker.patch("agent_on_demand.session_service.turn.execute_turn.defer")
+
+    from agent_on_demand.session_service.tasks import (
+        destroy_session_task,
+        provision_session_task,
+    )
+
+    def _inline_provision(**kwargs):
+        provision_session_task(**kwargs)
+
+    def _inline_destroy(**kwargs):
+        destroy_session_task(**kwargs)
+
+    mocker.patch.object(provision_session_task, "defer", side_effect=_inline_provision)
+    mocker.patch.object(destroy_session_task, "defer", side_effect=_inline_destroy)
+    return fake
+
+
+@pytest.fixture
 def fake_sprites(mocker):
     """Swap the real SpritesClient for a recording fake, run the provision
     task inline, and stub the per-turn task enqueue.

--- a/tests/fakes/backend.py
+++ b/tests/fakes/backend.py
@@ -1,0 +1,232 @@
+"""Recording fakes for the Backend Protocol, for use in unit tests.
+
+Mirrors the recording style of `tests/fakes/sprite.py` but conforms to
+the Protocol in `agent_on_demand.session_service.backend`. Tests assert
+on `.writes`, `.commands`, and `.network_policies` lists.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, BinaryIO, Callable
+
+from agent_on_demand.session_service.backend import (
+    BackendClient,
+    BackendError,
+    Command,
+    NetworkPolicy,
+    SessionHandle,
+    SessionNotFoundError,
+    WorkspaceFS,
+)
+
+
+@dataclass
+class RecordedWrite:
+    path: str
+    content: str
+
+
+@dataclass
+class RecordedChmod:
+    path: str
+    mode: int
+
+
+@dataclass
+class RecordedCommand:
+    argv: tuple[str, ...]
+    cwd: str | None = None
+    timeout: float | None = None
+    ran: bool = False
+    exit_code: int = 0
+    stdin: bytes | None = None
+
+
+class RecordingFS:
+    def __init__(self) -> None:
+        self.writes: list[RecordedWrite] = []
+        self.chmods: list[RecordedChmod] = []
+        self._write_raise_predicates: list[tuple[Any, Exception]] = []
+
+    def write_text(self, path: str, content: str) -> None:
+        normalized = "/" + path.lstrip("/")
+        for i, (pred, exc) in enumerate(self._write_raise_predicates):
+            matched = pred(normalized) if callable(pred) else pred in normalized
+            if matched:
+                del self._write_raise_predicates[i]
+                raise exc
+        self.writes.append(RecordedWrite(path=normalized, content=content))
+
+    def chmod(self, path: str, mode: int) -> None:
+        self.chmods.append(RecordedChmod(path="/" + path.lstrip("/"), mode=mode))
+
+    def raise_on_write(self, predicate: Any, exc: Exception) -> None:
+        """Arrange the next matching write_text to raise. Predicate may be
+        a callable taking the normalized path or a substring."""
+        self._write_raise_predicates.append((predicate, exc))
+
+
+class RecordingCommand:
+    def __init__(self, handle: "RecordingHandle", argv: tuple[str, ...],
+                 cwd: str | None, timeout: float | None) -> None:
+        self._handle = handle
+        self._record = RecordedCommand(argv=argv, cwd=cwd, timeout=timeout)
+        self._stdout: BinaryIO | None = None
+        self._stderr: BinaryIO | None = None
+        handle.commands.append(self._record)
+
+    def set_input(self, data: bytes) -> None:
+        self._record.stdin = data
+
+    def set_output(self, stdout: BinaryIO, stderr: BinaryIO) -> None:
+        self._stdout = stdout
+        self._stderr = stderr
+
+    def run(self) -> int:
+        self._record.ran = True
+        for i, (pred, action) in enumerate(self._handle._command_actions):
+            matched = pred(self._record.argv) if callable(pred) else (
+                bool(self._record.argv) and self._record.argv[0] == pred
+            )
+            if matched:
+                del self._handle._command_actions[i]
+                exit_code, stderr_bytes, exc = action
+                if stderr_bytes and self._stderr is not None:
+                    self._stderr.write(stderr_bytes)
+                if exc is not None:
+                    raise exc
+                self._record.exit_code = exit_code
+                return exit_code
+        return 0
+
+
+class RecordingHandle:
+    def __init__(self, name: str) -> None:
+        self._name = name
+        self._fs = RecordingFS()
+        self.commands: list[RecordedCommand] = []
+        self.network_policies: list[NetworkPolicy] = []
+        self._command_actions: list[
+            tuple[Any, tuple[int, bytes, Exception | None]]
+        ] = []
+        self._policy_raise: Exception | None = None
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def workspace(self) -> WorkspaceFS:
+        return self._fs
+
+    def make_command(
+        self,
+        *args: str,
+        cwd: str | None = None,
+        timeout: float | None = None,
+    ) -> Command:
+        return RecordingCommand(self, tuple(args), cwd, timeout)
+
+    def apply_network_policy(self, policy: NetworkPolicy) -> None:
+        if self._policy_raise is not None:
+            exc = self._policy_raise
+            self._policy_raise = None
+            raise exc
+        self.network_policies.append(policy)
+
+    @property
+    def writes(self) -> list[RecordedWrite]:
+        return self._fs.writes
+
+    @property
+    def chmods(self) -> list[RecordedChmod]:
+        return self._fs.chmods
+
+    def raise_on_write(self, predicate: Any, exc: Exception) -> None:
+        self._fs.raise_on_write(predicate, exc)
+
+    def set_command_outcome(
+        self,
+        predicate: Callable[[tuple[str, ...]], bool] | str,
+        *,
+        exit_code: int = 0,
+        stderr: bytes = b"",
+        exc: Exception | None = None,
+    ) -> None:
+        """Arrange the next matching command to exit with `exit_code`,
+        write `stderr` to the assigned buffer, or raise `exc`."""
+        self._command_actions.append((predicate, (exit_code, stderr, exc)))
+
+    def raise_on_apply_network_policy(self, exc: Exception) -> None:
+        self._policy_raise = exc
+
+
+class RecordingBackendClient:
+    def __init__(self) -> None:
+        self.handles: dict[str, RecordingHandle] = {}
+        self.created: list[str] = []
+        self.deleted: list[str] = []
+        self.closed = False
+        self._provision_error: Exception | None = None
+        self._get_missing: set[str] = set()
+
+    def provision(self, name: str) -> SessionHandle:
+        self.created.append(name)
+        if self._provision_error is not None:
+            err = self._provision_error
+            self._provision_error = None
+            raise err
+        handle = RecordingHandle(name)
+        self.handles[name] = handle
+        return handle
+
+    def get(self, name: str) -> SessionHandle:
+        if name in self._get_missing:
+            raise SessionNotFoundError(f"sprite {name} not found")
+        if name not in self.handles:
+            self.handles[name] = RecordingHandle(name)
+        return self.handles[name]
+
+    def destroy(self, name: str) -> None:
+        self.deleted.append(name)
+
+    def close(self) -> None:
+        self.closed = True
+
+    def raise_on_provision(self, exc: Exception) -> None:
+        self._provision_error = exc
+
+    def mark_missing(self, name: str) -> None:
+        self._get_missing.add(name)
+
+    def last_handle(self) -> RecordingHandle:
+        return self.handles[self.created[-1]]
+
+
+class FakeBackend:
+    """Recording `Backend` impl. `create_client` returns a fresh
+    `RecordingBackendClient` per call unless one was preset."""
+
+    def __init__(self, client: RecordingBackendClient | None = None) -> None:
+        self._client = client
+
+    def create_client(self, token: str) -> BackendClient:
+        if self._client is not None:
+            return self._client
+        return RecordingBackendClient()
+
+
+__all__ = [
+    "FakeBackend",
+    "RecordingBackendClient",
+    "RecordingCommand",
+    "RecordingFS",
+    "RecordingHandle",
+    "RecordedChmod",
+    "RecordedCommand",
+    "RecordedWrite",
+]
+
+
+# Re-export errors for convenience in tests
+_ = (BackendError, SessionNotFoundError)

--- a/tests/fakes/backend.py
+++ b/tests/fakes/backend.py
@@ -12,7 +12,6 @@ from typing import Any, BinaryIO, Callable
 
 from agent_on_demand.session_service.backend import (
     BackendClient,
-    BackendError,
     Command,
     NetworkPolicy,
     SessionHandle,
@@ -62,14 +61,23 @@ class RecordingFS:
         self.chmods.append(RecordedChmod(path="/" + path.lstrip("/"), mode=mode))
 
     def raise_on_write(self, predicate: Any, exc: Exception) -> None:
-        """Arrange the next matching write_text to raise. Predicate may be
-        a callable taking the normalized path or a substring."""
+        """Arrange the next matching write_text to raise.
+
+        ``predicate`` is matched against the normalized absolute path. A
+        callable is invoked with that path and must return truthy; any
+        other value is treated as a **substring** check (``predicate in
+        path``). Single-shot — the predicate is removed after firing."""
         self._write_raise_predicates.append((predicate, exc))
 
 
 class RecordingCommand:
-    def __init__(self, handle: "RecordingHandle", argv: tuple[str, ...],
-                 cwd: str | None, timeout: float | None) -> None:
+    def __init__(
+        self,
+        handle: "RecordingHandle",
+        argv: tuple[str, ...],
+        cwd: str | None,
+        timeout: float | None,
+    ) -> None:
         self._handle = handle
         self._record = RecordedCommand(argv=argv, cwd=cwd, timeout=timeout)
         self._stdout: BinaryIO | None = None
@@ -86,8 +94,10 @@ class RecordingCommand:
     def run(self) -> int:
         self._record.ran = True
         for i, (pred, action) in enumerate(self._handle._command_actions):
-            matched = pred(self._record.argv) if callable(pred) else (
-                bool(self._record.argv) and self._record.argv[0] == pred
+            matched = (
+                pred(self._record.argv)
+                if callable(pred)
+                else (bool(self._record.argv) and self._record.argv[0] == pred)
             )
             if matched:
                 del self._handle._command_actions[i]
@@ -107,9 +117,7 @@ class RecordingHandle:
         self._fs = RecordingFS()
         self.commands: list[RecordedCommand] = []
         self.network_policies: list[NetworkPolicy] = []
-        self._command_actions: list[
-            tuple[Any, tuple[int, bytes, Exception | None]]
-        ] = []
+        self._command_actions: list[tuple[Any, tuple[int, bytes, Exception | None]]] = []
         self._policy_raise: Exception | None = None
 
     @property
@@ -153,8 +161,15 @@ class RecordingHandle:
         stderr: bytes = b"",
         exc: Exception | None = None,
     ) -> None:
-        """Arrange the next matching command to exit with `exit_code`,
-        write `stderr` to the assigned buffer, or raise `exc`."""
+        """Arrange the next matching command to exit with ``exit_code``,
+        write ``stderr`` to the assigned buffer, or raise ``exc``.
+
+        ``predicate`` is matched against the recorded argv tuple. A
+        callable is invoked with the full argv and must return truthy;
+        a string is treated as an **exact match against argv[0]** (not a
+        substring of the full argv). Single-shot. This deliberately
+        differs from :meth:`raise_on_write` — write paths are matched by
+        substring while command argv is matched by program name."""
         self._command_actions.append((predicate, (exit_code, stderr, exc)))
 
     def raise_on_apply_network_policy(self, exc: Exception) -> None:
@@ -226,7 +241,3 @@ __all__ = [
     "RecordedCommand",
     "RecordedWrite",
 ]
-
-
-# Re-export errors for convenience in tests
-_ = (BackendError, SessionNotFoundError)

--- a/tests/test_backend_protocol.py
+++ b/tests/test_backend_protocol.py
@@ -39,12 +39,16 @@ def _fake_sprite(name: str = "test"):
 # ---------- _SpritesBackendClient ----------
 
 
-def test_provision_translates_not_found_error():
+def test_provision_does_not_translate_not_found_to_session_not_found():
+    """NotFoundError from create_sprite means a referenced pool/template
+    is missing, not the session — so it surfaces as a generic
+    BackendError, NOT SessionNotFoundError."""
     client_mock = _fake_sprites_client()
-    client_mock.create_sprite.side_effect = sprites.NotFoundError("missing")
+    client_mock.create_sprite.side_effect = sprites.NotFoundError("pool missing")
     bc = _SpritesBackendClient(client_mock)
-    with pytest.raises(SessionNotFoundError):
+    with pytest.raises(BackendError) as exc:
         bc.provision("name")
+    assert not isinstance(exc.value, SessionNotFoundError)
 
 
 def test_provision_translates_other_sprite_errors_to_backend_error():
@@ -178,9 +182,7 @@ def test_make_command_passes_args_cwd_timeout():
     handle = _SpritesHandle(sprite)
     cmd = handle.make_command("bash", "-lc", "true", cwd="/home/sprite", timeout=30.0)
 
-    sprite.command.assert_called_once_with(
-        "bash", "-lc", "true", cwd="/home/sprite", timeout=30.0
-    )
+    sprite.command.assert_called_once_with("bash", "-lc", "true", cwd="/home/sprite", timeout=30.0)
     assert isinstance(cmd, _SpritesCommand)
 
 
@@ -190,10 +192,10 @@ def test_make_command_passes_args_cwd_timeout():
 def test_apply_network_policy_translates_to_sprites_types():
     sprite = _fake_sprite()
     policy = NetworkPolicy(
-        rules=[
+        rules=(
             PolicyRule(domain="github.com", action="allow"),
             PolicyRule(domain="*", action="deny"),
-        ]
+        )
     )
     _SpritesHandle(sprite).apply_network_policy(policy)
 
@@ -211,14 +213,14 @@ def test_apply_network_policy_translates_not_found_error():
     sprite = _fake_sprite()
     sprite.update_network_policy.side_effect = sprites.NotFoundError("missing")
     with pytest.raises(SessionNotFoundError):
-        _SpritesHandle(sprite).apply_network_policy(NetworkPolicy(rules=[]))
+        _SpritesHandle(sprite).apply_network_policy(NetworkPolicy())
 
 
 def test_apply_network_policy_translates_other_sprite_errors():
     sprite = _fake_sprite()
     sprite.update_network_policy.side_effect = sprites.SpriteError("boom")
     with pytest.raises(BackendError):
-        _SpritesHandle(sprite).apply_network_policy(NetworkPolicy(rules=[]))
+        _SpritesHandle(sprite).apply_network_policy(NetworkPolicy())
 
 
 # ---------- SpritesBackend ----------

--- a/tests/test_backend_protocol.py
+++ b/tests/test_backend_protocol.py
@@ -1,0 +1,252 @@
+"""Tests for the SpritesBackend adapter — exception translation, command
+exit-code semantics, filesystem op forwarding, and network-policy translation."""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock
+
+import pytest
+import sprites
+
+from agent_on_demand.session_service.backend import (
+    BackendError,
+    NetworkPolicy,
+    PolicyRule,
+    SessionNotFoundError,
+)
+from agent_on_demand.session_service.sprites_backend import (
+    SpritesBackend,
+    _SpritesBackendClient,
+    _SpritesCommand,
+    _SpritesHandle,
+)
+
+
+def _fake_sprites_client():
+    """A MagicMock standing in for sprites.SpritesClient. Tests configure
+    `.create_sprite`, `.get_sprite`, `.delete_sprite`, `.close` directly."""
+    return MagicMock(spec=sprites.SpritesClient)
+
+
+def _fake_sprite(name: str = "test"):
+    """A MagicMock standing in for sprites.Sprite."""
+    sprite = MagicMock(spec=sprites.Sprite)
+    sprite.name = name
+    return sprite
+
+
+# ---------- _SpritesBackendClient ----------
+
+
+def test_provision_translates_not_found_error():
+    client_mock = _fake_sprites_client()
+    client_mock.create_sprite.side_effect = sprites.NotFoundError("missing")
+    bc = _SpritesBackendClient(client_mock)
+    with pytest.raises(SessionNotFoundError):
+        bc.provision("name")
+
+
+def test_provision_translates_other_sprite_errors_to_backend_error():
+    client_mock = _fake_sprites_client()
+    client_mock.create_sprite.side_effect = sprites.SpriteError("boom")
+    bc = _SpritesBackendClient(client_mock)
+    with pytest.raises(BackendError) as exc:
+        bc.provision("name")
+    # Not a SessionNotFoundError specifically.
+    assert not isinstance(exc.value, SessionNotFoundError)
+
+
+def test_provision_returns_handle_with_name():
+    sprite = _fake_sprite("abc")
+    client_mock = _fake_sprites_client()
+    client_mock.create_sprite.return_value = sprite
+    handle = _SpritesBackendClient(client_mock).provision("abc")
+    assert handle.name == "abc"
+
+
+def test_get_translates_not_found_error():
+    client_mock = _fake_sprites_client()
+    client_mock.get_sprite.side_effect = sprites.NotFoundError("missing")
+    bc = _SpritesBackendClient(client_mock)
+    with pytest.raises(SessionNotFoundError):
+        bc.get("name")
+
+
+def test_destroy_translates_other_sprite_errors_to_backend_error():
+    client_mock = _fake_sprites_client()
+    client_mock.delete_sprite.side_effect = sprites.SpriteError("boom")
+    bc = _SpritesBackendClient(client_mock)
+    with pytest.raises(BackendError):
+        bc.destroy("name")
+
+
+def test_close_forwards():
+    client_mock = _fake_sprites_client()
+    _SpritesBackendClient(client_mock).close()
+    client_mock.close.assert_called_once()
+
+
+# ---------- _SpritesCommand ----------
+
+
+def test_command_run_returns_zero_on_clean_exit():
+    cmd_mock = MagicMock()
+    cmd_mock.run.return_value = None
+    assert _SpritesCommand(cmd_mock).run() == 0
+
+
+def test_command_run_returns_exit_code_on_exec_error():
+    cmd_mock = MagicMock()
+    cmd_mock.run.side_effect = sprites.ExecError("nonzero", 137, b"", b"")
+    # ExecError.exit_code() is a method (not a property) in sprites-py;
+    # the adapter must call it.
+    assert _SpritesCommand(cmd_mock).run() == 137
+
+
+def test_command_run_raises_backend_error_on_other_sprite_errors():
+    cmd_mock = MagicMock()
+    cmd_mock.run.side_effect = sprites.SpriteError("transport failure")
+    with pytest.raises(BackendError):
+        _SpritesCommand(cmd_mock).run()
+
+
+def test_command_set_input_assigns_bytesio_to_stdin():
+    cmd_mock = MagicMock()
+    _SpritesCommand(cmd_mock).set_input(b"hello")
+    assert isinstance(cmd_mock.stdin, io.BytesIO)
+    cmd_mock.stdin.seek(0)
+    assert cmd_mock.stdin.read() == b"hello"
+
+
+def test_command_set_output_assigns_writers():
+    cmd_mock = MagicMock()
+    out = io.BytesIO()
+    err = io.BytesIO()
+    _SpritesCommand(cmd_mock).set_output(out, err)
+    assert cmd_mock.stdout is out
+    assert cmd_mock.stderr is err
+
+
+# ---------- _SpritesHandle / WorkspaceFS ----------
+
+
+def test_workspace_write_text_reaches_spritepath():
+    sprite = _fake_sprite()
+    fs_mock = MagicMock()
+    path_mock = MagicMock()
+    sprite.filesystem.return_value = fs_mock
+    fs_mock.__truediv__.return_value = path_mock
+
+    _SpritesHandle(sprite).workspace().write_text("/etc/foo", "body")
+    fs_mock.__truediv__.assert_called_once_with("etc/foo")
+    path_mock.write_text.assert_called_once_with("body")
+
+
+def test_workspace_chmod_reaches_spritepath():
+    sprite = _fake_sprite()
+    fs_mock = MagicMock()
+    path_mock = MagicMock()
+    sprite.filesystem.return_value = fs_mock
+    fs_mock.__truediv__.return_value = path_mock
+
+    _SpritesHandle(sprite).workspace().chmod("/run.sh", 0o755)
+    fs_mock.__truediv__.assert_called_once_with("run.sh")
+    path_mock.chmod.assert_called_once_with(0o755)
+
+
+def test_workspace_write_text_translates_sprite_error():
+    sprite = _fake_sprite()
+    fs_mock = MagicMock()
+    path_mock = MagicMock()
+    sprite.filesystem.return_value = fs_mock
+    fs_mock.__truediv__.return_value = path_mock
+    path_mock.write_text.side_effect = sprites.SpriteError("disk full")
+
+    with pytest.raises(BackendError):
+        _SpritesHandle(sprite).workspace().write_text("/x", "y")
+
+
+# ---------- _SpritesHandle.make_command ----------
+
+
+def test_make_command_passes_args_cwd_timeout():
+    sprite = _fake_sprite()
+    cmd_mock = MagicMock()
+    sprite.command.return_value = cmd_mock
+
+    handle = _SpritesHandle(sprite)
+    cmd = handle.make_command("bash", "-lc", "true", cwd="/home/sprite", timeout=30.0)
+
+    sprite.command.assert_called_once_with(
+        "bash", "-lc", "true", cwd="/home/sprite", timeout=30.0
+    )
+    assert isinstance(cmd, _SpritesCommand)
+
+
+# ---------- _SpritesHandle.apply_network_policy ----------
+
+
+def test_apply_network_policy_translates_to_sprites_types():
+    sprite = _fake_sprite()
+    policy = NetworkPolicy(
+        rules=[
+            PolicyRule(domain="github.com", action="allow"),
+            PolicyRule(domain="*", action="deny"),
+        ]
+    )
+    _SpritesHandle(sprite).apply_network_policy(policy)
+
+    assert sprite.update_network_policy.call_count == 1
+    translated = sprite.update_network_policy.call_args[0][0]
+    assert isinstance(translated, sprites.NetworkPolicy)
+    assert len(translated.rules) == 2
+    assert translated.rules[0].domain == "github.com"
+    assert translated.rules[0].action == "allow"
+    assert translated.rules[1].domain == "*"
+    assert translated.rules[1].action == "deny"
+
+
+def test_apply_network_policy_translates_not_found_error():
+    sprite = _fake_sprite()
+    sprite.update_network_policy.side_effect = sprites.NotFoundError("missing")
+    with pytest.raises(SessionNotFoundError):
+        _SpritesHandle(sprite).apply_network_policy(NetworkPolicy(rules=[]))
+
+
+def test_apply_network_policy_translates_other_sprite_errors():
+    sprite = _fake_sprite()
+    sprite.update_network_policy.side_effect = sprites.SpriteError("boom")
+    with pytest.raises(BackendError):
+        _SpritesHandle(sprite).apply_network_policy(NetworkPolicy(rules=[]))
+
+
+# ---------- SpritesBackend ----------
+
+
+def test_sprites_backend_create_client_uses_settings_base_url(mocker, settings):
+    settings.SPRITES_BASE_URL = "https://api.example.test"
+    constructor = mocker.patch(
+        "agent_on_demand.session_service.sprites_backend.sprites.SpritesClient"
+    )
+    SpritesBackend().create_client("token-abc")
+    constructor.assert_called_once_with(token="token-abc", base_url="https://api.example.test")
+
+
+def test_sprites_backend_websocket_patch_is_idempotent(mocker):
+    """Multiple SpritesBackend() instantiations should not re-wrap
+    websockets.connect."""
+    import sprites.websocket as ws
+
+    # Reset the marker so we can observe the first patch happen.
+    if hasattr(ws.websockets, "_aod_close_timeout_patched"):
+        delattr(ws.websockets, "_aod_close_timeout_patched")
+    original = ws.websockets.connect
+
+    SpritesBackend()
+    after_first = ws.websockets.connect
+    assert after_first is not original
+
+    SpritesBackend()
+    after_second = ws.websockets.connect
+    assert after_second is after_first  # no re-wrap

--- a/tests/test_fake_backend.py
+++ b/tests/test_fake_backend.py
@@ -167,7 +167,7 @@ def test_command_outcome_can_raise():
 def test_apply_network_policy_records_policies():
     client = RecordingBackendClient()
     handle = client.provision("s")
-    p = NetworkPolicy(rules=[PolicyRule(domain="x", action="allow")])
+    p = NetworkPolicy(rules=(PolicyRule(domain="x", action="allow"),))
     handle.apply_network_policy(p)
     assert handle.network_policies == [p]
 
@@ -177,7 +177,7 @@ def test_apply_network_policy_can_be_made_to_raise_once():
     handle = client.provision("s")
     handle.raise_on_apply_network_policy(BackendError("policy backend down"))
     with pytest.raises(BackendError):
-        handle.apply_network_policy(NetworkPolicy(rules=[]))
+        handle.apply_network_policy(NetworkPolicy())
     # Second call succeeds.
     handle.apply_network_policy(NetworkPolicy(rules=[]))
     assert len(handle.network_policies) == 1

--- a/tests/test_fake_backend.py
+++ b/tests/test_fake_backend.py
@@ -1,0 +1,183 @@
+"""Sanity tests for the FakeBackend recording fake.
+
+The fake doesn't replace any production behavior, but it underpins every
+session_service unit test going forward, so its accounting needs to be
+exact: writes, chmods, commands, and network policies should all show up
+in the lists tests inspect."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from agent_on_demand.session_service.backend import (
+    BackendError,
+    NetworkPolicy,
+    PolicyRule,
+    SessionNotFoundError,
+)
+from tests.fakes.backend import FakeBackend, RecordingBackendClient
+
+
+def test_fake_backend_create_client_returns_recording_client():
+    fb = FakeBackend()
+    client = fb.create_client("token")
+    assert isinstance(client, RecordingBackendClient)
+
+
+def test_fake_backend_returns_preset_client():
+    preset = RecordingBackendClient()
+    fb = FakeBackend(client=preset)
+    assert fb.create_client("token") is preset
+
+
+def test_provision_records_name_and_returns_handle():
+    client = RecordingBackendClient()
+    handle = client.provision("session-1")
+    assert client.created == ["session-1"]
+    assert handle.name == "session-1"
+    assert client.last_handle() is handle
+
+
+def test_provision_can_be_made_to_raise():
+    client = RecordingBackendClient()
+    client.raise_on_provision(BackendError("boom"))
+    with pytest.raises(BackendError):
+        client.provision("name")
+    # Single-shot — second call succeeds.
+    client.provision("name")
+
+
+def test_get_returns_existing_handle_after_provision():
+    client = RecordingBackendClient()
+    handle = client.provision("s")
+    assert client.get("s") is handle
+
+
+def test_get_can_be_marked_missing():
+    client = RecordingBackendClient()
+    client.mark_missing("ghost")
+    with pytest.raises(SessionNotFoundError):
+        client.get("ghost")
+
+
+def test_destroy_records_name():
+    client = RecordingBackendClient()
+    client.destroy("s")
+    assert client.deleted == ["s"]
+
+
+def test_close_marks_closed():
+    client = RecordingBackendClient()
+    client.close()
+    assert client.closed
+
+
+# ---------- Handle / Workspace ----------
+
+
+def test_handle_workspace_records_writes_with_normalized_paths():
+    client = RecordingBackendClient()
+    handle = client.provision("s")
+    fs = handle.workspace()
+    fs.write_text("tmp/aod-env", "FOO=bar\n")
+    fs.write_text("/tmp/run.sh", "#!/bin/bash\necho hi\n")
+    assert [w.path for w in handle.writes] == ["/tmp/aod-env", "/tmp/run.sh"]
+    assert handle.writes[0].content == "FOO=bar\n"
+
+
+def test_handle_workspace_records_chmods():
+    client = RecordingBackendClient()
+    handle = client.provision("s")
+    handle.workspace().chmod("/tmp/run.sh", 0o755)
+    assert handle.chmods[0].path == "/tmp/run.sh"
+    assert handle.chmods[0].mode == 0o755
+
+
+def test_handle_raise_on_write_fires_once():
+    client = RecordingBackendClient()
+    handle = client.provision("s")
+    handle.raise_on_write("aod-env", BackendError("disk full"))
+    fs = handle.workspace()
+    with pytest.raises(BackendError):
+        fs.write_text("/tmp/aod-env", "x")
+    # Predicate is single-shot — the next write to the same path succeeds.
+    fs.write_text("/tmp/aod-env", "y")
+    assert handle.writes == [fs.writes[0]]
+    assert handle.writes[0].content == "y"
+
+
+# ---------- Commands ----------
+
+
+def test_make_command_records_argv_cwd_timeout():
+    client = RecordingBackendClient()
+    handle = client.provision("s")
+    cmd = handle.make_command("bash", "-lc", "true", cwd="/home/sprite", timeout=30.0)
+    cmd.run()
+    rec = handle.commands[0]
+    assert rec.argv == ("bash", "-lc", "true")
+    assert rec.cwd == "/home/sprite"
+    assert rec.timeout == 30.0
+    assert rec.ran is True
+    assert rec.exit_code == 0
+
+
+def test_make_command_set_input_records_stdin():
+    client = RecordingBackendClient()
+    handle = client.provision("s")
+    cmd = handle.make_command("cat")
+    cmd.set_input(b"hello")
+    cmd.run()
+    assert handle.commands[0].stdin == b"hello"
+
+
+def test_command_outcome_can_be_overridden_with_exit_code():
+    client = RecordingBackendClient()
+    handle = client.provision("s")
+    handle.set_command_outcome(lambda argv: argv[0] == "false", exit_code=1)
+    cmd = handle.make_command("false")
+    assert cmd.run() == 1
+
+
+def test_command_outcome_can_write_stderr_to_assigned_buffer():
+    client = RecordingBackendClient()
+    handle = client.provision("s")
+    handle.set_command_outcome("bash", exit_code=2, stderr=b"oh no\n")
+    cmd = handle.make_command("bash", "-lc", "exit 2")
+    err_buf = io.BytesIO()
+    cmd.set_output(io.BytesIO(), err_buf)
+    assert cmd.run() == 2
+    assert err_buf.getvalue() == b"oh no\n"
+
+
+def test_command_outcome_can_raise():
+    client = RecordingBackendClient()
+    handle = client.provision("s")
+    handle.set_command_outcome("bash", exc=BackendError("transport"))
+    cmd = handle.make_command("bash", "-lc", "true")
+    with pytest.raises(BackendError):
+        cmd.run()
+
+
+# ---------- Network policies ----------
+
+
+def test_apply_network_policy_records_policies():
+    client = RecordingBackendClient()
+    handle = client.provision("s")
+    p = NetworkPolicy(rules=[PolicyRule(domain="x", action="allow")])
+    handle.apply_network_policy(p)
+    assert handle.network_policies == [p]
+
+
+def test_apply_network_policy_can_be_made_to_raise_once():
+    client = RecordingBackendClient()
+    handle = client.provision("s")
+    handle.raise_on_apply_network_policy(BackendError("policy backend down"))
+    with pytest.raises(BackendError):
+        handle.apply_network_policy(NetworkPolicy(rules=[]))
+    # Second call succeeds.
+    handle.apply_network_policy(NetworkPolicy(rules=[]))
+    assert len(handle.network_policies) == 1


### PR DESCRIPTION
## Summary

PR 1 of the session-backend extraction plan
(`thoughts/plans/2026-04-27-session-backend-extraction.md`,
interface design in `thoughts/research/2026-04-18-session-backend-abstraction.md`).

Adds the `Backend` / `BackendClient` / `SessionHandle` / `WorkspaceFS` /
`Command` Protocols and a `SpritesBackend` adapter behind them. Purely
additive — no caller switches yet. Subsequent PRs migrate
`session_service/`, `runtimes/`, the execution path, and the API
surface onto the Protocol; PRs 6–8 do the schema rename.

Key shape decisions vs. the 2026-04-18 research:

- `Command.run() -> int` returns the exit code directly; non-zero exits
  are not raised. `ExecutionError` is reserved for transport-layer
  failures.
- `set_executable` collapsed into `WorkspaceFS.chmod` (filesystem op,
  not a shell-out).
- Websocket close-timeout patch applied idempotently inside
  `SpritesBackend.__init__`. The existing `sprites_patch.py` import in
  `apps.py` stays put — its retirement is scheduled for PR 5.

A `FakeBackend` in `tests/fakes/backend.py` mirrors the recording shape
from `tests/fakes/sprite.py`, with a parallel `fake_backend` conftest
fixture so PR 2 lands cleanly.

Closes #242.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 993 passed (38 new)
- [x] `make coverage` — 99.09% total (floor at 96, stays flat)
- [x] `apps.py:18` `import agent_on_demand.sprites_patch` untouched
- [x] `from sprites` imports in `src/`: existing 13 + new
      `sprites_backend.py` = 14, matching the issue's "same count + the
      lines in `sprites_backend.py`" criterion

🤖 Generated with [Claude Code](https://claude.com/claude-code)