### PR TITLE
Add backend_handle column with dual-write to sprite_name

### DIFF
--- a/src/agent_on_demand/admin.py
+++ b/src/agent_on_demand/admin.py
@@ -212,13 +212,14 @@ class AgentSessionLogInline(admin.TabularInline):
 class AgentSessionAdmin(admin.ModelAdmin):
     list_display = ("id", "user", "runtime", "status", "exit_code", "created_at")
     list_filter = ("runtime", "status")
-    search_fields = ("id", "sprite_name", "user__email")
+    search_fields = ("id", "sprite_name", "backend_handle", "user__email")
     readonly_fields = (
         "id",
         "user",
         "runtime",
         "prompt",
         "sprite_name",
+        "backend_handle",
         "status",
         "exit_code",
         "created_at",
@@ -244,18 +245,20 @@ class AgentSessionAdmin(admin.ModelAdmin):
         terminated = 0
         missing_key_users: set[str] = set()
         for session in queryset.exclude(status="terminated"):
-            if session.sprite_name:
+            handle = session.backend_handle or session.sprite_name
+            if handle:
                 client = client_for(session.user)
                 if client is None:
                     missing_key_users.add(str(session.user))
                 else:
                     try:
-                        client.destroy(session.sprite_name)
+                        client.destroy(handle)
                     except BackendError:
                         pass
             session.status = "terminated"
             session.sprite_name = ""
-            session.save(update_fields=["status", "sprite_name", "updated_at"])
+            session.backend_handle = ""
+            session.save(update_fields=["status", "sprite_name", "backend_handle", "updated_at"])
             terminated += 1
         skipped = queryset.filter(status="terminated").count()
         msg = f"Terminated {terminated} session(s)."

--- a/src/agent_on_demand/migrations/0018_add_session_backend_handle.py
+++ b/src/agent_on_demand/migrations/0018_add_session_backend_handle.py
@@ -1,0 +1,37 @@
+"""Step 1 of two-step rename: add ``backend_handle`` alongside ``sprite_name``.
+
+Application code dual-writes both columns and reads ``backend_handle`` with a
+fallback to ``sprite_name`` (for sessions provisioned during the deploy window
+before the dual-write code shipped). A follow-up forward-only migration drops
+``sprite_name`` after this dual-write deploy soaks for at least one day.
+
+The new field is ``null=True`` *and* ``default=""`` — the default backfills
+existing rows safely on Postgres; ``null=True`` is the conservative pairing.
+Application code always writes a string value, so reads are typed-string.
+
+``IgnoreMigration`` is the documented escape hatch for false positives in
+the SQL analyser. CI runs the linter against SQLite (matching local test
+DB), and SQLite's table-rebuild dance for AddField triggers ``NOT NULL
+constraint on columns`` on every existing NOT NULL column in the table — a
+known limitation of the analyser that cannot be turned off per-rule. The
+column add itself is genuinely safe (nullable, defaulted); review-gate
+this migration manually per CLAUDE.md's danger-zone policy.
+"""
+
+from django.db import migrations, models
+from django_migration_linter import IgnoreMigration
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("fairy", "0016_runtime_redesign"),
+    ]
+
+    operations = [
+        IgnoreMigration(),
+        migrations.AddField(
+            model_name="agentsession",
+            name="backend_handle",
+            field=models.CharField(blank=True, default="", max_length=100, null=True),
+        ),
+    ]

--- a/src/agent_on_demand/migrations/0018_add_session_backend_handle.py
+++ b/src/agent_on_demand/migrations/0018_add_session_backend_handle.py
@@ -24,7 +24,7 @@ from django_migration_linter import IgnoreMigration
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("fairy", "0016_runtime_redesign"),
+        ("fairy", "0017_add_session_backend"),
     ]
 
     operations = [

--- a/src/agent_on_demand/models/sessions.py
+++ b/src/agent_on_demand/models/sessions.py
@@ -33,6 +33,12 @@ class AgentSession(models.Model):
     prompt = models.TextField()
     sprite_name = models.CharField(max_length=100, blank=True)
     backend = models.CharField(max_length=32, default="sprites")
+    # Step 1 of two-step rename: dual-written with `sprite_name`; reads prefer
+    # this field with `sprite_name` as a fallback. A follow-up PR drops
+    # `sprite_name` after the dual-write deploy soaks. `null=True` is a
+    # migration-linter concession (see migration 0018); app code always
+    # writes a string, so reads stay typed-string.
+    backend_handle = models.CharField(max_length=100, blank=True, default="", null=True)
     runtime_session_id = models.UUIDField(null=True, blank=True)
     status = models.CharField(max_length=16, choices=STATUS_CHOICES, default="pending")
     exit_code = models.IntegerField(null=True, blank=True)

--- a/src/agent_on_demand/session_service/spec_factory.py
+++ b/src/agent_on_demand/session_service/spec_factory.py
@@ -52,7 +52,7 @@ def build_spec_for_session(session: AgentSession) -> SessionSpec:
     ]
 
     return SessionSpec(
-        name=session.sprite_name,
+        name=session.backend_handle or session.sprite_name,
         runtime=RUNTIMES[session.runtime],
         model=model,
         user=session.user,

--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -199,7 +199,8 @@ def _mark_provision_failed(session: AgentSession, turn_id: int, message: str) ->
     if session.status != "terminated":
         session.status = "failed"
         session.sprite_name = ""
-        session.save(update_fields=["status", "sprite_name", "updated_at"])
+        session.backend_handle = ""
+        session.save(update_fields=["status", "sprite_name", "backend_handle", "updated_at"])
 
     SessionTurn.objects.filter(pk=turn_id).update(
         status="failed",
@@ -309,7 +310,7 @@ def _execute_turn_inner(
         },
     ) as span:
         try:
-            handle = resume_session(session.user, session.sprite_name)
+            handle = resume_session(session.user, session.backend_handle or session.sprite_name)
         except SessionHandleNotFound as e:
             logger.warning("sprite not found for session %s turn %s: %s", session_id, turn_id, e)
             span.set_attribute("aod.failure_stage", "sprite_not_found")

--- a/src/agent_on_demand/signals.py
+++ b/src/agent_on_demand/signals.py
@@ -10,8 +10,7 @@ def delete_sprite_on_session_delete(sender, instance, **kwargs):
     """Enqueue Sprite cleanup when a session is deleted, regardless of
     deletion path. Runs async so DELETE /sessions/{id} doesn't block on the
     Sprites API."""
-    if not instance.sprite_name:
+    handle = instance.backend_handle or instance.sprite_name
+    if not handle:
         return
-    session_service.destroy_session_task.defer(
-        user_id=instance.user_id, sprite_name=instance.sprite_name
-    )
+    session_service.destroy_session_task.defer(user_id=instance.user_id, sprite_name=handle)

--- a/src/agent_on_demand/templates/ui/session_detail.html
+++ b/src/agent_on_demand/templates/ui/session_detail.html
@@ -19,7 +19,7 @@
     <dt>Runtime</dt><dd>{{ session.runtime }}</dd>
     <dt>Status</dt><dd>{{ session.status }}</dd>
     <dt>Exit code</dt><dd>{% if session.exit_code is not None %}{{ session.exit_code }}{% else %}<span class="muted">—</span>{% endif %}</dd>
-    <dt>Sprite name</dt><dd>{% if session.sprite_name %}<code>{{ session.sprite_name }}</code>{% else %}<span class="muted">—</span>{% endif %}</dd>
+    <dt>Backend handle</dt><dd>{% if session.backend_handle or session.sprite_name %}<code>{{ session.backend_handle|default:session.sprite_name }}</code>{% else %}<span class="muted">—</span>{% endif %}</dd>
     <dt>Prompt</dt><dd><pre>{{ session.prompt }}</pre></dd>
     <dt>Resources</dt>
     <dd>

--- a/src/agent_on_demand/views/sessions/create.py
+++ b/src/agent_on_demand/views/sessions/create.py
@@ -167,6 +167,7 @@ def _create_session(request):
             runtime=runtime,
             prompt=req.prompt,
             sprite_name=name,
+            backend_handle=name,
             runtime_session_id=runtime_session_id,
             status="pending",
         )

--- a/src/agent_on_demand/views/sessions/lifecycle.py
+++ b/src/agent_on_demand/views/sessions/lifecycle.py
@@ -68,7 +68,7 @@ def send_prompt(request, session_id):
         return JsonResponse({"detail": e.errors(include_context=False)}, status=422)
 
     try:
-        session_service.resume_session(request.user, session.sprite_name)
+        session_service.resume_session(request.user, session.backend_handle or session.sprite_name)
     except session_service.NoBackendCredentialsError as e:
         return JsonResponse({"detail": str(e)}, status=400)
     except session_service.SessionHandleNotFound:
@@ -164,15 +164,16 @@ def terminate_session(request, session_id):
             err = _pkg.check_can_terminate(session.status)
             if err is not None:
                 return err
-            sprite_name = session.sprite_name
+            handle = session.backend_handle or session.sprite_name
             session.status = "terminated"
             session.sprite_name = ""
-            session.save(update_fields=["status", "sprite_name", "updated_at"])
+            session.backend_handle = ""
+            session.save(update_fields=["status", "sprite_name", "backend_handle", "updated_at"])
     except AgentSession.DoesNotExist:
         return JsonResponse({"detail": "Session not found"}, status=404)
 
-    if sprite_name:
-        session_service.destroy_session_task.defer(user_id=request.user.id, sprite_name=sprite_name)
+    if handle:
+        session_service.destroy_session_task.defer(user_id=request.user.id, sprite_name=handle)
 
     with posthog.new_context():
         posthog.identify_context(str(request.user.id))

--- a/tests/test_backend_handle.py
+++ b/tests/test_backend_handle.py
@@ -1,0 +1,169 @@
+"""Pin step 1 of the ``sprite_name`` → ``backend_handle`` rename.
+
+This PR adds the ``backend_handle`` column. App code dual-writes both
+columns and reads ``backend_handle`` with a fallback to ``sprite_name``.
+The fallback path covers in-flight sessions provisioned during the deploy
+window before the dual-write code shipped — without it, those sessions get
+stranded with an empty handle and orphan their backend resource on
+termination.
+
+Step 2 (drop ``sprite_name``) is a separate forward-only PR after the
+dual-write deploy soaks for >=1 day.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.contrib.auth.models import User
+from django.db import connection
+from django.test import Client
+
+from agent_on_demand.models import Agent, AgentSession, APIKey, UserCredential, UserSpritesKey
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="bhuser", password="x")
+
+
+@pytest.fixture
+def auth_headers(user):
+    _, raw = APIKey.create_key(user, "k")
+    return {"HTTP_AUTHORIZATION": f"Bearer {raw}"}
+
+
+@pytest.fixture
+def sprites_key(user):
+    usk = UserSpritesKey(user=user)
+    usk.set_api_key("fake-sprites")
+    usk.save()
+    return usk
+
+
+@pytest.fixture
+def runtime_key(user, sprites_key):
+    cred = UserCredential(user=user, kind="provider:anthropic")
+    cred.set_value("fake-anthropic")
+    cred.save()
+    return cred
+
+
+@pytest.fixture
+def agent(user):
+    return Agent.objects.create(
+        user=user,
+        name="Test Agent",
+        model="anthropic/claude-sonnet-4-6",
+        runtime="claude",
+        version=1,
+    )
+
+
+@pytest.mark.django_db
+def test_backend_handle_column_exists():
+    """Migration 0018 added a ``backend_handle`` column on the sessions table.
+
+    Goes through Django's introspection API so the assertion holds on both
+    the SQLite test backend and Postgres in production.
+    """
+    with connection.cursor() as cursor:
+        descriptions = connection.introspection.get_table_description(cursor, "agent_sessions")
+    by_name = {d.name: d for d in descriptions}
+    assert "backend_handle" in by_name, "backend_handle column should exist after migration 0018"
+    assert "sprite_name" in by_name, "sprite_name column must still exist — step 2 is a separate PR"
+
+
+@pytest.mark.django_db
+def test_backend_handle_defaults_to_empty_for_existing_rows(user):
+    """Rows created without an explicit ``backend_handle`` default to empty —
+    that's what makes the additive migration safe on the populated table."""
+    session = AgentSession.objects.create(
+        user=user, runtime="claude", prompt="x", sprite_name="legacy-handle"
+    )
+    session.refresh_from_db()
+    assert session.backend_handle == ""
+    assert session.sprite_name == "legacy-handle"
+
+
+@pytest.mark.django_db
+def test_create_session_dual_writes_backend_handle(
+    client: Client, auth_headers, runtime_key, agent, fake_sprites
+):
+    """POST /sessions sets ``backend_handle`` and ``sprite_name`` to the same
+    value. Missing this dual-write is the failure mode that strands new
+    sessions when step 2 drops ``sprite_name``."""
+    resp = client.post(
+        "/sessions",
+        data=json.dumps({"agent_id": str(agent.id), "prompt": "hi"}),
+        content_type="application/json",
+        **auth_headers,
+    )
+    assert resp.status_code == 202
+    session = AgentSession.objects.get(pk=resp.json()["id"])
+    assert session.sprite_name
+    assert session.backend_handle == session.sprite_name
+
+
+@pytest.mark.django_db
+def test_terminate_session_clears_both_handle_columns(
+    client: Client, auth_headers, sprites_key, user, fake_sprites
+):
+    """Terminate must clear both columns or step 2's drop of ``sprite_name``
+    would silently leave a stale handle on the session row."""
+    session = AgentSession.objects.create(
+        user=user,
+        runtime="claude",
+        prompt="t",
+        sprite_name="aod-dual",
+        backend_handle="aod-dual",
+        status="completed",
+    )
+    resp = client.post(f"/sessions/{session.id}/terminate", **auth_headers)
+    assert resp.status_code == 200
+    session.refresh_from_db()
+    assert session.sprite_name == ""
+    assert session.backend_handle == ""
+    # Cleanup task must have fired with the captured handle, not an empty one.
+    assert fake_sprites.deleted == ["aod-dual"]
+
+
+@pytest.mark.django_db
+def test_terminate_falls_back_to_sprite_name_when_backend_handle_empty(
+    client: Client, auth_headers, sprites_key, user, fake_sprites
+):
+    """In-flight sessions provisioned before the dual-write code shipped have
+    ``backend_handle=""`` and ``sprite_name="..."``. Termination must read the
+    legacy column or the backend resource is orphaned."""
+    session = AgentSession.objects.create(
+        user=user,
+        runtime="claude",
+        prompt="t",
+        sprite_name="legacy-handle",
+        backend_handle="",
+        status="completed",
+    )
+    resp = client.post(f"/sessions/{session.id}/terminate", **auth_headers)
+    assert resp.status_code == 200
+    assert fake_sprites.deleted == ["legacy-handle"]
+
+
+@pytest.mark.django_db
+def test_delete_session_signal_falls_back_to_sprite_name(
+    client: Client, auth_headers, sprites_key, user, fake_sprites
+):
+    """The pre_delete signal that enqueues backend cleanup must also honour
+    the fallback — a deleted in-flight session whose ``backend_handle`` was
+    never set still needs its backend resource cleaned up."""
+    session = AgentSession.objects.create(
+        user=user,
+        runtime="claude",
+        prompt="t",
+        sprite_name="legacy-del",
+        backend_handle="",
+        status="completed",
+    )
+    resp = client.delete(f"/sessions/{session.id}/delete", **auth_headers)
+    assert resp.status_code == 200
+    assert fake_sprites.deleted == ["legacy-del"]

--- a/tests/test_spec_factory.py
+++ b/tests/test_spec_factory.py
@@ -67,6 +67,7 @@ def _session(
     runtime="claude",
     runtime_session_id=None,
     sprite_name="sprite-1",
+    backend_handle=_UNSET,
     environment=_UNSET,
     resources=None,
     backend="sprites",
@@ -77,12 +78,18 @@ def _session(
         user = SimpleNamespace()
     if environment is _UNSET:
         environment = None
+    # Default backend_handle to mirror sprite_name to match production's
+    # dual-write semantics. Tests that exercise the fallback-read path can
+    # pass `backend_handle=""` explicitly.
+    if backend_handle is _UNSET:
+        backend_handle = sprite_name
     return SimpleNamespace(
         agent=agent,
         user=user,
         runtime=runtime,
         runtime_session_id=runtime_session_id,
         sprite_name=sprite_name,
+        backend_handle=backend_handle,
         environment=environment,
         resources=_resources(resources),
         backend=backend,
@@ -474,6 +481,21 @@ def test_runtime_session_id_uuid_is_stringified():
 def test_sprite_name_passes_through():
     spec = build_spec_for_session(_session(sprite_name="aod-abc123"))
     assert spec.name == "aod-abc123"
+
+
+def test_backend_handle_overrides_sprite_name():
+    """When both columns are populated, ``backend_handle`` wins. Pin so an
+    ``or`` → ``and`` mutant (which would yield ``sprite_name``) is killed."""
+    spec = build_spec_for_session(_session(sprite_name="legacy", backend_handle="new-handle"))
+    assert spec.name == "new-handle"
+
+
+def test_sprite_name_used_when_backend_handle_empty():
+    """In-flight sessions provisioned before dual-write have
+    ``backend_handle=""``. ``spec.name`` must fall back to ``sprite_name``
+    or those sessions get stranded."""
+    spec = build_spec_for_session(_session(sprite_name="legacy-only", backend_handle=""))
+    assert spec.name == "legacy-only"
 
 
 def test_user_passes_through_unchanged():

--- a/tests/test_spec_factory_django.py
+++ b/tests/test_spec_factory_django.py
@@ -248,6 +248,32 @@ def test_backend_persists_and_threads_through(user):
 
 
 @pytest.mark.django_db
+def test_spec_name_prefers_backend_handle_with_sprite_name_fallback(user):
+    """`spec.name` reads `backend_handle` and only falls back to `sprite_name`
+    when the new column is empty. Step 2 will drop `sprite_name`; that PR's
+    safety relies on this preference being correct now."""
+    new_handle = AgentSession.objects.create(
+        user=user,
+        runtime="claude",
+        prompt="t",
+        status="pending",
+        sprite_name="legacy",
+        backend_handle="new-handle",
+    )
+    assert build_spec_for_session(new_handle).name == "new-handle"
+
+    legacy_only = AgentSession.objects.create(
+        user=user,
+        runtime="claude",
+        prompt="t",
+        status="pending",
+        sprite_name="legacy-only",
+        backend_handle="",
+    )
+    assert build_spec_for_session(legacy_only).name == "legacy-only"
+
+
+@pytest.mark.django_db
 def test_no_agent_with_resources(user):
     """The no-agent guard does not short-circuit resource iteration —
     real `SessionResource` rows must still rehydrate into `RepoSpec`


### PR DESCRIPTION
## Summary
Step 1 of a two-step migration to rename `AgentSession.sprite_name` → `backend_handle`. Implements **PR 7** of `thoughts/plans/2026-04-27-session-backend-extraction.md`.

- Migration `0018_add_session_backend_handle` adds the new column. `default=""` backfills existing rows; `null=True` is a conservative pairing because the SQLite migration linter flags every column-add to a populated table (the linter's table-rebuild dance can't tell which NOT NULLs are pre-existing). `IgnoreMigration()` is used with an in-file comment explaining the false positive — the column add is genuinely safe.
- App code dual-writes both `sprite_name` and `backend_handle` on every existing write site (5 spots: `views/sessions/create.py`, `views/sessions/lifecycle.py` terminate, `admin.py` terminate-action, `session_service/tasks.py` `_mark_provision_failed`).
- App code reads `backend_handle or sprite_name` on every existing read site (7 spots: `views/sessions/lifecycle.py` resume + terminate, `signals.py` pre_delete, `session_service/spec_factory.py`, `session_service/tasks.py` execute_turn, `admin.py` terminate-action, `templates/ui/session_detail.html`). The fallback covers in-flight sessions provisioned during the deploy window before the dual-write code shipped — without it, those sessions orphan their backend resource on terminate/delete.

**This is step 1 of a two-step migration; step 2 (drop `sprite_name`) is a follow-up forward-only PR after the dual-write deploy soaks for at least one day.**

This PR ships in parallel with sibling PRs 6 (backend discriminator column) and 8 (UserSpritesKey → UserBackendCredential). Both also touch `models/sessions.py` / migrations; merge order is the user's call.

API surface unchanged: `sprite_name` is not in `docs/openapi.yaml` or `docs/request_schemas.json` (`make check-schemas` passes unchanged). Admin and UI show `backend_handle` preferred with `sprite_name` fallback during the soak.

Plan tags this as **Medium risk** (column rename on a hot table). Two-deploy dance is the standard mitigation.

## Test plan
- [x] `make lint`
- [x] `make test` — 1167 passed
- [x] `make check-migrations` — passes via `IgnoreMigration` (false positive documented in the migration docstring)
- [x] `make check-schemas` — request-schema snapshot unchanged
- [x] `make mutation-test` — 1136/1140 killed, 4 known-equivalent survivors (allowlist)
- [x] New tests: `tests/test_backend_handle.py` (column exists, default empty, dual-write, terminate clears both, fallback-read on terminate, fallback on signal-pre-delete), `tests/test_spec_factory.py` (`backend_handle` overrides + fallback), `tests/test_spec_factory_django.py` (ORM-level preference assertion)
- [ ] **E2E: AOD_API_TOKEN unset locally — maintainer must run `make test-e2e-fast` before promoting from draft to ready.** Plan tags this PR as Medium risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)