### PR TITLE
Hotfix: guard django_migration_linter import in migration 0018

### DIFF
--- a/src/agent_on_demand/migrations/0018_add_session_backend_handle.py
+++ b/src/agent_on_demand/migrations/0018_add_session_backend_handle.py
@@ -18,8 +18,16 @@ column add itself is genuinely safe (nullable, defaulted); review-gate
 this migration manually per CLAUDE.md's danger-zone policy.
 """
 
+import importlib.util
+
 from django.db import migrations, models
-from django_migration_linter import IgnoreMigration
+
+
+_extra_operations = []
+if importlib.util.find_spec("django_migration_linter") is not None:
+    from django_migration_linter import IgnoreMigration
+
+    _extra_operations.append(IgnoreMigration())
 
 
 class Migration(migrations.Migration):
@@ -28,7 +36,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        IgnoreMigration(),
+        *_extra_operations,
         migrations.AddField(
             model_name="agentsession",
             name="backend_handle",


### PR DESCRIPTION
## Summary

Production deploy was failing at the pre-deploy `migrate` step:

```
File "src/agent_on_demand/migrations/0018_add_session_backend_handle.py", line 22, in <module>
    from django_migration_linter import IgnoreMigration
ModuleNotFoundError: No module named 'django_migration_linter'
```

`django_migration_linter` is a dev-only extra (used by CI's `make check-migrations` to opt this migration out of a SQLite false-positive). It isn't installed in the prod virtualenv, so the bare top-level import crashed Django's migration loader before any migration ran.

The fix mirrors the conditional-import pattern already in [`0017_add_session_backend.py`](https://github.com/ravi-hq/agent-on-demand/blob/main/src/agent_on_demand/migrations/0017_add_session_backend.py) — guard with `importlib.util.find_spec` and append `IgnoreMigration()` only when the linter is available.

## Test plan
- [x] `make lint` clean
- [x] `make check-migrations` clean (linter still sees `IgnoreMigration()` in dev)
- [ ] CI green
- [ ] Deploy succeeds — `manage.py migrate --noinput` runs through 0018 without the import crash

## Why this slipped past CI
CI installs the dev extras (`uv sync --all-extras`), so `django_migration_linter` was always available. The bare import never fired in CI; it only manifested in prod where the venv is built without dev extras.

Long-term: worth a `make prod-imports` lint or a CI job that imports every migration without dev extras to catch this class of bug. Tracked separately.