### PR TITLE
Move runtimes onto SessionHandle

### DIFF
--- a/src/agent_on_demand/runtimes/base.py
+++ b/src/agent_on_demand/runtimes/base.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal, Protocol
 
 if TYPE_CHECKING:
-    from sprites import Sprite
-
+    from agent_on_demand.session_service.backend import SessionHandle
     from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
 
 
@@ -14,14 +13,14 @@ class Runtime(Protocol):
     skills_root: str | None  # absolute path on Sprite for SKILL.md files, or None to disable
     skills_sh_agent: str | None  # `--agent` id for `npx skills add`, or None if unsupported
 
-    def install(self, sprite: Sprite) -> None:
-        """Install the runtime CLI on the Sprite. No-op if pre-installed in the base image."""
+    def install(self, handle: SessionHandle) -> None:
+        """Install the runtime CLI on the session. No-op if pre-installed in the base image."""
 
     def build_command(self, spec: SessionSpec, mode: Literal["run", "continue"]) -> list[str]:
         """Argv for the per-turn command. Prompt arrives via stdin."""
 
     def write_config(
-        self, sprite: Sprite, spec: SessionSpec, mcp_servers: list[McpServerSpec]
+        self, handle: SessionHandle, spec: SessionSpec, mcp_servers: list[McpServerSpec]
     ) -> None:
-        """Write any per-runtime config files on the Sprite. Always called at provision time,
+        """Write any per-runtime config files on the session. Always called at provision time,
         even when mcp_servers is empty."""

--- a/src/agent_on_demand/runtimes/claude.py
+++ b/src/agent_on_demand/runtimes/claude.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Literal
 
-from sprites import Sprite
-
 from agent_on_demand.runtimes.claude_command import build_claude_command
 from agent_on_demand.runtimes.claude_config import render_claude_mcp_config
 
 if TYPE_CHECKING:
+    from agent_on_demand.session_service.backend import SessionHandle
     from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
 
 
@@ -25,7 +24,7 @@ class ClaudeRuntime:
     skills_root: str | None = "/home/sprite/.claude/skills"
     skills_sh_agent: str | None = "claude-code"
 
-    def install(self, sprite: Sprite) -> None:
+    def install(self, handle: "SessionHandle") -> None:
         return None
 
     def build_command(self, spec: "SessionSpec", mode: Literal["run", "continue"]) -> list[str]:
@@ -33,12 +32,14 @@ class ClaudeRuntime:
 
     def write_config(
         self,
-        sprite: Sprite,
+        handle: "SessionHandle",
         spec: "SessionSpec",
         mcp_servers: list["McpServerSpec"],
     ) -> None:
         config = render_claude_mcp_config(mcp_servers)
         if config is None:
             return
-        fs = sprite.filesystem()
-        (fs / "home/sprite/.claude.json").write_text(json.dumps({"mcpServers": config}, indent=2))
+        handle.workspace().write_text(
+            "/home/sprite/.claude.json",
+            json.dumps({"mcpServers": config}, indent=2),
+        )

--- a/src/agent_on_demand/runtimes/codex.py
+++ b/src/agent_on_demand/runtimes/codex.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
 
-from sprites import Sprite
-
 from agent_on_demand.runtimes.codex_command import build_codex_command
 from agent_on_demand.runtimes.codex_config import render_codex_mcp_config
 
 if TYPE_CHECKING:
+    from agent_on_demand.session_service.backend import SessionHandle
     from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
 
 
@@ -19,7 +18,7 @@ class CodexRuntime:
     skills_root: str | None = "/home/sprite/.codex/skills"
     skills_sh_agent: str | None = "codex"
 
-    def install(self, sprite: Sprite) -> None:
+    def install(self, handle: "SessionHandle") -> None:
         return None
 
     def build_command(self, spec: "SessionSpec", mode: Literal["run", "continue"]) -> list[str]:
@@ -27,7 +26,7 @@ class CodexRuntime:
 
     def write_config(
         self,
-        sprite: Sprite,
+        handle: "SessionHandle",
         spec: "SessionSpec",
         mcp_servers: list["McpServerSpec"],
     ) -> None:
@@ -39,5 +38,4 @@ class CodexRuntime:
         if not mcp_servers:
             return
         body = render_codex_mcp_config(mcp_servers)
-        fs = sprite.filesystem()
-        (fs / "home/sprite/.codex/config.toml").write_text(body)
+        handle.workspace().write_text("/home/sprite/.codex/config.toml", body)

--- a/src/agent_on_demand/runtimes/gemini.py
+++ b/src/agent_on_demand/runtimes/gemini.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Literal
 
-from sprites import Sprite
-
 from agent_on_demand.runtimes.gemini_command import build_gemini_command
 from agent_on_demand.runtimes.gemini_config import render_gemini_mcp_config
 
 if TYPE_CHECKING:
+    from agent_on_demand.session_service.backend import SessionHandle
     from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
 
 
@@ -20,7 +19,7 @@ class GeminiRuntime:
     skills_root: str | None = "/home/sprite/.gemini/skills"
     skills_sh_agent: str | None = "gemini-cli"
 
-    def install(self, sprite: Sprite) -> None:
+    def install(self, handle: "SessionHandle") -> None:
         return None
 
     def build_command(self, spec: "SessionSpec", mode: Literal["run", "continue"]) -> list[str]:
@@ -28,14 +27,14 @@ class GeminiRuntime:
 
     def write_config(
         self,
-        sprite: Sprite,
+        handle: "SessionHandle",
         spec: "SessionSpec",
         mcp_servers: list["McpServerSpec"],
     ) -> None:
         config = render_gemini_mcp_config(mcp_servers)
         if config is None:
             return
-        fs = sprite.filesystem()
-        (fs / "home/sprite/.gemini/settings.json").write_text(
-            json.dumps({"mcpServers": config}, indent=2)
+        handle.workspace().write_text(
+            "/home/sprite/.gemini/settings.json",
+            json.dumps({"mcpServers": config}, indent=2),
         )

--- a/src/agent_on_demand/runtimes/opencode.py
+++ b/src/agent_on_demand/runtimes/opencode.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Literal
 
-from sprites import Sprite
-
 from agent_on_demand.runtimes.opencode_command import build_opencode_command
 from agent_on_demand.runtimes.opencode_config import render_opencode_mcp_config
 
 if TYPE_CHECKING:
+    from agent_on_demand.session_service.backend import SessionHandle
     from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
 
 
@@ -35,22 +34,22 @@ class OpencodeRuntime:
     skills_root: str | None = "/home/sprite/.config/opencode/skills"
     skills_sh_agent: str | None = "opencode"
 
-    def install(self, sprite: Sprite) -> None:
-        sprite.command("bash", "-lc", f"npm install -g opencode-ai@{OPENCODE_VERSION}").run()
+    def install(self, handle: "SessionHandle") -> None:
+        handle.make_command("bash", "-lc", f"npm install -g opencode-ai@{OPENCODE_VERSION}").run()
 
     def build_command(self, spec: "SessionSpec", mode: Literal["run", "continue"]) -> list[str]:
         return build_opencode_command(spec, mode)
 
     def write_config(
         self,
-        sprite: Sprite,
+        handle: "SessionHandle",
         spec: "SessionSpec",
         mcp_servers: list["McpServerSpec"],
     ) -> None:
         config = render_opencode_mcp_config(mcp_servers)
         if config is None:
             return
-        fs = sprite.filesystem()
-        (fs / "home/sprite/.config/opencode/opencode.json").write_text(
-            json.dumps({"mcp": config}, indent=2)
+        handle.workspace().write_text(
+            "/home/sprite/.config/opencode/opencode.json",
+            json.dumps({"mcp": config}, indent=2),
         )

--- a/src/agent_on_demand/session_service/provisioning_stages.py
+++ b/src/agent_on_demand/session_service/provisioning_stages.py
@@ -18,11 +18,11 @@ from .errors import ProvisionError
 from .git_credentials import build_git_credentials_lines
 from .network_policy import build_network_policy
 
-# Transitional: runtime methods (`install`, `write_config`) still raise
-# native `SpriteError` because runtimes haven't ported to the Protocol
-# yet (PR 3 of the session-backend extraction). This catches that path
-# alongside `BackendError`; once runtimes are ported, the SpriteError
-# catches in `install_runtime` / `write_runtime_config` go away.
+# Defensive: runtime methods now route through the `SessionHandle` Protocol,
+# which translates `SpriteError` to `BackendError` at the adapter boundary.
+# The `SpriteError` catch is retained as a safety net — tests assert that
+# a `SpriteError` raised directly by a mocked runtime impl is still tagged
+# with the correct provisioning stage.
 from .sprites_backend import SpriteError
 from .provision_script import (
     ENV_FILE_PATH,
@@ -60,12 +60,7 @@ def install_runtime(handle: SessionHandle, spec: SessionSpec, session_id: str | 
     meta-runtimes that fetch binaries, internet access is required here."""
     with stage_timer(session_id, STAGE_INSTALL_RUNTIME):
         try:
-            # Runtime methods still type their arg as `Sprite` until PR 3
-            # of the session-backend extraction. The recording fake and
-            # the production sprite both expose the legacy shape, so the
-            # call works at runtime; the `type: ignore` lifts when
-            # runtimes accept `SessionHandle`.
-            spec.runtime.install(handle)  # type: ignore[arg-type]
+            spec.runtime.install(handle)
         except (BackendError, SpriteError) as e:
             raise ProvisionError(
                 f"Failed to install runtime: {e}", stage=STAGE_INSTALL_RUNTIME
@@ -158,9 +153,7 @@ def write_runtime_config(
     nothing to say."""
     with stage_timer(session_id, STAGE_RUNTIME_CONFIG):
         try:
-            # Same `type: ignore` story as `install_runtime` above —
-            # lifts in PR 3 when runtimes accept `SessionHandle`.
-            spec.runtime.write_config(handle, spec, spec.mcp_servers)  # type: ignore[arg-type]
+            spec.runtime.write_config(handle, spec, spec.mcp_servers)
         except (BackendError, SpriteError) as e:
             raise ProvisionError(
                 f"Failed to write runtime config: {e}", stage=STAGE_RUNTIME_CONFIG

--- a/tests/runtimes/test_codex.py
+++ b/tests/runtimes/test_codex.py
@@ -108,7 +108,7 @@ def test_write_config_empty_mcp_servers_writes_nothing(user):
 def test_install_is_a_no_op():
     """The Codex CLI is preinstalled in the runtime image, so .install() must
     do nothing — adding work here would silently slow every session start."""
-    assert CodexRuntime().install(sprite=None) is None
+    assert CodexRuntime().install(handle=None) is None
 
 
 @pytest.mark.django_db

--- a/tests/runtimes/test_gemini.py
+++ b/tests/runtimes/test_gemini.py
@@ -97,7 +97,7 @@ def test_write_config_empty_mcp_servers_writes_nothing(user):
 def test_install_is_a_no_op():
     """The Gemini CLI is preinstalled in the runtime image, so .install() must
     do nothing — adding work here would silently slow every session start."""
-    assert GeminiRuntime().install(sprite=None) is None
+    assert GeminiRuntime().install(handle=None) is None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

PR 3 of the session-backend extraction plan
(`thoughts/plans/2026-04-27-session-backend-extraction.md`, lines ~143–172).

- The five runtime classes (`base.py`, `claude.py`, `codex.py`, `gemini.py`,
  `opencode.py`) now type their `install` / `write_config` parameter as
  `SessionHandle` instead of `Sprite`. Bodies route through
  `handle.workspace().write_text(...)` and
  `handle.make_command(...).run()` — no more `sprite.filesystem()` /
  `sprite.command()`. The argument is renamed `handle` to match the
  `session_service/provisioning_stages.py` style adopted in PR 2.
- The `# type: ignore[arg-type]` comments PR 2 added at the runtime
  hand-off in `provisioning_stages.py` are gone. The `SpriteError`
  fall-through catches stay as a defensive safety net — covered by
  `test_session_service.py::test_install_runtime_sprite_error_tags_stage`
  which patches a runtime impl to raise `SpriteError` directly.

## Grep invariant

```
$ grep -rn "from sprites" src/agent_on_demand/runtimes/
(empty)
```

## Test plan

- [x] `make lint`
- [x] `make test` — 1160 passed (two test kwargs `install(sprite=None)` →
  `install(handle=None)` updated to follow the rename)
- [x] `make mutation-test` — 1135/1139 killed, no new survivors

🤖 Generated with [Claude Code](https://claude.com/claude-code)