### PR TITLE
Move _execute_turn_body onto SessionHandle

### DIFF
--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -48,7 +48,6 @@ from agent_on_demand.observability import get_tracer
 from .errors import NoBackendCredentialsError, ProvisionError, SessionHandleNotFound
 from .provisioning import destroy_session, provision_session, resume_session
 from .spec_factory import build_spec_for_session
-from .sprites_backend import ExecError
 from .stage_events import STAGE_RUNTIME_START, emit_stage_event
 from .turn_argv import build_turn_argv
 from .turn_outcome import compute_final_status
@@ -310,16 +309,16 @@ def _execute_turn_inner(
         },
     ) as span:
         try:
-            sprite = resume_session(session.user, session.sprite_name)
+            handle = resume_session(session.user, session.sprite_name)
         except SessionHandleNotFound as e:
             logger.warning("sprite not found for session %s turn %s: %s", session_id, turn_id, e)
             span.set_attribute("aod.failure_stage", "sprite_not_found")
             _fail_pending_turn(session, turn, str(e))
             return
-        _execute_turn_body(session, turn, spec, sprite, prompt, mode, timeout, span)
+        _execute_turn_body(session, turn, spec, handle, prompt, mode, timeout, span)
 
 
-def _execute_turn_body(session, turn, spec, sprite, prompt, mode, timeout, span) -> None:
+def _execute_turn_body(session, turn, spec, handle, prompt, mode, timeout, span) -> None:
     output_q: queue.Queue = queue.Queue(maxsize=4096)
     db_buffer: list[AgentSessionLog] = []
     result_holder: list = []
@@ -358,18 +357,11 @@ def _execute_turn_body(session, turn, spec, sprite, prompt, mode, timeout, span)
         # NOTE: if you add DB writes inside this inner thread, wrap the body
         # in close_old_connections()/finally. Today it only drives the SDK.
         try:
-            cmd = sprite.command(
-                *argv,
-                cwd="/home/sprite",
-                timeout=timeout,
-            )
-            cmd.stdin = io.BytesIO(prompt.encode("utf-8"))
-            cmd.stdout = stdout_writer
-            cmd.stderr = stderr_writer
-            cmd.run()
-            result_holder.append(("exit", 0))
-        except ExecError as e:
-            result_holder.append(("exit", e.exit_code()))
+            cmd = handle.make_command(*argv, cwd="/home/sprite", timeout=timeout)
+            cmd.set_input(prompt.encode("utf-8"))
+            cmd.set_output(stdout=stdout_writer, stderr=stderr_writer)
+            exit_code = cmd.run()
+            result_holder.append(("exit", exit_code))
         except Exception as e:
             logger.exception("session %s turn %s task raised", session.id, turn.turn_number)
             result_holder.append(("error", str(e)))

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -8,12 +8,13 @@ contract without spinning up a worker or needing Postgres locally.
 
 from __future__ import annotations
 
+import io
 import queue
 import threading
 
 import pytest
 from django.contrib.auth.models import User
-from sprites import ExecError, SpriteError
+from sprites import SpriteError
 
 from agent_on_demand.models import (
     Agent,
@@ -69,22 +70,39 @@ def _make_session_and_turn(user):
 
 
 def _patch_sprite(mocker, exit_behavior):
-    """Return (mock_sprite, mock_cmd). `exit_behavior` controls what
-    `cmd.run()` does: "success", ExecError, or a generic Exception."""
+    """Return (mock_handle, mock_cmd). `exit_behavior` controls what
+    `cmd.run()` does: "success" (exit 0), an int exit code, or a raised
+    Exception. The handle exposes the post-PR-4 Protocol shape:
+    `make_command(...)` returns a command with `set_input`, `set_output`,
+    and `run() -> int`. For test ergonomics, `set_input(data)` stores a
+    `BytesIO` on `mock_cmd.stdin` and `set_output(stdout=, stderr=)`
+    stores both on `mock_cmd.stdout` / `mock_cmd.stderr` so existing
+    assertions and writer-capturing patterns keep working."""
     mock_cmd = mocker.MagicMock()
     if exit_behavior == "success":
-        mock_cmd.run.return_value = None
-    elif isinstance(exit_behavior, ExecError):
-        mock_cmd.run.side_effect = exit_behavior
+        mock_cmd.run.return_value = 0
+    elif isinstance(exit_behavior, int):
+        mock_cmd.run.return_value = exit_behavior
     else:
         mock_cmd.run.side_effect = exit_behavior
-    mock_sprite = mocker.MagicMock()
-    mock_sprite.command.return_value = mock_cmd
+
+    def _set_input(data):
+        mock_cmd.stdin = io.BytesIO(data)
+
+    def _set_output(stdout, stderr):
+        mock_cmd.stdout = stdout
+        mock_cmd.stderr = stderr
+
+    mock_cmd.set_input.side_effect = _set_input
+    mock_cmd.set_output.side_effect = _set_output
+
+    mock_handle = mocker.MagicMock()
+    mock_handle.make_command.return_value = mock_cmd
     mocker.patch(
         "agent_on_demand.session_service.tasks.resume_session",
-        return_value=mock_sprite,
+        return_value=mock_handle,
     )
-    return mock_sprite, mock_cmd
+    return mock_handle, mock_cmd
 
 
 @pytest.mark.django_db
@@ -111,12 +129,13 @@ def test_execute_turn_marks_completed_on_success(user, mocker):
 
 
 @pytest.mark.django_db
-def test_execute_turn_marks_failed_on_exec_error(user, mocker):
-    """Regression: ExecError.exit_code is a method, not a property. The
-    task body must call it before storing on session.exit_code, otherwise
-    Django's IntegerField raises TypeError at save time."""
+def test_execute_turn_marks_failed_on_nonzero_exit(user, mocker):
+    """A non-zero exit code from the backend command surfaces as a failed
+    session. Post-PR-4 the backend's `cmd.run()` returns the exit code as
+    an int (it absorbs the SDK's `ExecError` internally), so the task body
+    sees `("exit", 1)` and stores it directly on session.exit_code."""
     session, turn = _make_session_and_turn(user)
-    _, mock_cmd = _patch_sprite(mocker, ExecError("exit status 1", exit_code=1))
+    _, mock_cmd = _patch_sprite(mocker, 1)
 
     execute_turn(
         session_id=str(session.id),
@@ -142,7 +161,7 @@ def test_execute_turn_marks_failed_on_exec_error(user, mocker):
 @pytest.mark.django_db
 def test_execute_turn_builds_expected_argv(user, mocker):
     session, turn = _make_session_and_turn(user)
-    mock_sprite, _ = _patch_sprite(mocker, "success")
+    mock_handle, _ = _patch_sprite(mocker, "success")
 
     execute_turn(
         session_id=str(session.id),
@@ -152,7 +171,7 @@ def test_execute_turn_builds_expected_argv(user, mocker):
         timeout=10.0,
     )
 
-    argv = mock_sprite.command.call_args.args
+    argv = mock_handle.make_command.call_args.args
     # Thin shim: bash -lc sourcing /tmp/aod-env, then exec "$@" ... argv.
     assert argv[0] == "bash"
     assert argv[1] == "-lc"


### PR DESCRIPTION
## Summary

PR 4 of the session-backend extraction plan
(`thoughts/plans/2026-04-27-session-backend-extraction.md`, lines ~174-217).

Ports `tasks.py::_execute_turn_body`'s inner `_run_command` thread off the
sprites SDK shape (`sprite.command(...)`, attribute-assigned `stdin/stdout/
stderr`, `cmd.run()` + `except ExecError`) onto the backend Protocol's
`SessionHandle.make_command(...)` + `Command.set_input/set_output/run() -> int`.

## Honest port — exit-code behavior change

This is the **honest port**, not a compatibility shim. Previously:

```python
cmd.run()
result_holder.append(("exit", 0))   # always 0 if no exception
except ExecError as e:
    result_holder.append(("exit", e.exit_code()))
```

`cmd.run()` returning normally was unconditionally tagged ``("exit", 0)``,
so any code path that returned non-zero without raising `ExecError` was
silently reported as "completed" with `exit_code=0`. After this PR:

```python
exit_code = cmd.run()                # absorbs ExecError -> int
result_holder.append(("exit", exit_code))
```

A non-zero exit code now surfaces as session `failed` (via the existing
`compute_final_status` mapping), instead of silently `completed`. **This is
a correctness improvement.** Any session that newly reports `failed`
post-merge was being masked before.

The `except Exception` arm in `_run_command` stays — after this PR it
catches `BackendError` for transport failures (raised by
`_SpritesCommand.run()` when the SDK raises `SpriteError`), which is the
right behavior.

## Threading core untouched

Out of scope for this PR (Muddy Zone deferrals from the plan):

- `cmd_thread.join(timeout=5.0)` zombie-detection path
- `--dangerously-skip-permissions` asymmetry
- Any threading-model refactor (no async swap, no mutmut-ifying
  `_execute_turn_body`)

`_run_command`, `output_q`, `TaggingQueueWriter`, and `_flush_buffer` are
structurally unchanged — only the SDK-call shape inside `_run_command`
moved to the Protocol.

## Grep invariant

After this PR, `tasks.py` no longer imports anything from `sprites`
(directly or transitively via `sprites_backend`):

```
$ grep -rn "from sprites\|import sprites" \
    src/agent_on_demand/session_service/tasks.py
(no output)
```

## Test plan

- [x] `make lint` — clean
- [x] `make test` — 1158 passed
- [x] `make mutation-test` — 1135/1139 killed, 4 expected survivors
- [ ] `make test-e2e-fast` — **deferred, needs manual run before merge.**
  `AOD_API_TOKEN` was unset locally. This PR changes the hot path for
  every agent turn, so the plan calls for a careful e2e run before
  promoting out of draft. Once a maintainer runs `make test-e2e-fast`
  against a live deployment and confirms green, mark this PR ready and
  add the `ready` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)