### PR TITLE
Move session_service internals onto Backend Protocol

### DIFF
--- a/src/agent_on_demand/session_service/client.py
+++ b/src/agent_on_demand/session_service/client.py
@@ -1,14 +1,24 @@
 import logging
+from functools import cache
 
 from agent_on_demand.models import UserSpritesKey
 
-from .backend import BackendClient, BackendError
+from .backend import Backend, BackendClient, BackendError
 from .errors import NoSpritesKeyError
 from .sprites_backend import SpritesBackend
 
 logger = logging.getLogger(__name__)
 
-_BACKEND = SpritesBackend()
+
+@cache
+def _backend() -> Backend:
+    """Lazily construct the backend singleton.
+
+    `SpritesBackend.__init__` applies a websocket close-timeout monkeypatch
+    on first instantiation, so we defer construction until the first
+    `get_client` call rather than running at import time.
+    """
+    return SpritesBackend()
 
 
 def get_client(user) -> BackendClient | None:
@@ -20,7 +30,7 @@ def get_client(user) -> BackendClient | None:
         token = user.sprites_key.get_api_key()
     except UserSpritesKey.DoesNotExist:
         return None
-    return _BACKEND.create_client(token)
+    return _backend().create_client(token)
 
 
 def require_client(user) -> BackendClient:

--- a/src/agent_on_demand/session_service/client.py
+++ b/src/agent_on_demand/session_service/client.py
@@ -1,17 +1,18 @@
 import logging
 
-from django.conf import settings
-from sprites import SpriteError, SpritesClient
-
 from agent_on_demand.models import UserSpritesKey
 
+from .backend import BackendClient, BackendError
 from .errors import NoSpritesKeyError
+from .sprites_backend import SpritesBackend
 
 logger = logging.getLogger(__name__)
 
+_BACKEND = SpritesBackend()
 
-def get_client(user) -> SpritesClient | None:
-    """Build a SpritesClient from the caller's stored token.
+
+def get_client(user) -> BackendClient | None:
+    """Build a backend client from the caller's stored token.
 
     Returns None when the user has no token configured.
     """
@@ -19,18 +20,18 @@ def get_client(user) -> SpritesClient | None:
         token = user.sprites_key.get_api_key()
     except UserSpritesKey.DoesNotExist:
         return None
-    return SpritesClient(token=token, base_url=settings.SPRITES_BASE_URL)
+    return _BACKEND.create_client(token)
 
 
-def require_client(user) -> SpritesClient:
+def require_client(user) -> BackendClient:
     client = get_client(user)
     if client is None:
         raise NoSpritesKeyError("No Sprites API key configured")
     return client
 
 
-def best_effort_delete(client: SpritesClient, name: str) -> None:
+def best_effort_delete(client: BackendClient, name: str) -> None:
     try:
-        client.delete_sprite(name)
-    except SpriteError:
-        logger.warning("Failed to cleanup Sprite %s", name, exc_info=True)
+        client.destroy(name)
+    except BackendError:
+        logger.warning("Failed to cleanup session %s", name, exc_info=True)

--- a/src/agent_on_demand/session_service/network_policy.py
+++ b/src/agent_on_demand/session_service/network_policy.py
@@ -3,7 +3,7 @@
 The deny-all rule must be appended *last* so allow-listed hosts take
 precedence — a reorder would silently let everything through. The pure
 construction lives here so it can be direct-tested under mutmut's
-hammett runner without pulling in the Sprite SDK or ORM dependencies
+hammett runner without pulling in the backend SDK or ORM dependencies
 that `apply_network_policy` carries.
 """
 
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sprites import NetworkPolicy, PolicyRule
+from .backend import NetworkPolicy, PolicyRule
 
 if TYPE_CHECKING:
     from agent_on_demand.models import Environment
@@ -29,4 +29,4 @@ def build_network_policy(env: "Environment | None") -> NetworkPolicy | None:
     allowed_hosts = (env.networking_config or {}).get("allowed_hosts", [])
     rules = [PolicyRule(domain=host, action="allow") for host in allowed_hosts]
     rules.append(PolicyRule(domain="*", action="deny"))
-    return NetworkPolicy(rules=rules)
+    return NetworkPolicy(rules=tuple(rules))

--- a/src/agent_on_demand/session_service/provisioning.py
+++ b/src/agent_on_demand/session_service/provisioning.py
@@ -1,7 +1,7 @@
-"""Sprite provisioning — orchestrator that creates a Sprite and dispatches to
-the per-stage helpers in `provisioning_stages.py`.
+"""Session provisioning — orchestrator that creates a backend handle and dispatches
+to the per-stage helpers in `provisioning_stages.py`.
 
-Each `sprite.command()` round trip costs ~5s of WebSocket-layer overhead
+Each backend `make_command()` round trip costs ~5s of WebSocket-layer overhead
 regardless of what it runs, so the provisioning flow is shaped to minimize
 the number of commands. See `provisioning_stages.py` for the per-stage I/O
 and `provision_script.py` for the combined bash script that folds the
@@ -12,12 +12,16 @@ from __future__ import annotations
 
 import logging
 
-from sprites import Sprite, SpriteError
-
 from agent_on_demand.observability import get_tracer
 
+from .backend import BackendError, SessionHandle
 from .client import best_effort_delete, require_client
 from .errors import ProvisionError
+
+# Transitional: catches a `SpriteError` that leaked from a stage helper
+# whose internal `try/except` did not yet wrap it. Removed once
+# runtimes (PR 3) and the threading core (PR 4) are on the Protocol.
+from .sprites_backend import SpriteError
 
 # Re-exported so call-sites in `provision_session` resolve through this
 # module's namespace — that lets tests patch e.g. `provisioning.install_runtime`
@@ -37,10 +41,10 @@ from .stage_events import STAGE_CREATE_SPRITE, stage_timer
 logger = logging.getLogger(__name__)
 
 
-def provision_session(user, spec: SessionSpec, session_id: str | None = None) -> Sprite:
-    """Create a Sprite and run all setup stages against it.
+def provision_session(user, spec: SessionSpec, session_id: str | None = None) -> SessionHandle:
+    """Create a session handle on the backend and run all setup stages against it.
 
-    On any failure the Sprite is best-effort deleted before a `ProvisionError`
+    On any failure the handle is best-effort destroyed before a `ProvisionError`
     is re-raised. Per-stage `stage_timer` events are emitted as rows in
     `AgentSessionLog` so clients can render provisioning progress via the SSE
     stream. Passing `session_id=None` disables emission (used by unit tests
@@ -64,8 +68,8 @@ def provision_session(user, spec: SessionSpec, session_id: str | None = None) ->
         try:
             with stage_timer(session_id, STAGE_CREATE_SPRITE):
                 try:
-                    sprite = client.create_sprite(spec.name)
-                except SpriteError as e:
+                    handle = client.provision(spec.name)
+                except BackendError as e:
                     raise ProvisionError(
                         f"Failed to create Sprite: {e}", stage=STAGE_CREATE_SPRITE
                     ) from e
@@ -74,38 +78,38 @@ def provision_session(user, spec: SessionSpec, session_id: str | None = None) ->
             raise
 
         try:
-            install_runtime(sprite, spec, session_id)
-            apply_network_policy(sprite, env, session_id)
-            write_env_file(sprite, spec, session_id)
-            write_git_credentials(sprite, spec.repos, session_id)
-            run_provision_setup(sprite, spec, session_id)
-            write_runtime_config(sprite, spec, session_id)
-            write_skills(sprite, spec, session_id)
+            install_runtime(handle, spec, session_id)
+            apply_network_policy(handle, env, session_id)
+            write_env_file(handle, spec, session_id)
+            write_git_credentials(handle, spec.repos, session_id)
+            run_provision_setup(handle, spec, session_id)
+            write_runtime_config(handle, spec, session_id)
+            write_skills(handle, spec, session_id)
         except ProvisionError as e:
             span.set_attribute("aod.failure_stage", e.stage)
             best_effort_delete(client, spec.name)
             raise
-        except SpriteError as e:
+        except (BackendError, SpriteError) as e:
             span.set_attribute("aod.failure_stage", "unknown")
             best_effort_delete(client, spec.name)
             raise ProvisionError(f"Failed to prepare Sprite: {e}", stage="unknown") from e
 
-        return sprite
+        return handle
 
 
-def resume_session(user, sprite_name: str) -> Sprite:
-    """Look up the Sprite backing an existing session."""
+def resume_session(user, sprite_name: str) -> SessionHandle:
+    """Look up the backend handle backing an existing session."""
     from .errors import SessionHandleNotFound
 
     client = require_client(user)
     try:
-        return client.get_sprite(sprite_name)
-    except SpriteError as e:
+        return client.get(sprite_name)
+    except BackendError as e:
         raise SessionHandleNotFound(f"Sprite not found: {e}") from e
 
 
 def destroy_session(user, sprite_name: str) -> None:
-    """Delete the Sprite. Best-effort — logs on failure but never raises."""
+    """Destroy the backend session. Best-effort — logs on failure but never raises."""
     if not sprite_name:
         return
     from .client import get_client

--- a/src/agent_on_demand/session_service/provisioning_stages.py
+++ b/src/agent_on_demand/session_service/provisioning_stages.py
@@ -1,7 +1,7 @@
 """Per-stage helpers invoked by `provision_session`.
 
 Each function corresponds to one provisioning stage and is responsible
-for emitting its `stage_timer` event and wrapping any `SpriteError` as a
+for emitting its `stage_timer` event and wrapping any `BackendError` as a
 `ProvisionError` tagged with the stage name. The orchestrator in
 `provisioning.py` owns sequencing and cleanup; everything I/O lives here.
 """
@@ -10,14 +10,20 @@ from __future__ import annotations
 
 import io
 
-from sprites import Sprite, SpriteError
-
 from agent_on_demand.models import Environment
 
+from .backend import BackendError, SessionHandle
 from .env_file import build_env_file_body
 from .errors import ProvisionError
 from .git_credentials import build_git_credentials_lines
 from .network_policy import build_network_policy
+
+# Transitional: runtime methods (`install`, `write_config`) still raise
+# native `SpriteError` because runtimes haven't ported to the Protocol
+# yet (PR 3 of the session-backend extraction). This catches that path
+# alongside `BackendError`; once runtimes are ported, the SpriteError
+# catches in `install_runtime` / `write_runtime_config` go away.
+from .sprites_backend import SpriteError
 from .provision_script import (
     ENV_FILE_PATH,
     GIT_CREDS_PATH,
@@ -48,33 +54,35 @@ __all__ = [
 ]
 
 
-def install_runtime(sprite: Sprite, spec: SessionSpec, session_id: str | None) -> None:
+def install_runtime(handle: SessionHandle, spec: SessionSpec, session_id: str | None) -> None:
     """Run per-runtime `install` hook before the network policy locks things
     down. For pre-baked runtimes (claude/codex/gemini) this is a no-op; for
     meta-runtimes that fetch binaries, internet access is required here."""
     with stage_timer(session_id, STAGE_INSTALL_RUNTIME):
         try:
-            spec.runtime.install(sprite)
-        except SpriteError as e:
+            spec.runtime.install(handle)
+        except (BackendError, SpriteError) as e:
             raise ProvisionError(
                 f"Failed to install runtime: {e}", stage=STAGE_INSTALL_RUNTIME
             ) from e
 
 
-def apply_network_policy(sprite: Sprite, env: Environment | None, session_id: str | None) -> None:
+def apply_network_policy(
+    handle: SessionHandle, env: Environment | None, session_id: str | None
+) -> None:
     policy = build_network_policy(env)
     if policy is None:
         return
     with stage_timer(session_id, STAGE_NETWORK_POLICY):
         try:
-            sprite.update_network_policy(policy)
-        except SpriteError as e:
+            handle.apply_network_policy(policy)
+        except BackendError as e:
             raise ProvisionError(
                 f"Failed to prepare Sprite: {e}", stage=STAGE_NETWORK_POLICY
             ) from e
 
 
-def write_env_file(sprite: Sprite, spec: SessionSpec, session_id: str | None) -> None:
+def write_env_file(handle: SessionHandle, spec: SessionSpec, session_id: str | None) -> None:
     """Write /tmp/aod-env (fs.write only — chmod happens in the provision
     script). The file is sourced (with `set -a`) by the per-turn dispatcher,
     so every line must be a valid KEY=value shell assignment.
@@ -92,13 +100,14 @@ def write_env_file(sprite: Sprite, spec: SessionSpec, session_id: str | None) ->
     body = build_env_file_body(spec, credentials)
     with stage_timer(session_id, STAGE_ENV_FILE):
         try:
-            fs = sprite.filesystem()
-            (fs / ENV_FILE_PATH.lstrip("/")).write_text(body)
-        except SpriteError as e:
+            handle.workspace().write_text(ENV_FILE_PATH, body)
+        except BackendError as e:
             raise ProvisionError(f"Failed to prepare Sprite: {e}", stage=STAGE_ENV_FILE) from e
 
 
-def write_git_credentials(sprite: Sprite, repos: list[RepoSpec], session_id: str | None) -> None:
+def write_git_credentials(
+    handle: SessionHandle, repos: list[RepoSpec], session_id: str | None
+) -> None:
     """Write /tmp/.git-credentials if any repo has a token (fs.write only;
     chmod + `git config credential.helper` live in the provision script)."""
     cred_lines = build_git_credentials_lines(repos)
@@ -106,35 +115,26 @@ def write_git_credentials(sprite: Sprite, repos: list[RepoSpec], session_id: str
         return
     with stage_timer(session_id, STAGE_GIT_CREDENTIALS):
         try:
-            fs = sprite.filesystem()
-            (fs / GIT_CREDS_PATH.lstrip("/")).write_text("\n".join(cred_lines) + "\n")
-        except SpriteError as e:
+            handle.workspace().write_text(GIT_CREDS_PATH, "\n".join(cred_lines) + "\n")
+        except BackendError as e:
             raise ProvisionError(
                 f"Failed to prepare Sprite: {e}", stage=STAGE_GIT_CREDENTIALS
             ) from e
 
 
-def run_provision_setup(sprite: Sprite, spec: SessionSpec, session_id: str | None) -> None:
-    """Write /tmp/aod-provision.sh and invoke it as one `sprite.command`. This
+def run_provision_setup(handle: SessionHandle, spec: SessionSpec, session_id: str | None) -> None:
+    """Write /tmp/aod-provision.sh and invoke it as one backend command. This
     is the single expensive round trip — everything shell-flavoured
     (chmod, package install, git clone, user setup) runs inside it."""
     script = build_provision_script(spec)
     with stage_timer(session_id, STAGE_PROVISION_SETUP):
+        err_buf = io.BytesIO()
         try:
-            fs = sprite.filesystem()
-            (fs / PROVISION_SCRIPT_PATH.lstrip("/")).write_text(script)
-            err_buf = io.BytesIO()
-            cmd = sprite.command("bash", "-l", PROVISION_SCRIPT_PATH)
-            # Capture stderr so a failure message carries useful context
-            # (apt errors, git errors, user-setup stderr). Best-effort: if
-            # the Sprite SDK doesn't support the assignment, the attribute
-            # is silently ignored and err_buf stays empty.
-            try:
-                cmd.stderr = err_buf
-            except AttributeError:
-                pass
+            handle.workspace().write_text(PROVISION_SCRIPT_PATH, script)
+            cmd = handle.make_command("bash", "-l", PROVISION_SCRIPT_PATH)
+            cmd.set_output(stdout=io.BytesIO(), stderr=err_buf)
             cmd.run()
-        except SpriteError as e:
+        except BackendError as e:
             stderr_tail = err_buf.getvalue().decode("utf-8", errors="replace")[-2000:]
             detail = f"Provisioning script failed: {e}"
             if stderr_tail.strip():
@@ -143,7 +143,7 @@ def run_provision_setup(sprite: Sprite, spec: SessionSpec, session_id: str | Non
 
 
 def write_runtime_config(
-    sprite: Sprite,
+    handle: SessionHandle,
     spec: SessionSpec,
     session_id: str | None,
 ) -> None:
@@ -153,24 +153,24 @@ def write_runtime_config(
     nothing to say."""
     with stage_timer(session_id, STAGE_RUNTIME_CONFIG):
         try:
-            spec.runtime.write_config(sprite, spec, spec.mcp_servers)
-        except SpriteError as e:
+            spec.runtime.write_config(handle, spec, spec.mcp_servers)
+        except (BackendError, SpriteError) as e:
             raise ProvisionError(
                 f"Failed to write runtime config: {e}", stage=STAGE_RUNTIME_CONFIG
             ) from e
 
 
 def write_skills(
-    sprite: Sprite,
+    handle: SessionHandle,
     spec: SessionSpec,
     session_id: str | None,
 ) -> None:
-    """Materialize skills onto the Sprite.
+    """Materialize skills onto the backend session.
 
-    Inline skills are written directly with ``sprite.filesystem()``.
+    Inline skills are written directly with ``handle.workspace()``.
     Github-source skills are installed via the
     `skills.sh <https://skills.sh>`_ CLI (``npx -y skills@latest add ...``)
-    which the Sprite has network access for at this point in provisioning.
+    which the session has network access for at this point in provisioning.
 
     Runtimes whose ``skills_root`` is ``None`` skip inline writes; runtimes
     without a ``skills_sh_agent`` skip github installs.
@@ -184,18 +184,18 @@ def write_skills(
         try:
             root = spec.runtime.skills_root
             if inline and root is not None:
-                fs = sprite.filesystem()
+                fs = handle.workspace()
                 for s in inline:
                     # Inline skills must have a name (validated upstream).
                     assert s.name is not None
                     assert s.content is not None
                     dir_path = f"{root}/{s.name}"
-                    (fs / f"{dir_path.lstrip('/')}/SKILL.md").write_text(s.content)
+                    fs.write_text(f"{dir_path}/SKILL.md", s.content)
             agent_id = spec.runtime.skills_sh_agent
             if github and agent_id is not None:
                 for s in github:
                     assert s.source is not None
                     cmd = build_skills_install_command(s.source, agent_id, s.name)
-                    sprite.command("bash", "-lc", cmd).run()
-        except SpriteError as e:
+                    handle.make_command("bash", "-lc", cmd).run()
+        except BackendError as e:
             raise ProvisionError(f"Failed to write skills: {e}", stage=STAGE_SKILLS) from e

--- a/src/agent_on_demand/session_service/provisioning_stages.py
+++ b/src/agent_on_demand/session_service/provisioning_stages.py
@@ -60,7 +60,12 @@ def install_runtime(handle: SessionHandle, spec: SessionSpec, session_id: str | 
     meta-runtimes that fetch binaries, internet access is required here."""
     with stage_timer(session_id, STAGE_INSTALL_RUNTIME):
         try:
-            spec.runtime.install(handle)
+            # Runtime methods still type their arg as `Sprite` until PR 3
+            # of the session-backend extraction. The recording fake and
+            # the production sprite both expose the legacy shape, so the
+            # call works at runtime; the `type: ignore` lifts when
+            # runtimes accept `SessionHandle`.
+            spec.runtime.install(handle)  # type: ignore[arg-type]
         except (BackendError, SpriteError) as e:
             raise ProvisionError(
                 f"Failed to install runtime: {e}", stage=STAGE_INSTALL_RUNTIME
@@ -153,7 +158,9 @@ def write_runtime_config(
     nothing to say."""
     with stage_timer(session_id, STAGE_RUNTIME_CONFIG):
         try:
-            spec.runtime.write_config(handle, spec, spec.mcp_servers)
+            # Same `type: ignore` story as `install_runtime` above —
+            # lifts in PR 3 when runtimes accept `SessionHandle`.
+            spec.runtime.write_config(handle, spec, spec.mcp_servers)  # type: ignore[arg-type]
         except (BackendError, SpriteError) as e:
             raise ProvisionError(
                 f"Failed to write runtime config: {e}", stage=STAGE_RUNTIME_CONFIG

--- a/src/agent_on_demand/session_service/sprites_backend.py
+++ b/src/agent_on_demand/session_service/sprites_backend.py
@@ -31,6 +31,15 @@ from .backend import (
     WorkspaceFS,
 )
 
+# Re-exported for callers that still need to catch sprites-native
+# exceptions during the PR 2 → PR 4 transition. `tasks.py` catches
+# `ExecError` from the threading core (PR 4 scope); `provisioning_stages.py`
+# catches `SpriteError` from `runtime.install` / `runtime.write_config`
+# until those runtimes port to the Protocol (PR 3). Removed once those
+# call paths are on the Protocol.
+ExecError = sprites.ExecError
+SpriteError = sprites.SpriteError
+
 
 _PATCH_MARKER = "_aod_close_timeout_patched"
 

--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -37,7 +37,6 @@ from django.contrib.auth import get_user_model
 from django.db import close_old_connections
 from django.utils import timezone
 from procrastinate.contrib.django import app as procrastinate_app
-from sprites import ExecError
 
 from agent_on_demand.models import (
     AgentSession,
@@ -49,6 +48,7 @@ from agent_on_demand.observability import get_tracer
 from .errors import NoSpritesKeyError, ProvisionError, SessionHandleNotFound
 from .provisioning import destroy_session, provision_session, resume_session
 from .spec_factory import build_spec_for_session
+from .sprites_backend import ExecError
 from .stage_events import STAGE_RUNTIME_START, emit_stage_event
 from .turn_argv import build_turn_argv
 from .turn_outcome import compute_final_status

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,11 +11,15 @@ def client():
 
 @pytest.fixture
 def fake_sprites(mocker):
-    """Swap the real SpritesClient for a recording fake, run the provision
+    """Swap the real backend client for a recording fake, run the provision
     task inline, and stub the per-turn task enqueue.
 
     Returns the RecordingSpritesClient; use `.last_sprite()` or `.sprites`
     to reach the RecordingSprite(s) created by the test under inspection.
+    The fake satisfies both the legacy sprites SDK shape and the
+    `BackendClient` Protocol so existing tests (which patch
+    `delete_sprite` etc.) keep working alongside production callers that
+    now go through the Protocol.
 
     `provision_session_task.defer` is patched to execute the task body
     synchronously against the fake client. That keeps HTTP-layer tests
@@ -44,4 +48,26 @@ def fake_sprites(mocker):
 
     mocker.patch.object(provision_session_task, "defer", side_effect=_inline_provision)
     mocker.patch.object(destroy_session_task, "defer", side_effect=_inline_destroy)
+    return fake
+
+
+@pytest.fixture
+def fake_backend(mocker):
+    """Backend-Protocol-only fake for tests that exercise the new
+    `BackendClient` / `SessionHandle` shape directly.
+
+    Returns the `RecordingBackendClient` patched in for `get_client`.
+    `tasks.py` still calls sprites-specific methods on its sprite handle
+    (the threading core moves to the Protocol in PR 4 of the
+    session-backend extraction), so this fixture intentionally does NOT
+    inline-run `provision_session_task` / `destroy_session_task` — use
+    `fake_sprites` for tests that drive the full task path. Use
+    `fake_backend` for tests that call `provision_session` /
+    `destroy_session` directly and want pure-Protocol assertions.
+    """
+    from tests.fakes.backend import RecordingBackendClient
+
+    fake = RecordingBackendClient()
+    mocker.patch("agent_on_demand.session_service.client.get_client", return_value=fake)
+    mocker.patch("agent_on_demand.session_service.get_client", return_value=fake)
     return fake

--- a/tests/fakes/sprite.py
+++ b/tests/fakes/sprite.py
@@ -113,6 +113,11 @@ class _BackendCommandAdapter:
         pass
 
     def set_output(self, stdout: BinaryIO, stderr: BinaryIO) -> None:
+        # The legacy `_CommandHandle` only models stderr capture (the only
+        # field the existing `raise_on(..., stderr=...)` predicate writes
+        # to). stdout is recorded as argv via `RecordedCommand.argv` in
+        # the recorder; passing a real stdout buffer here is harmless but
+        # nothing populates it. Production always passes `io.BytesIO()`.
         self._handle.stderr = stderr
 
     def run(self) -> int:

--- a/tests/fakes/sprite.py
+++ b/tests/fakes/sprite.py
@@ -5,12 +5,32 @@ service over WebSockets. For unit tests we don't care about the transport; we
 care that `provision_session` invoked the right sequence of commands and wrote
 the right files. These fakes capture every call and expose lists the tests can
 assert against.
+
+After PR 2 of the session-backend extraction, callers in `session_service/`
+go through the `BackendClient` / `SessionHandle` Protocols instead of the
+sprites SDK directly. To keep existing tests asserting on
+`fake_sprites.last_sprite().write_map()` / `command_strings()` working,
+`RecordingSpritesClient` and `RecordingSprite` also implement the Protocol
+surface — `provision`/`get`/`destroy`/`close` on the client,
+`workspace`/`make_command`/`apply_network_policy` on the sprite — and
+translate `SpriteError` to `BackendError` so production exception handling
+(which expects `BackendError`) catches recorded test failures.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, BinaryIO
+
+from sprites import SpriteError
+
+from agent_on_demand.session_service.backend import (
+    BackendError,
+    Command,
+    NetworkPolicy,
+    SessionHandle,
+    WorkspaceFS,
+)
 
 
 @dataclass
@@ -77,8 +97,65 @@ class _CommandHandle:
         self._recorder._maybe_raise(self._argv, stderr_buf=self.stderr)
 
 
+class _BackendCommandAdapter:
+    """`Command` Protocol adapter over `_CommandHandle`.
+
+    Translates `SpriteError` from `_CommandHandle.run()` to `BackendError`
+    so production code (which catches `BackendError`) can drive the
+    recording fake unchanged.
+    """
+
+    def __init__(self, handle: _CommandHandle) -> None:
+        self._handle = handle
+
+    def set_input(self, data: bytes) -> None:
+        # Not asserted on by any current test; recorded form is the argv.
+        pass
+
+    def set_output(self, stdout: BinaryIO, stderr: BinaryIO) -> None:
+        self._handle.stderr = stderr
+
+    def run(self) -> int:
+        try:
+            self._handle.run()
+        except SpriteError as e:
+            raise BackendError(str(e)) from e
+        return 0
+
+
+class _BackendWorkspaceAdapter:
+    """`WorkspaceFS` Protocol adapter over `_Filesystem`.
+
+    `write_text(path, content)` is translated into the existing
+    `(fs / path).write_text(content)` call so `raise_on_write` predicates
+    fire the same way they did in PR 1.
+    """
+
+    def __init__(self, fs: _Filesystem) -> None:
+        self._fs = fs
+
+    def write_text(self, path: str, content: str) -> None:
+        try:
+            (self._fs / path.lstrip("/")).write_text(content)
+        except SpriteError as e:
+            raise BackendError(str(e)) from e
+
+    def chmod(self, path: str, mode: int) -> None:
+        # No-op — current tests don't observe chmod calls; the real
+        # provisioning script does its chmods inside the bash script.
+        pass
+
+
 class RecordingSprite:
-    """Drop-in replacement for sprites.Sprite in unit tests."""
+    """Drop-in replacement for sprites.Sprite in unit tests.
+
+    Implements both the legacy sprites SDK shape (`filesystem()`,
+    `command()`, `update_network_policy()`) and the `SessionHandle`
+    Protocol shape (`workspace()`, `make_command()`,
+    `apply_network_policy()`). The two surfaces share underlying
+    recording state so tests can assert on `writes` / `commands` /
+    `policies` regardless of which surface drove the call.
+    """
 
     def __init__(self, name: str):
         self.name = name
@@ -86,6 +163,9 @@ class RecordingSprite:
         self.commands: list[RecordedCommand] = []
         self.policies: list[Any] = []
         self._raise_on_predicates: list[tuple] = []
+
+    # Legacy sprites SDK shape — runtimes still call these in PR 2;
+    # PR 3 will switch them to the SessionHandle methods below.
 
     def filesystem(self) -> _Filesystem:
         return self._fs
@@ -96,6 +176,25 @@ class RecordingSprite:
     def update_network_policy(self, policy: Any) -> None:
         self.policies.append(policy)
         self._maybe_raise(("update_network_policy",))
+
+    # SessionHandle Protocol shape.
+
+    def workspace(self) -> WorkspaceFS:
+        return _BackendWorkspaceAdapter(self._fs)
+
+    def make_command(
+        self,
+        *args: str,
+        cwd: str | None = None,
+        timeout: float | None = None,
+    ) -> Command:
+        return _BackendCommandAdapter(_CommandHandle(self, tuple(args)))
+
+    def apply_network_policy(self, policy: NetworkPolicy) -> None:
+        try:
+            self.update_network_policy(policy)
+        except SpriteError as e:
+            raise BackendError(str(e)) from e
 
     @property
     def writes(self) -> list[RecordedWrite]:
@@ -153,13 +252,22 @@ class RecordingSprite:
 
 
 class RecordingSpritesClient:
-    """Drop-in replacement for sprites.SpritesClient."""
+    """Drop-in replacement for sprites.SpritesClient.
+
+    Implements both the legacy sprites SDK shape (`create_sprite`,
+    `get_sprite`, `delete_sprite`) and the `BackendClient` Protocol shape
+    (`provision`, `get`, `destroy`, `close`). Protocol methods translate
+    `SpriteError` to `BackendError` to match production exception handling.
+    """
 
     def __init__(self):
         self.sprites: dict[str, RecordingSprite] = {}
         self.created: list[str] = []
         self.deleted: list[str] = []
         self._create_error: Exception | None = None
+
+    # Legacy sprites SDK shape — used by tests that arrange test doubles via
+    # `mocker.patch.object(fake_sprites, "delete_sprite", ...)`.
 
     def create_sprite(self, name: str) -> RecordingSprite:
         self.created.append(name)
@@ -178,6 +286,29 @@ class RecordingSpritesClient:
 
     def delete_sprite(self, name: str) -> None:
         self.deleted.append(name)
+
+    # BackendClient Protocol shape.
+
+    def provision(self, name: str) -> SessionHandle:
+        try:
+            return self.create_sprite(name)
+        except SpriteError as e:
+            raise BackendError(str(e)) from e
+
+    def get(self, name: str) -> SessionHandle:
+        try:
+            return self.get_sprite(name)
+        except SpriteError as e:
+            raise BackendError(str(e)) from e
+
+    def destroy(self, name: str) -> None:
+        try:
+            self.delete_sprite(name)
+        except SpriteError as e:
+            raise BackendError(str(e)) from e
+
+    def close(self) -> None:
+        pass
 
     def raise_on_create(self, exc: Exception) -> None:
         self._create_error = exc

--- a/tests/test_fake_backend.py
+++ b/tests/test_fake_backend.py
@@ -181,3 +181,27 @@ def test_apply_network_policy_can_be_made_to_raise_once():
     # Second call succeeds.
     handle.apply_network_policy(NetworkPolicy(rules=[]))
     assert len(handle.network_policies) == 1
+
+
+@pytest.mark.django_db
+def test_destroy_session_round_trip_through_fake_backend(fake_backend):
+    """End-to-end round-trip via the new `fake_backend` fixture: a
+    `BackendClient` Protocol-only fake plugged in for `get_client`
+    drives `destroy_session` and the deletion is recorded.
+
+    `provision_session` itself is not exercised here because the
+    runtime-touching stages still expect the legacy sprite SDK shape
+    (PR 3 will port them); this round-trip pins the parts of the
+    Protocol that PR 2 already drives end-to-end."""
+    from django.contrib.auth.models import User
+
+    from agent_on_demand.models import UserSpritesKey
+    from agent_on_demand.session_service.provisioning import destroy_session
+
+    user = User.objects.create_user(username="bk-rt", password="p")
+    usk = UserSpritesKey(user=user)
+    usk.set_api_key("token")
+    usk.save()
+
+    destroy_session(user, "session-xyz")
+    assert fake_backend.deleted == ["session-xyz"]

--- a/tests/test_network_policy.py
+++ b/tests/test_network_policy.py
@@ -19,8 +19,7 @@ runner) can execute them. ``Environment`` is duck-typed via
 
 from types import SimpleNamespace
 
-from sprites import NetworkPolicy, PolicyRule
-
+from agent_on_demand.session_service.backend import NetworkPolicy, PolicyRule
 from agent_on_demand.session_service.network_policy import build_network_policy
 
 
@@ -63,11 +62,11 @@ def test_limited_returns_network_policy_instance():
 def test_limited_with_two_allowed_hosts_emits_three_rules_in_order():
     env = _env(networking_config={"allowed_hosts": ["github.com", "pypi.org"]})
     policy = build_network_policy(env)
-    assert policy.rules == [
+    assert policy.rules == (
         PolicyRule(domain="github.com", action="allow"),
         PolicyRule(domain="pypi.org", action="allow"),
         PolicyRule(domain="*", action="deny"),
-    ]
+    )
 
 
 def test_limited_preserves_input_order_of_allowed_hosts():
@@ -81,10 +80,10 @@ def test_limited_preserves_input_order_of_allowed_hosts():
 def test_limited_with_one_allowed_host_emits_two_rules():
     env = _env(networking_config={"allowed_hosts": ["api.anthropic.com"]})
     policy = build_network_policy(env)
-    assert policy.rules == [
+    assert policy.rules == (
         PolicyRule(domain="api.anthropic.com", action="allow"),
         PolicyRule(domain="*", action="deny"),
-    ]
+    )
 
 
 # ---------- empty / missing allowed_hosts ----------
@@ -93,19 +92,19 @@ def test_limited_with_one_allowed_host_emits_two_rules():
 def test_limited_with_empty_allowed_hosts_emits_only_deny():
     env = _env(networking_config={"allowed_hosts": []})
     policy = build_network_policy(env)
-    assert policy.rules == [PolicyRule(domain="*", action="deny")]
+    assert policy.rules == (PolicyRule(domain="*", action="deny"),)
 
 
 def test_limited_with_none_networking_config_emits_only_deny():
     env = _env(networking_config=None)
     policy = build_network_policy(env)
-    assert policy.rules == [PolicyRule(domain="*", action="deny")]
+    assert policy.rules == (PolicyRule(domain="*", action="deny"),)
 
 
 def test_limited_with_empty_networking_config_emits_only_deny():
     env = _env(networking_config={})
     policy = build_network_policy(env)
-    assert policy.rules == [PolicyRule(domain="*", action="deny")]
+    assert policy.rules == (PolicyRule(domain="*", action="deny"),)
 
 
 # ---------- final rule is always *-deny ----------
@@ -164,10 +163,10 @@ def test_allow_rules_carry_host_as_domain():
 def test_wildcard_allow_host_passes_through():
     env = _env(networking_config={"allowed_hosts": ["*.github.com"]})
     policy = build_network_policy(env)
-    assert policy.rules == [
+    assert policy.rules == (
         PolicyRule(domain="*.github.com", action="allow"),
         PolicyRule(domain="*", action="deny"),
-    ]
+    )
 
 
 # ---------- rule count invariants ----------

--- a/tests/test_networking_wiring.py
+++ b/tests/test_networking_wiring.py
@@ -3,7 +3,9 @@ import json
 import pytest
 from django.contrib.auth.models import User
 from django.test import Client
-from sprites import NetworkPolicy, PolicyRule, SpriteError
+from sprites import SpriteError
+
+from agent_on_demand.session_service.backend import NetworkPolicy, PolicyRule
 
 from agent_on_demand.models import (
     Agent,
@@ -107,11 +109,11 @@ class TestSessionNetworkingIntegration:
         assert len(sprite.policies) == 1
         policy = sprite.policies[0]
         assert isinstance(policy, NetworkPolicy)
-        assert policy.rules == [
+        assert policy.rules == (
             PolicyRule(domain="api.anthropic.com", action="allow"),
             PolicyRule(domain="*.github.com", action="allow"),
             PolicyRule(domain="*", action="deny"),
-        ]
+        )
 
     def test_unrestricted_networking_skips_policy_call(
         self, client: Client, auth_headers, runtime_key, user, agent, fake_sprites
@@ -204,4 +206,4 @@ class TestSessionNetworkingIntegration:
 
         sprite = fake_sprites.last_sprite()
         assert len(sprite.policies) == 1
-        assert sprite.policies[0].rules == [PolicyRule(domain="*", action="deny")]
+        assert sprite.policies[0].rules == (PolicyRule(domain="*", action="deny"),)


### PR DESCRIPTION
## Summary

PR 2 of the session-backend extraction plan
(`thoughts/plans/2026-04-27-session-backend-extraction.md`). Ports
`session_service/{client,provisioning,provisioning_stages,network_policy}.py`
off direct `sprites.*` imports onto the Protocol introduced in #245.
SpritesBackend stays the only impl; behavior is identical.

## Grep invariant

```
$ grep -rn "from sprites" src/agent_on_demand/session_service/
src/agent_on_demand/session_service/backend.py:5:through these types — direct `from sprites import` is confined to
```

Only the docstring hit in `backend.py`. The lone real `import sprites` lives in `sprites_backend.py`.

## What's in the diff

- `client.py`: `get_client(user)` returns a `BackendClient` (constructs `SpritesBackend(...).create_client(token)` internally). `best_effort_delete` swallows `BackendError`.
- `provisioning.py`: `provision_session` returns `SessionHandle`; calls `client.provision/get/destroy`. Catches `BackendError` and (transitionally) `SpriteError` for the catch-all unwrapped-leak path.
- `provisioning_stages.py`: stages take `SessionHandle`; use `handle.workspace().write_text` / `handle.make_command` / `handle.apply_network_policy`. `install_runtime` and `write_runtime_config` keep a transitional `SpriteError` catch alongside `BackendError` because runtimes haven't ported yet (PR 3 scope).
- `network_policy.py`: imports `NetworkPolicy` / `PolicyRule` from `.backend`. Returns frozen-tuple rules.
- `sprites_backend.py`: re-exports `ExecError` (for `tasks.py`, removed in PR 4) and `SpriteError` (for the transitional catches above, removed in PR 3/4).
- `tasks.py`: drops `from sprites import ExecError` in favor of the re-export from `sprites_backend`.

## Test plan

- [x] `make lint`
- [x] `make test` — 1160 passed (1159 existing + 1 new `fake_backend` round-trip)
- [x] `make mutation-test` — 1135/1139 killed, 4 known-equivalents
- [x] grep invariant verified

## Test surface changes

`tests/fakes/sprite.py` now also implements the `BackendClient` / `SessionHandle` Protocols (`provision`/`get`/`destroy`/`close` on the client; `workspace`/`make_command`/`apply_network_policy` on the sprite) and translates `SpriteError` → `BackendError` so production exception handling drives the recording fake unchanged.

`tests/conftest.py` adds a `fake_backend` fixture using `FakeBackend` from `tests/fakes/backend.py` (landed in #245). The fixture is intentionally minimal — `tasks.py` still calls sprites-specific methods on its sprite handle (the threading core moves to the Protocol in PR 4), so the Protocol-only fake would `AttributeError` if used in the inline-task path.

`tests/test_network_policy.py` and `tests/test_networking_wiring.py` get a one-line import swap (sprites → backend Protocol) plus tuple-comparison adjustment for `policy.rules` (frozen tuple per #245's review fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)