### PR TITLE
Eliminate known-equivalent mutants in build_turn_argv

### DIFF
--- a/scripts/check_mutmut.py
+++ b/scripts/check_mutmut.py
@@ -40,19 +40,6 @@ KNOWN_EQUIVALENT: set[str] = {
     # Keeping the guard.
     "agent_on_demand.session_service.provision_script.x_build_provision_script__mutmut_29",
     "agent_on_demand.session_service.provision_script.x_build_provision_script__mutmut_31",
-    # `cast(Literal["run", "continue"], mode)` -> any mutation of the type
-    # literal (None, "XXrunXX", "RUN", "XXcontinueXX", "CONTINUE"). At runtime
-    # `typing.cast(typ, val)` is `return val` — the type expression is never
-    # evaluated, so every mutation produces identical bytes. The cast exists
-    # only to satisfy mypy's narrowing of `mode: str` to the Literal that
-    # `Runtime.build_command` requires; removing it would just push the cast
-    # to the caller in `tasks.py` (which is not mutation-tested), gaining
-    # nothing.
-    "agent_on_demand.session_service.turn_argv.x_build_turn_argv__mutmut_6",
-    "agent_on_demand.session_service.turn_argv.x_build_turn_argv__mutmut_10",
-    "agent_on_demand.session_service.turn_argv.x_build_turn_argv__mutmut_11",
-    "agent_on_demand.session_service.turn_argv.x_build_turn_argv__mutmut_12",
-    "agent_on_demand.session_service.turn_argv.x_build_turn_argv__mutmut_13",
 }
 
 

--- a/src/agent_on_demand/session_service/turn_argv.py
+++ b/src/agent_on_demand/session_service/turn_argv.py
@@ -30,12 +30,13 @@ def build_turn_argv(runtime: Runtime, spec: SessionSpec, mode: str) -> list[str]
     Prompt delivery is out of band: callers attach `cmd.stdin` with the
     prompt bytes so it flows through the bash shim into the runtime CLI.
 
-    Raises ``ValueError`` if ``mode`` is anything other than ``"run"`` or
-    ``"continue"`` — runtime validation in place of a ``typing.cast`` so
-    typos surface here instead of being silently forwarded to the runtime
-    CLI (and so the mode tuple becomes a mutation-killable surface
-    rather than an unkillable type-only cast).
+    Raises ``ValueError`` if ``mode`` is not exactly ``"run"`` or
+    ``"continue"``, with the message ``"mode must be 'run' or 'continue',
+    got <repr>"``. Catches typos at the boundary instead of forwarding
+    them to the runtime CLI as opaque flags.
     """
+    # Runtime check (not `typing.cast`) so the literal tuple is a real
+    # surface — don't "simplify" this back into a cast.
     if mode not in ("run", "continue"):
         raise ValueError(f"mode must be 'run' or 'continue', got {mode!r}")
     argv = runtime.build_command(spec, mode)  # type: ignore[arg-type]

--- a/src/agent_on_demand/session_service/turn_argv.py
+++ b/src/agent_on_demand/session_service/turn_argv.py
@@ -8,7 +8,7 @@ Procrastinate task decorators in tasks.py).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING
 
 from agent_on_demand.runtimes import Runtime
 
@@ -29,6 +29,14 @@ def build_turn_argv(runtime: Runtime, spec: SessionSpec, mode: str) -> list[str]
 
     Prompt delivery is out of band: callers attach `cmd.stdin` with the
     prompt bytes so it flows through the bash shim into the runtime CLI.
+
+    Raises ``ValueError`` if ``mode`` is anything other than ``"run"`` or
+    ``"continue"`` — runtime validation in place of a ``typing.cast`` so
+    typos surface here instead of being silently forwarded to the runtime
+    CLI (and so the mode tuple becomes a mutation-killable surface
+    rather than an unkillable type-only cast).
     """
-    argv = runtime.build_command(spec, cast(Literal["run", "continue"], mode))
+    if mode not in ("run", "continue"):
+        raise ValueError(f"mode must be 'run' or 'continue', got {mode!r}")
+    argv = runtime.build_command(spec, mode)  # type: ignore[arg-type]
     return ["bash", "-lc", _ENV_SOURCE_SHIM, "--", *argv]

--- a/tests/test_turn_argv.py
+++ b/tests/test_turn_argv.py
@@ -14,6 +14,10 @@ per-turn argv construction:
     (``"run"`` and ``"continue"`` both reach the runtime).
   - An empty ``build_command`` return → argv is exactly the 4-element
     shim with no trailing items.
+  - Any ``mode`` other than the literal lowercase ``"run"`` or
+    ``"continue"`` raises ``ValueError`` with an exact message — pins
+    the validation tuple so a mutant that uppercases or string-wraps
+    the literals dies.
 
 Tests are sync, no Django imports — required so hammett (mutmut's
 runner) can execute them. ``Runtime`` and ``SessionSpec`` are
@@ -21,6 +25,8 @@ duck-typed via ``SimpleNamespace``.
 """
 
 from types import SimpleNamespace
+
+import pytest
 
 from agent_on_demand.session_service.turn_argv import (
     _ENV_SOURCE_SHIM,
@@ -138,3 +144,54 @@ def test_spec_is_forwarded_to_build_command():
     spec = _spec()
     build_turn_argv(_runtime(argv=[], recorder=calls), spec, "run")
     assert calls[0][0] is spec
+
+
+# ---------- mode validation ----------
+#
+# These tests replace what used to be a `typing.cast(Literal[...], mode)`
+# — a runtime no-op that mutmut couldn't kill (5 known-equivalent
+# survivors). Runtime validation gives mutmut a real surface to mutate
+# (the tuple `("run", "continue")`) and gives callers a clear failure
+# at the boundary instead of an opaque downstream error.
+#
+# Exact-equality assertions on `str(exc.value)` (not `match=`) — mutmut's
+# string-wrap mutation `"XXmust be 'run'...XX"` would survive a substring
+# match. Same lesson as PR #232's CI fix.
+
+
+def test_invalid_mode_raises_value_error():
+    """A mode that isn't ``"run"`` or ``"continue"`` raises
+    ``ValueError`` before ``runtime.build_command`` is ever called."""
+    calls: list = []
+    with pytest.raises(ValueError) as exc_info:
+        build_turn_argv(_runtime(argv=["x"], recorder=calls), _spec(), "garbage")
+    assert str(exc_info.value) == "mode must be 'run' or 'continue', got 'garbage'"
+    assert calls == []
+
+
+def test_empty_string_mode_raises_value_error():
+    """An empty mode string raises ``ValueError`` — pins that the
+    validation isn't a truthiness check (``if not mode``) but a
+    membership check against the literal tuple."""
+    with pytest.raises(ValueError) as exc_info:
+        build_turn_argv(_runtime(argv=["x"]), _spec(), "")
+    assert str(exc_info.value) == "mode must be 'run' or 'continue', got ''"
+
+
+def test_uppercase_run_mode_raises_value_error():
+    """``mode="RUN"`` raises — pins the literal lowercase ``"run"``
+    in the validation tuple. Kills a mutant that uppercases the first
+    tuple entry (``("RUN", "continue")``) since ``"RUN"`` would then
+    pass through silently."""
+    with pytest.raises(ValueError) as exc_info:
+        build_turn_argv(_runtime(argv=["x"]), _spec(), "RUN")
+    assert str(exc_info.value) == "mode must be 'run' or 'continue', got 'RUN'"
+
+
+def test_uppercase_continue_mode_raises_value_error():
+    """``mode="CONTINUE"`` raises — pins the literal lowercase
+    ``"continue"`` in the validation tuple. Kills a mutant that
+    uppercases the second tuple entry (``("run", "CONTINUE")``)."""
+    with pytest.raises(ValueError) as exc_info:
+        build_turn_argv(_runtime(argv=["x"]), _spec(), "CONTINUE")
+    assert str(exc_info.value) == "mode must be 'run' or 'continue', got 'CONTINUE'"


### PR DESCRIPTION
## Summary

`turn_argv.py` had 5 documented known-equivalent surviving mutants — all 5 were mutations to the first argument of `typing.cast(Literal["run", "continue"], mode)`:

- `cast(None, mode)`
- `cast(Literal["XXrunXX", "continue"], mode)`
- `cast(Literal["RUN", "continue"], mode)`
- `cast(Literal["run", "XXcontinueXX"], mode)`
- `cast(Literal["run", "CONTINUE"], mode)`

`typing.cast(typ, val)` is a runtime no-op — it returns `val` unchanged regardless of the type expression. Those mutations all produce identical runtime behavior, so no test can ever kill them.

This PR replaces the cast with a runtime tuple check:

```python
if mode not in ("run", "continue"):
    raise ValueError(f"mode must be 'run' or 'continue', got {mode!r}")
argv = runtime.build_command(spec, mode)  # type: ignore[arg-type]
```

This trades 5 unkillable cast mutants for ~3 newly-killable mutants on the validation tuple itself (`"XXrunXX"`, `"RUN"`, `"XXcontinueXX"`, `"CONTINUE"` — each now flips a `"run"`/`"continue"` call into a raise that the new tests catch). It also adds genuine input safety: a caller passing a typo mode now fails fast at the boundary rather than silently forwarding garbage to the runtime CLI.

The `# type: ignore[arg-type]` is a comment — not a mutation surface — so mutmut leaves it alone.

## Changes

- `src/agent_on_demand/session_service/turn_argv.py`: drop `cast` + `Literal` imports, replace `cast(Literal[...], mode)` with a runtime membership check; updated docstring to document the new contract.
- `tests/test_turn_argv.py`: added 4 tests pinning the validation tuple contents and the exact error message (using `str(exc.value) == "..."` rather than `match=` regex — same lesson as PR #232's CI fix, where substring matches let `XX...XX`-wrapped mutants survive).
- `scripts/check_mutmut.py`: removed the 5 turn_argv entries from `KNOWN_EQUIVALENT` (9 → 4).

## Test plan

- [x] `make lint` — clean
- [x] `uv run pytest tests/test_turn_argv.py -v` — 12/12 pass (was 8)
- [x] Full test suite — 1121/1121 pass
- [x] `make mutation-test` — `Mutants: 1134/1138 killed, 4 survived` (4 = remaining KNOWN_EQUIVALENT entries: 2 in auth, 2 in provision_script)
- [x] All 16 `build_turn_argv` mutants now killed (verified via `mutmut show`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)