### PR TITLE
Extract git_credentials + skills_install helpers + mutation tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,8 @@ paths_to_mutate = [
     "src/agent_on_demand/session_service/env_file.py",
     "src/agent_on_demand/session_service/turn_outcome.py",
     "src/agent_on_demand/session_service/network_policy.py",
+    "src/agent_on_demand/session_service/git_credentials.py",
+    "src/agent_on_demand/session_service/skills_install.py",
 ]
 tests_dir = [
     "tests/test_auth.py",
@@ -193,6 +195,8 @@ tests_dir = [
     "tests/test_env_file.py",
     "tests/test_turn_outcome.py",
     "tests/test_network_policy.py",
+    "tests/test_git_credentials.py",
+    "tests/test_skills_install.py",
 ]
 # mutmut copies its working tree to ./mutants/ and runs pytest from there;
 # without these, the rest of the src/ tree isn't available to the test runner.

--- a/src/agent_on_demand/session_service/git_credentials.py
+++ b/src/agent_on_demand/session_service/git_credentials.py
@@ -1,0 +1,34 @@
+"""Compose the body of `/tmp/.git-credentials`.
+
+The file is consumed by git's `store` credential helper at clone /
+fetch / push time. Each line follows the format
+``https://<token>:x-oauth-basic@github.com`` — GitHub's documented
+contract for using a personal access token as the password component
+of HTTP basic auth (the username is the literal ``x-oauth-basic``
+sentinel). A wrong format silently breaks git auth or — worse —
+exposes tokens in error messages, so the line builder lives in its
+own pure module direct-testable under mutmut's hammett runner without
+pulling in the Sprite or ORM dependencies that
+`write_git_credentials` carries.
+
+Returns a ``list[str]`` rather than a joined string: line-joining and
+trailing-newline handling are concerns of the caller writing to the
+Sprite filesystem, not of the line builder.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .specs import RepoSpec
+
+
+def build_git_credentials_lines(repos: list["RepoSpec"]) -> list[str]:
+    """Return one credential line per token-bearing repo.
+
+    Repos with a falsy ``token`` (``None`` or ``""``) are skipped.
+    Order is preserved from the input — no sort, no dedup. Each line
+    is exactly ``https://<token>:x-oauth-basic@github.com``.
+    """
+    return [f"https://{r.token}:x-oauth-basic@github.com" for r in repos if r.token]

--- a/src/agent_on_demand/session_service/git_credentials.py
+++ b/src/agent_on_demand/session_service/git_credentials.py
@@ -1,15 +1,21 @@
 """Compose the body of `/tmp/.git-credentials`.
 
 The file is consumed by git's `store` credential helper at clone /
-fetch / push time. Each line follows the format
-``https://<token>:x-oauth-basic@github.com`` — GitHub's documented
-contract for using a personal access token as the password component
-of HTTP basic auth (the username is the literal ``x-oauth-basic``
-sentinel). A wrong format silently breaks git auth or — worse —
-exposes tokens in error messages, so the line builder lives in its
-own pure module direct-testable under mutmut's hammett runner without
-pulling in the Sprite or ORM dependencies that
-`write_git_credentials` carries.
+fetch / push time. Each line is exactly
+``https://<token>:x-oauth-basic@github.com`` — the PAT goes in the
+*username* slot and the literal ``x-oauth-basic`` sentinel in the
+*password* slot. This is the inverse of GitHub's documented
+PAT-as-password form (``https://x-oauth-basic:<token>@...``), but it
+is the empirically-working shape we ship: production sessions clone
+private repos with this format today. GitHub's basic-auth handling
+accepts the PAT in either credential slot, so do NOT "fix" the order
+to match the docs — flipping it risks silently breaking every active
+session's git auth.
+
+A wrong format silently breaks git auth or — worse — exposes tokens
+in error messages, so the line builder lives in its own pure module
+direct-testable under mutmut's hammett runner without pulling in the
+Sprite or ORM dependencies that `write_git_credentials` carries.
 
 Returns a ``list[str]`` rather than a joined string: line-joining and
 trailing-newline handling are concerns of the caller writing to the

--- a/src/agent_on_demand/session_service/provisioning_stages.py
+++ b/src/agent_on_demand/session_service/provisioning_stages.py
@@ -9,7 +9,6 @@ for emitting its `stage_timer` event and wrapping any `SpriteError` as a
 from __future__ import annotations
 
 import io
-import shlex
 
 from sprites import Sprite, SpriteError
 
@@ -17,6 +16,7 @@ from agent_on_demand.models import Environment
 
 from .env_file import build_env_file_body
 from .errors import ProvisionError
+from .git_credentials import build_git_credentials_lines
 from .network_policy import build_network_policy
 from .provision_script import (
     ENV_FILE_PATH,
@@ -24,6 +24,7 @@ from .provision_script import (
     PROVISION_SCRIPT_PATH,
     build_provision_script,
 )
+from .skills_install import build_skills_install_command
 from .specs import RepoSpec, SessionSpec
 from .stage_events import (
     STAGE_ENV_FILE,
@@ -100,7 +101,7 @@ def write_env_file(sprite: Sprite, spec: SessionSpec, session_id: str | None) ->
 def write_git_credentials(sprite: Sprite, repos: list[RepoSpec], session_id: str | None) -> None:
     """Write /tmp/.git-credentials if any repo has a token (fs.write only;
     chmod + `git config credential.helper` live in the provision script)."""
-    cred_lines = [f"https://{r.token}:x-oauth-basic@github.com" for r in repos if r.token]
+    cred_lines = build_git_credentials_lines(repos)
     if not cred_lines:
         return
     with stage_timer(session_id, STAGE_GIT_CREDENTIALS):
@@ -194,14 +195,7 @@ def write_skills(
             if github and agent_id is not None:
                 for s in github:
                     assert s.source is not None
-                    cmd = (
-                        f"npx -y skills@latest add {shlex.quote(s.source)} "
-                        f"--global --agent {shlex.quote(agent_id)} --yes"
-                    )
-                    if s.name:
-                        # Pin to a single skill from the repo. Without --skill,
-                        # the CLI installs every SKILL.md it finds.
-                        cmd += f" --skill {shlex.quote(s.name)}"
+                    cmd = build_skills_install_command(s.source, agent_id, s.name)
                     sprite.command("bash", "-lc", cmd).run()
         except SpriteError as e:
             raise ProvisionError(f"Failed to write skills: {e}", stage=STAGE_SKILLS) from e

--- a/src/agent_on_demand/session_service/skills_install.py
+++ b/src/agent_on_demand/session_service/skills_install.py
@@ -1,0 +1,35 @@
+"""Build the `skills.sh` install command for a github-source skill.
+
+The composed string is handed to ``bash -lc`` on the Sprite, so every
+user-controlled component (``source``, ``agent_id``, ``name``) MUST be
+``shlex.quote``-d before interpolation — ``source`` is an
+``owner/repo`` identifier supplied by API callers and would otherwise
+allow arbitrary command injection (e.g. ``foo; rm -rf /``). The
+quoting guard is load-bearing for security, so the builder lives in
+its own pure module direct-testable under mutmut's hammett runner.
+
+The function returns a single command string ready for
+``sprite.command("bash", "-lc", cmd).run()``; callers retain
+responsibility for invoking the Sprite SDK.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+
+def build_skills_install_command(source: str, agent_id: str, name: str | None) -> str:
+    """Return the `npx skills@latest add ...` command for a github skill.
+
+    When ``name`` is truthy, ``--skill <name>`` is appended so the CLI
+    installs a single SKILL.md from the repo. When falsy (``None`` or
+    ``""``), the flag is omitted and the CLI installs every SKILL.md
+    in the repo.
+    """
+    cmd = (
+        f"npx -y skills@latest add {shlex.quote(source)} "
+        f"--global --agent {shlex.quote(agent_id)} --yes"
+    )
+    if name:
+        cmd += f" --skill {shlex.quote(name)}"
+    return cmd

--- a/tests/test_git_credentials.py
+++ b/tests/test_git_credentials.py
@@ -1,7 +1,7 @@
 """Direct unit tests for `build_git_credentials_lines`.
 
 Mutation-tested. Each test pins one mutation-killable property of the
-`/tmp/.git-credentials` body that GitHub's `store` credential helper
+`/tmp/.git-credentials` body that git's `store` credential helper
 consumes:
 
   - Empty input → empty output.
@@ -9,9 +9,12 @@ consumes:
   - Mixed input → only token-bearing repos appear, in input order.
   - Each emitted line is exactly
     ``https://<token>:x-oauth-basic@github.com`` — character-for-
-    character. The ``:x-oauth-basic@github.com`` suffix is GitHub's
-    PAT-as-password contract; mutating any character silently breaks
-    git auth on the Sprite.
+    character. The PAT goes in the username slot and the literal
+    ``x-oauth-basic`` in the password slot; this is the inverse of
+    GitHub's documented PAT-as-password form but is the empirically-
+    working shape production sessions ship today. See the module
+    docstring on ``git_credentials.py`` — do NOT "fix" the order.
+    Mutating any character silently breaks git auth on the Sprite.
   - Tokens are interpolated VERBATIM; no URL-encoding, no
     transformation, no dedup, no sort.
 
@@ -54,10 +57,11 @@ def test_mixed_none_and_empty_string_returns_empty():
 
 def test_single_repo_line_is_exact_full_string():
     """Full-string equality on the single emitted line. The
-    ``:x-oauth-basic@github.com`` suffix is GitHub's documented
-    contract for PAT-as-password basic auth — any mutant that drops a
-    character (the colon, the literal ``x-oauth-basic``, the ``@``,
-    the ``github.com`` host) breaks auth on the Sprite."""
+    ``:x-oauth-basic@github.com`` suffix encodes the
+    ``x-oauth-basic`` password sentinel and the ``github.com`` host
+    that GitHub's basic-auth handler matches against — any mutant
+    that drops a character (the colon, the literal ``x-oauth-basic``,
+    the ``@``, the ``github.com`` host) breaks auth on the Sprite."""
     lines = build_git_credentials_lines([_repo("ghp_abc123")])
     assert lines == ["https://ghp_abc123:x-oauth-basic@github.com"]
 
@@ -79,9 +83,14 @@ def test_line_starts_with_https_scheme():
 
 
 def test_line_uses_x_oauth_basic_username_literal():
-    """The literal ``x-oauth-basic`` is GitHub's required username
-    sentinel when using a PAT as the password. A mutant that swaps it
-    for any other string (even ``oauth2`` or empty) breaks auth."""
+    """The literal ``x-oauth-basic`` appears after the ``:`` — i.e.
+    in the *password* slot of the basic-auth URL — with the PAT in
+    the username slot. (The function name dates from a misreading of
+    GitHub's documented form, which puts the sentinel in the
+    username slot; the empirically-working shape we ship inverts
+    that order. See the module docstring.) A mutant that swaps the
+    literal for any other string (even ``oauth2`` or empty) breaks
+    auth."""
     lines = build_git_credentials_lines([_repo("tok")])
     assert lines[0] == "https://tok:x-oauth-basic@github.com"
 

--- a/tests/test_git_credentials.py
+++ b/tests/test_git_credentials.py
@@ -1,0 +1,166 @@
+"""Direct unit tests for `build_git_credentials_lines`.
+
+Mutation-tested. Each test pins one mutation-killable property of the
+`/tmp/.git-credentials` body that GitHub's `store` credential helper
+consumes:
+
+  - Empty input → empty output.
+  - All-falsy tokens (``None`` or ``""``) → empty output.
+  - Mixed input → only token-bearing repos appear, in input order.
+  - Each emitted line is exactly
+    ``https://<token>:x-oauth-basic@github.com`` — character-for-
+    character. The ``:x-oauth-basic@github.com`` suffix is GitHub's
+    PAT-as-password contract; mutating any character silently breaks
+    git auth on the Sprite.
+  - Tokens are interpolated VERBATIM; no URL-encoding, no
+    transformation, no dedup, no sort.
+
+Tests are sync, no Django imports — required so hammett (mutmut's
+runner) can execute them. ``RepoSpec`` is duck-typed via
+``SimpleNamespace``.
+"""
+
+from types import SimpleNamespace
+
+from agent_on_demand.session_service.git_credentials import build_git_credentials_lines
+
+
+def _repo(token):
+    return SimpleNamespace(token=token)
+
+
+# ---------- empty / all-falsy → empty ----------
+
+
+def test_empty_repo_list_returns_empty():
+    assert build_git_credentials_lines([]) == []
+
+
+def test_all_none_tokens_returns_empty():
+    assert build_git_credentials_lines([_repo(None), _repo(None)]) == []
+
+
+def test_all_empty_string_tokens_returns_empty():
+    # Empty-string tokens are falsy and skipped — same as None.
+    assert build_git_credentials_lines([_repo(""), _repo("")]) == []
+
+
+def test_mixed_none_and_empty_string_returns_empty():
+    assert build_git_credentials_lines([_repo(None), _repo("")]) == []
+
+
+# ---------- exact line format ----------
+
+
+def test_single_repo_line_is_exact_full_string():
+    """Full-string equality on the single emitted line. The
+    ``:x-oauth-basic@github.com`` suffix is GitHub's documented
+    contract for PAT-as-password basic auth — any mutant that drops a
+    character (the colon, the literal ``x-oauth-basic``, the ``@``,
+    the ``github.com`` host) breaks auth on the Sprite."""
+    lines = build_git_credentials_lines([_repo("ghp_abc123")])
+    assert lines == ["https://ghp_abc123:x-oauth-basic@github.com"]
+
+
+def test_token_interpolated_verbatim():
+    """The token is inlined exactly as supplied — no URL-encoding,
+    no escaping, no transformation. Pin so a mutant that wraps
+    ``r.token`` in ``str(...)`` or applies ``.strip()`` is caught."""
+    lines = build_git_credentials_lines([_repo("abc-123")])
+    assert lines == ["https://abc-123:x-oauth-basic@github.com"]
+
+
+def test_line_starts_with_https_scheme():
+    """Pin the ``https://`` scheme prefix — git's `store` helper
+    matches credentials by scheme+host, so a mutant that swaps to
+    ``http://`` or drops the scheme silently sends no credentials."""
+    lines = build_git_credentials_lines([_repo("t")])
+    assert lines == ["https://t:x-oauth-basic@github.com"]
+
+
+def test_line_uses_x_oauth_basic_username_literal():
+    """The literal ``x-oauth-basic`` is GitHub's required username
+    sentinel when using a PAT as the password. A mutant that swaps it
+    for any other string (even ``oauth2`` or empty) breaks auth."""
+    lines = build_git_credentials_lines([_repo("tok")])
+    assert lines[0] == "https://tok:x-oauth-basic@github.com"
+
+
+def test_line_targets_github_com_host():
+    """Pin ``@github.com`` — credentials stored against another host
+    won't match GitHub clones."""
+    lines = build_git_credentials_lines([_repo("tok")])
+    assert lines[0] == "https://tok:x-oauth-basic@github.com"
+
+
+# ---------- ordering / mixing ----------
+
+
+def test_mixed_tokens_only_truthy_appear_in_input_order():
+    """Repos with falsy tokens are skipped; the remainder appear in
+    input order (no sort, no dedup). Distinguishes a mutant that
+    reverses the comprehension or sorts the result."""
+    repos = [
+        _repo("first"),
+        _repo(None),
+        _repo("second"),
+        _repo(""),
+        _repo("third"),
+    ]
+    assert build_git_credentials_lines(repos) == [
+        "https://first:x-oauth-basic@github.com",
+        "https://second:x-oauth-basic@github.com",
+        "https://third:x-oauth-basic@github.com",
+    ]
+
+
+def test_two_distinct_tokens_both_emitted_in_order():
+    repos = [_repo("alpha"), _repo("beta")]
+    assert build_git_credentials_lines(repos) == [
+        "https://alpha:x-oauth-basic@github.com",
+        "https://beta:x-oauth-basic@github.com",
+    ]
+
+
+def test_duplicate_tokens_are_not_deduped():
+    """Caller-determined input order is preserved verbatim — if the
+    caller hands in the same token twice, both lines appear. Pin so a
+    mutant that converts via ``set(...)`` is caught."""
+    repos = [_repo("same"), _repo("same")]
+    assert build_git_credentials_lines(repos) == [
+        "https://same:x-oauth-basic@github.com",
+        "https://same:x-oauth-basic@github.com",
+    ]
+
+
+def test_input_order_is_not_sorted():
+    """Reverse-alphabetical input stays reverse-alphabetical out —
+    no sort applied. Distinguishes a mutant that wraps the
+    comprehension in ``sorted(...)``."""
+    repos = [_repo("zzz"), _repo("aaa")]
+    assert build_git_credentials_lines(repos) == [
+        "https://zzz:x-oauth-basic@github.com",
+        "https://aaa:x-oauth-basic@github.com",
+    ]
+
+
+def test_first_repo_with_none_does_not_shift_order():
+    """A leading falsy-token repo is skipped without consuming a
+    slot — the next truthy repo is line[0]."""
+    repos = [_repo(None), _repo("only")]
+    assert build_git_credentials_lines(repos) == [
+        "https://only:x-oauth-basic@github.com",
+    ]
+
+
+# ---------- count invariants ----------
+
+
+def test_line_count_equals_truthy_token_count():
+    repos = [_repo("a"), _repo(None), _repo("b"), _repo(""), _repo("c")]
+    assert len(build_git_credentials_lines(repos)) == 3
+
+
+def test_three_truthy_repos_emit_three_lines():
+    repos = [_repo("a"), _repo("b"), _repo("c")]
+    assert len(build_git_credentials_lines(repos)) == 3

--- a/tests/test_skills_install.py
+++ b/tests/test_skills_install.py
@@ -1,0 +1,193 @@
+"""Direct unit tests for `build_skills_install_command`.
+
+Mutation-tested. Each test pins one mutation-killable property of the
+shell command handed to ``bash -lc`` for ``skills.sh`` install:
+
+  - The fixed flag set (``npx -y skills@latest add``,
+    ``--global``, ``--agent``, ``--yes``) appears in exact order. A
+    reorder that places ``--agent`` before ``add`` flips the CLI's
+    argument parser into a different mode.
+  - User-controlled inputs (``source``, ``agent_id``, ``name``) are
+    routed through ``shlex.quote`` before interpolation. A mutant
+    that drops the quoting opens a shell-injection sink: ``source``
+    is an API-supplied ``owner/repo`` string interpolated into a
+    string handed to ``bash -lc``.
+  - Falsy ``name`` (``None`` or ``""``) → ``--skill`` flag is
+    omitted; truthy ``name`` → ``--skill <quoted-name>`` is appended.
+
+Tests are sync, no Django imports — required so hammett (mutmut's
+runner) can execute them.
+"""
+
+from agent_on_demand.session_service.skills_install import build_skills_install_command
+
+
+# ---------- exact full-string equality (anchor tests) ----------
+
+
+def test_exact_command_without_name():
+    """Full-string equality with shell-safe inputs (``owner/repo`` and
+    ``claude`` need no quoting). Anchors the entire command shape so
+    any single-character mutation is caught."""
+    cmd = build_skills_install_command("owner/repo", "claude", None)
+    assert cmd == "npx -y skills@latest add owner/repo --global --agent claude --yes"
+
+
+def test_exact_command_with_name():
+    """Full-string equality including the ``--skill`` tail."""
+    cmd = build_skills_install_command("owner/repo", "claude", "my-skill")
+    assert cmd == (
+        "npx -y skills@latest add owner/repo --global --agent claude --yes --skill my-skill"
+    )
+
+
+# ---------- name=None / empty-string falsy ----------
+
+
+def test_name_none_omits_skill_flag():
+    cmd = build_skills_install_command("owner/repo", "claude", None)
+    assert "--skill" not in cmd
+
+
+def test_name_empty_string_omits_skill_flag():
+    """``if name:`` treats empty string as falsy, same as None. Pin
+    so a mutant that swaps to ``if name is not None:`` is caught."""
+    cmd = build_skills_install_command("owner/repo", "claude", "")
+    assert "--skill" not in cmd
+    assert cmd == "npx -y skills@latest add owner/repo --global --agent claude --yes"
+
+
+def test_name_truthy_appends_skill_flag():
+    cmd = build_skills_install_command("owner/repo", "claude", "my-skill")
+    assert cmd.endswith("--skill my-skill")
+
+
+# ---------- shlex.quote on source ----------
+
+
+def test_source_with_space_is_single_quoted():
+    """``shlex.quote('foo bar')`` → ``'foo bar'``. Distinguishes a
+    mutant that drops the quoting (would emit a bare ``foo bar``,
+    which the shell parses as two args)."""
+    cmd = build_skills_install_command("foo bar", "claude", None)
+    assert "'foo bar'" in cmd
+    assert cmd == "npx -y skills@latest add 'foo bar' --global --agent claude --yes"
+
+
+def test_source_with_command_substitution_is_quoted():
+    """A source like ``$(whoami)`` MUST be single-quoted so the
+    shell does not execute it. This is the security-load-bearing
+    case: a mutant that drops the quoting opens a shell-injection
+    sink. ``shlex.quote('$(whoami)')`` → ``'$(whoami)'``."""
+    cmd = build_skills_install_command("$(whoami)", "claude", None)
+    assert "'$(whoami)'" in cmd
+    assert cmd == "npx -y skills@latest add '$(whoami)' --global --agent claude --yes"
+
+
+def test_source_with_semicolon_is_quoted():
+    """A source like ``foo;rm`` is single-quoted — semicolons would
+    otherwise terminate the npx command and run a follow-up."""
+    cmd = build_skills_install_command("foo;rm", "claude", None)
+    assert "'foo;rm'" in cmd
+
+
+def test_source_with_backtick_is_quoted():
+    """Backticks would trigger command substitution if unquoted."""
+    cmd = build_skills_install_command("`whoami`", "claude", None)
+    assert "'`whoami`'" in cmd
+
+
+# ---------- shlex.quote on agent_id ----------
+
+
+def test_agent_id_with_space_is_single_quoted():
+    cmd = build_skills_install_command("owner/repo", "agent name", None)
+    assert "'agent name'" in cmd
+    assert cmd == "npx -y skills@latest add owner/repo --global --agent 'agent name' --yes"
+
+
+def test_agent_id_with_metacharacters_is_quoted():
+    cmd = build_skills_install_command("owner/repo", "$(whoami)", None)
+    assert "'$(whoami)'" in cmd
+
+
+# ---------- shlex.quote on name ----------
+
+
+def test_name_with_space_is_single_quoted():
+    cmd = build_skills_install_command("owner/repo", "claude", "my skill")
+    assert "--skill 'my skill'" in cmd
+    assert cmd == (
+        "npx -y skills@latest add owner/repo --global --agent claude --yes --skill 'my skill'"
+    )
+
+
+def test_name_with_metacharacters_is_quoted():
+    cmd = build_skills_install_command("owner/repo", "claude", "$(rm -rf /)")
+    assert "--skill '$(rm -rf /)'" in cmd
+
+
+# ---------- fixed flag presence and ordering ----------
+
+
+def test_command_starts_with_npx_dash_y():
+    """``npx -y`` is the literal prefix — ``-y`` accepts the
+    auto-install prompt non-interactively."""
+    cmd = build_skills_install_command("owner/repo", "claude", None)
+    assert cmd.startswith("npx -y skills@latest add ")
+
+
+def test_command_includes_skills_at_latest():
+    """Pin the ``skills@latest`` package spec — a mutant that drops
+    the version pin or substitutes a different package name reaches
+    out for the wrong CLI."""
+    cmd = build_skills_install_command("owner/repo", "claude", None)
+    assert "skills@latest" in cmd
+
+
+def test_command_includes_add_subcommand():
+    """The CLI verb is ``add`` — distinguishes a mutant that swaps
+    to ``install`` or drops the verb entirely."""
+    cmd = build_skills_install_command("owner/repo", "claude", None)
+    assert " add " in cmd
+
+
+def test_command_includes_global_flag():
+    cmd = build_skills_install_command("owner/repo", "claude", None)
+    assert "--global" in cmd
+
+
+def test_command_includes_agent_flag():
+    cmd = build_skills_install_command("owner/repo", "claude", None)
+    assert "--agent" in cmd
+
+
+def test_command_includes_yes_flag():
+    cmd = build_skills_install_command("owner/repo", "claude", None)
+    assert "--yes" in cmd
+
+
+def test_flag_ordering_add_before_global():
+    """``add <source>`` must come before ``--global`` so the source
+    is captured as the positional argument. A reorder mutant that
+    moves ``--global`` before the source breaks the CLI."""
+    cmd = build_skills_install_command("owner/repo", "claude", None)
+    assert cmd.index(" add ") < cmd.index("--global")
+
+
+def test_flag_ordering_global_before_agent():
+    cmd = build_skills_install_command("owner/repo", "claude", None)
+    assert cmd.index("--global") < cmd.index("--agent")
+
+
+def test_flag_ordering_agent_before_yes():
+    cmd = build_skills_install_command("owner/repo", "claude", None)
+    assert cmd.index("--agent") < cmd.index("--yes")
+
+
+def test_skill_flag_appears_after_yes():
+    """When ``name`` is supplied, ``--skill`` is appended *after*
+    ``--yes`` — the function builds the base command first, then
+    tacks on ``--skill``."""
+    cmd = build_skills_install_command("owner/repo", "claude", "my-skill")
+    assert cmd.index("--yes") < cmd.index("--skill")


### PR DESCRIPTION
## Summary

- Extracts `build_git_credentials_lines` from `write_git_credentials` into a new pure module so its line format (the GitHub PAT-as-password URL contract `https://<token>:x-oauth-basic@github.com`) can be pinned by mutation tests.
- Extracts `build_skills_install_command` from `write_skills` into a new pure module so the security-load-bearing `shlex.quote` calls on `source` / `agent_id` / `name` can be pinned by mutation tests — `source` is API-supplied and reaches `bash -lc`, so a quoting-bypass mutant is a command-injection sink.
- Adds `tests/test_git_credentials.py` + `tests/test_skills_install.py` (sync, no Django imports — required for hammett) and registers both modules + test files in `[tool.mutmut]`.

Next entry in the mutation-coverage ratchet for the session-service refactor.

## Test plan
- [x] `make lint`
- [x] `uv run pytest tests/test_git_credentials.py tests/test_skills_install.py -v` (39 pass)
- [x] `uv run pytest tests/test_session_service.py -v` regression for `write_git_credentials` / `write_skills` (38 pass)
- [x] Full unit/integration suite (1045 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)