### PR TITLE
Drop UserSpritesKey table after backfill soak

### DIFF
--- a/src/agent_on_demand/admin.py
+++ b/src/agent_on_demand/admin.py
@@ -15,7 +15,6 @@ from agent_on_demand.models import (
     UserBackendCredential,
     UserCredential,
     UserQuota,
-    UserSpritesKey,
 )
 from agent_on_demand.models.auth import CREDENTIAL_ENV_VAR
 from agent_on_demand.session_service.backends import BackendClient, BackendError
@@ -32,13 +31,6 @@ class UserCredentialInline(admin.TabularInline):
     model = UserCredential
     extra = 0
     fields = ("kind", "created_at", "updated_at")
-    readonly_fields = ("created_at", "updated_at")
-
-
-class UserSpritesKeyInline(admin.TabularInline):
-    model = UserSpritesKey
-    extra = 0
-    fields = ("created_at", "updated_at")
     readonly_fields = ("created_at", "updated_at")
 
 
@@ -64,7 +56,6 @@ class UserAdmin(BaseUserAdmin):
     inlines = list(BaseUserAdmin.inlines) + [
         APIKeyInline,
         UserCredentialInline,
-        UserSpritesKeyInline,
         UserBackendCredentialInline,
         UserQuotaInline,
     ]
@@ -140,42 +131,6 @@ class UserCredentialAdmin(admin.ModelAdmin):
         if obj is None:
             return ("user", "kind", "value")
         return ("user", "kind", "value", "created_at", "updated_at")
-
-
-class UserSpritesKeyForm(forms.ModelForm):
-    api_key = forms.CharField(
-        widget=forms.PasswordInput(render_value=True),
-        help_text="The Sprites API token. Stored encrypted.",
-    )
-
-    class Meta:
-        model = UserSpritesKey
-        fields = ("user", "api_key")
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if self.instance.pk:
-            self.fields["api_key"].initial = self.instance.get_api_key()
-
-    def save(self, commit=True):
-        instance = super().save(commit=False)
-        instance.set_api_key(self.cleaned_data["api_key"])
-        if commit:
-            instance.save()
-        return instance
-
-
-@admin.register(UserSpritesKey)
-class UserSpritesKeyAdmin(admin.ModelAdmin):
-    form = UserSpritesKeyForm
-    list_display = ("user", "created_at", "updated_at")
-    search_fields = ("user__email",)
-    readonly_fields = ("created_at", "updated_at")
-
-    def get_fields(self, request, obj=None):
-        if obj is None:
-            return ("user", "api_key")
-        return ("user", "api_key", "created_at", "updated_at")
 
 
 # Only "sprites" is wired today. ModalBackend lands in a follow-up plan and

--- a/src/agent_on_demand/migrations/0021_drop_user_sprites_key.py
+++ b/src/agent_on_demand/migrations/0021_drop_user_sprites_key.py
@@ -1,12 +1,13 @@
 """Drop the legacy ``UserSpritesKey`` table.
 
 Step 2 of the credential generalization started in #256 (migration
-``0019_user_backend_credential``). PR 8 created ``UserBackendCredential``,
-backfilled every ``UserSpritesKey`` row into it as ``backend="sprites"``,
-and left the legacy table in place behind a ``_lookup_token`` fallback so
-no caller lost access during the deploy window. The backfill has now
-soaked in production, so this forward-only migration removes the legacy
-table and the application-side fallback that read from it.
+``0019_user_backend_credential``). That PR created
+``UserBackendCredential``, backfilled every ``UserSpritesKey`` row into
+it as ``backend="sprites"``, and left the legacy table in place behind a
+``_lookup_token`` fallback so no caller lost access during the deploy
+window. The backfill has now soaked in production, so this forward-only
+migration removes the legacy table and the application-side fallback
+that read from it.
 
 The conditional ``IgnoreMigration`` opts this migration out of
 django-migration-linter, which flags the underlying ``DROP TABLE`` —

--- a/src/agent_on_demand/migrations/0021_drop_user_sprites_key.py
+++ b/src/agent_on_demand/migrations/0021_drop_user_sprites_key.py
@@ -1,0 +1,41 @@
+"""Drop the legacy ``UserSpritesKey`` table.
+
+Step 2 of the credential generalization started in #256 (migration
+``0019_user_backend_credential``). PR 8 created ``UserBackendCredential``,
+backfilled every ``UserSpritesKey`` row into it as ``backend="sprites"``,
+and left the legacy table in place behind a ``_lookup_token`` fallback so
+no caller lost access during the deploy window. The backfill has now
+soaked in production, so this forward-only migration removes the legacy
+table and the application-side fallback that read from it.
+
+The conditional ``IgnoreMigration`` opts this migration out of
+django-migration-linter, which flags the underlying ``DROP TABLE`` —
+correctly identifying it as destructive. Drops are documented as
+forward-only in this repo (see ``CLAUDE.md`` danger zones); this
+particular drop is intentional and is reviewed at the PR level rather
+than at the linter level. The import is guarded because
+django-migration-linter is a dev-only extra and is absent in production
+(see ``settings.py``).
+"""
+
+import importlib.util
+
+from django.db import migrations
+
+
+_extra_operations = []
+if importlib.util.find_spec("django_migration_linter") is not None:
+    from django_migration_linter import IgnoreMigration
+
+    _extra_operations.append(IgnoreMigration())
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("fairy", "0020_drop_sprite_name"),
+    ]
+
+    operations = [
+        *_extra_operations,
+        migrations.DeleteModel(name="UserSpritesKey"),
+    ]

--- a/src/agent_on_demand/models/__init__.py
+++ b/src/agent_on_demand/models/__init__.py
@@ -3,7 +3,6 @@ from agent_on_demand.models.auth import (
     APIKey,
     UserBackendCredential,
     UserCredential,
-    UserSpritesKey,
 )
 from agent_on_demand.models.environments import Environment, EnvironmentVersion
 from agent_on_demand.models.quota import UserQuota
@@ -27,5 +26,4 @@ __all__ = [
     "UserBackendCredential",
     "UserQuota",
     "UserCredential",
-    "UserSpritesKey",
 ]

--- a/src/agent_on_demand/models/auth.py
+++ b/src/agent_on_demand/models/auth.py
@@ -88,27 +88,6 @@ class UserCredential(models.Model):
             return None
 
 
-class UserSpritesKey(models.Model):
-    user = models.OneToOneField(
-        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="sprites_key"
-    )
-    encrypted_key = models.BinaryField()
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
-
-    class Meta:
-        db_table = "user_sprites_keys"
-
-    def __str__(self):
-        return f"{self.user} — sprites"
-
-    def set_api_key(self, raw_key: str):
-        self.encrypted_key = encrypt(raw_key)
-
-    def get_api_key(self) -> str:
-        return decrypt(bytes(self.encrypted_key))
-
-
 class UserBackendCredential(models.Model):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,

--- a/src/agent_on_demand/session_service/client.py
+++ b/src/agent_on_demand/session_service/client.py
@@ -1,6 +1,6 @@
 import logging
 
-from agent_on_demand.models import UserBackendCredential, UserSpritesKey
+from agent_on_demand.models import UserBackendCredential
 
 from .backends import BackendClient, BackendError, get_backend
 from .errors import NoBackendCredentialsError
@@ -12,18 +12,8 @@ def _lookup_token(user, backend: str) -> str | None:
     try:
         cred = UserBackendCredential.objects.get(user=user, backend=backend)
     except UserBackendCredential.DoesNotExist:
-        cred = None
-    if cred is not None:
-        return cred.get_token()
-    # Fallback covers the deploy window between this PR landing and the
-    # backfill RunPython completing, plus any new `UserSpritesKey` rows
-    # written through the legacy admin/UI before the follow-up PR drops them.
-    if backend == "sprites":
-        try:
-            return user.sprites_key.get_api_key()
-        except UserSpritesKey.DoesNotExist:
-            return None
-    return None
+        return None
+    return cred.get_token()
 
 
 def get_client(user, backend: str = "sprites") -> BackendClient | None:

--- a/src/agent_on_demand/ui/views.py
+++ b/src/agent_on_demand/ui/views.py
@@ -12,7 +12,7 @@ from agent_on_demand.models import (
     AgentSessionLog,
     APIKey,
     Environment,
-    UserSpritesKey,
+    UserBackendCredential,
 )
 from agent_on_demand.ui.forms import APIKeyCreateForm, RegisterForm, SpritesKeyForm
 
@@ -30,9 +30,9 @@ def register(request):
         if form.is_valid():
             user = form.save()
 
-            usk = UserSpritesKey(user=user)
-            usk.set_api_key(form.cleaned_data["sprites_api_key"])
-            usk.save()
+            cred = UserBackendCredential(user=user, backend="sprites")
+            cred.set_token(form.cleaned_data["sprites_api_key"])
+            cred.save()
 
             _, raw_key = APIKey.create_key(user=user, name="Onboarding key")
 
@@ -66,7 +66,9 @@ def welcome(request):
 
 @login_required(login_url="/ui/login")
 def dashboard(request):
-    has_sprites_key = UserSpritesKey.objects.filter(user=request.user).exists()
+    has_sprites_key = UserBackendCredential.objects.filter(
+        user=request.user, backend="sprites"
+    ).exists()
     counts = {
         "agents": Agent.objects.filter(user=request.user, archived_at__isnull=True).count(),
         "environments": Environment.objects.filter(
@@ -84,14 +86,14 @@ def dashboard(request):
 
 @login_required(login_url="/ui/login")
 def sprites_key(request):
-    existing = UserSpritesKey.objects.filter(user=request.user).first()
+    existing = UserBackendCredential.objects.filter(user=request.user, backend="sprites").first()
 
     if request.method == "POST":
         form = SpritesKeyForm(request.POST)
         if form.is_valid():
-            usk = existing or UserSpritesKey(user=request.user)
-            usk.set_api_key(form.cleaned_data["api_key"])
-            usk.save()
+            cred = existing or UserBackendCredential(user=request.user, backend="sprites")
+            cred.set_token(form.cleaned_data["api_key"])
+            cred.save()
             messages.success(request, "Sprites token saved.")
             return redirect("ui-sprites-key")
     else:

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -8,7 +8,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "dev-insecure-key-change-in-prod")
 
-# Dedicated KEK for encrypted model fields (UserSpritesKey, UserCredential). Split
+# Dedicated KEK for encrypted model fields (UserBackendCredential, UserCredential). Split
 # from SECRET_KEY so session-signing keys can be rotated independently of the
 # field-encryption key. Rotating this key still requires a re-encrypt migration.
 FIELD_ENCRYPTION_KEY = os.environ.get("FIELD_ENCRYPTION_KEY")

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -11,8 +11,8 @@ from agent_on_demand.models import (
     AgentVersion,
     APIKey,
     Environment,
+    UserBackendCredential,
     UserCredential,
-    UserSpritesKey,
 )
 
 
@@ -35,10 +35,10 @@ def auth_headers(api_key):
 
 @pytest.fixture
 def sprites_key(user):
-    usk = UserSpritesKey(user=user)
-    usk.set_api_key("fake-sprites-token")
-    usk.save()
-    return usk
+    cred = UserBackendCredential(user=user, backend="sprites")
+    cred.set_token("fake-sprites-token")
+    cred.save()
+    return cred
 
 
 @pytest.fixture

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,9 +11,9 @@ from agent_on_demand.models import (
     AgentSession,
     AgentSessionLog,
     SessionTurn,
+    UserBackendCredential,
     UserCredential,
     UserQuota,
-    UserSpritesKey,
 )
 
 
@@ -56,11 +56,12 @@ def auth_headers(api_key):
 
 @pytest.fixture
 def sprites_key(user):
-    """Create a UserSpritesKey so session creation passes the Sprites-key check."""
-    usk = UserSpritesKey(user=user)
-    usk.set_api_key("fake-sprites-token")
-    usk.save()
-    return usk
+    """Create a UserBackendCredential so session creation passes the
+    backend-credential check."""
+    cred = UserBackendCredential(user=user, backend="sprites")
+    cred.set_token("fake-sprites-token")
+    cred.save()
+    return cred
 
 
 @pytest.fixture
@@ -78,7 +79,8 @@ def runtime_key(user, sprites_key):
 
 @pytest.fixture
 def runtime_key_without_sprites(user):
-    """Runtime credential configured, but no UserSpritesKey — for negative tests."""
+    """Runtime credential configured, but no backend credential — for negative
+    tests."""
     cred = UserCredential(user=user, kind="provider:anthropic")
     cred.set_value("fake-anthropic-key")
     cred.save()
@@ -193,8 +195,11 @@ def test_run_no_runtime_key(client: Client, auth_headers, agent):
 
 
 @pytest.mark.django_db
-def test_run_no_sprites_key(client: Client, auth_headers, runtime_key_without_sprites, agent):
-    """Runtime credential is set but no UserSpritesKey — session create must 400."""
+def test_run_no_backend_credential(
+    client: Client, auth_headers, runtime_key_without_sprites, agent
+):
+    """Runtime credential is set but no backend credential — session create
+    must 400."""
     resp = client.post(
         "/sessions",
         data=json.dumps({"agent_id": str(agent.id), "prompt": "hello"}),

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -61,13 +61,13 @@ def test_get_client_routes_through_registry(mocker):
     `SpritesBackend()` is caught."""
     from django.contrib.auth.models import User
 
-    from agent_on_demand.models import UserSpritesKey
+    from agent_on_demand.models import UserBackendCredential
     from agent_on_demand.session_service.client import get_client
 
     user = User.objects.create_user(username="be-sel", password="x")
-    UserSpritesKey.objects.create(user=user)
-    user.sprites_key.set_api_key("fake-token")
-    user.sprites_key.save()
+    cred = UserBackendCredential(user=user, backend="sprites")
+    cred.set_token("fake-token")
+    cred.save()
 
     fake_backend = mocker.MagicMock()
     fake_backend.create_client.return_value = mocker.sentinel.client

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -12,8 +12,8 @@ from agent_on_demand.models import (
     APIKey,
     Environment,
     EnvironmentVersion,
+    UserBackendCredential,
     UserCredential,
-    UserSpritesKey,
 )
 
 
@@ -39,10 +39,10 @@ def auth_headers(api_key):
 
 @pytest.fixture
 def sprites_key(user):
-    usk = UserSpritesKey(user=user)
-    usk.set_api_key("fake-sprites-token")
-    usk.save()
-    return usk
+    cred = UserBackendCredential(user=user, backend="sprites")
+    cred.set_token("fake-sprites-token")
+    cred.save()
+    return cred
 
 
 @pytest.fixture

--- a/tests/test_fake_backend.py
+++ b/tests/test_fake_backend.py
@@ -195,13 +195,13 @@ def test_destroy_session_round_trip_through_fake_backend(fake_backend):
     Protocol that PR 2 already drives end-to-end."""
     from django.contrib.auth.models import User
 
-    from agent_on_demand.models import UserSpritesKey
+    from agent_on_demand.models import UserBackendCredential
     from agent_on_demand.session_service.provisioning import destroy_session
 
     user = User.objects.create_user(username="bk-rt", password="p")
-    usk = UserSpritesKey(user=user)
-    usk.set_api_key("token")
-    usk.save()
+    cred = UserBackendCredential(user=user, backend="sprites")
+    cred.set_token("token")
+    cred.save()
 
     destroy_session(user, "session-xyz")
     assert fake_backend.deleted == ["session-xyz"]

--- a/tests/test_model_repr.py
+++ b/tests/test_model_repr.py
@@ -21,7 +21,6 @@ from agent_on_demand.models import (
     EnvironmentVersion,
     SessionResource,
     SessionTurn,
-    UserSpritesKey,
 )
 from agent_on_demand.models.sessions import AgentSessionLog
 
@@ -136,19 +135,11 @@ def test_api_key_str_uses_prefix_and_name(user):
     assert k.key_prefix in s
 
 
-@pytest.mark.django_db
-def test_user_sprites_key_str_includes_user(user):
-    usk = UserSpritesKey(user=user)
-    usk.set_api_key("fake-token")
-    usk.save()
-    assert str(user) in str(usk)
-
-
 # --- session_service.client.require_client raises when no key configured ---
 
 
 @pytest.mark.django_db
-def test_require_client_raises_when_no_sprites_key(user):
+def test_require_client_raises_when_no_backend_credential(user):
     """The session-creation hot path uses get_client; a few infrequent code
     paths use require_client which surfaces NoBackendCredentialsError. Pin
     the raise so a refactor that returned None-or-default can't slip past."""

--- a/tests/test_networking_wiring.py
+++ b/tests/test_networking_wiring.py
@@ -12,8 +12,8 @@ from agent_on_demand.models import (
     APIKey,
     Environment,
     EnvironmentVersion,
+    UserBackendCredential,
     UserCredential,
-    UserSpritesKey,
 )
 
 
@@ -36,10 +36,10 @@ def auth_headers(api_key):
 
 @pytest.fixture
 def sprites_key(user):
-    usk = UserSpritesKey(user=user)
-    usk.set_api_key("fake-sprites-token")
-    usk.save()
-    return usk
+    cred = UserBackendCredential(user=user, backend="sprites")
+    cred.set_token("fake-sprites-token")
+    cred.save()
+    return cred
 
 
 @pytest.fixture

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -19,7 +19,7 @@ from django.contrib.auth.models import User
 from django.test import Client
 
 from agent_on_demand import observability
-from agent_on_demand.models import APIKey, UserCredential, UserSpritesKey
+from agent_on_demand.models import APIKey, UserBackendCredential, UserCredential
 
 
 SENSITIVE_PROMPT = "PLEASE_DO_NOT_LEAK_THIS_PROMPT_TEXT_2026"
@@ -42,9 +42,9 @@ def auth_headers(user):
 
 @pytest.fixture
 def runtime_keys(user):
-    usk = UserSpritesKey(user=user)
-    usk.set_api_key("fake-sprites")
-    usk.save()
+    bcred = UserBackendCredential(user=user, backend="sprites")
+    bcred.set_token("fake-sprites")
+    bcred.save()
     cred = UserCredential(user=user, kind="provider:anthropic")
     cred.set_value("fake-anthropic")
     cred.save()

--- a/tests/test_provision_task_failures.py
+++ b/tests/test_provision_task_failures.py
@@ -28,8 +28,8 @@ from agent_on_demand.models import (
     AgentSessionLog,
     APIKey,
     SessionTurn,
+    UserBackendCredential,
     UserCredential,
-    UserSpritesKey,
 )
 from agent_on_demand.session_service.errors import NoBackendCredentialsError
 from agent_on_demand.session_service.tasks import _provision_session_inner
@@ -46,9 +46,9 @@ def _stub_close_old_connections(mocker):
 def user(db):
     u = User.objects.create_user(username="provtest", password="x")
     APIKey.create_key(u, "k")
-    usk = UserSpritesKey(user=u)
-    usk.set_api_key("fake-sprites")
-    usk.save()
+    bcred = UserBackendCredential(user=u, backend="sprites")
+    bcred.set_token("fake-sprites")
+    bcred.save()
     cred = UserCredential(user=u, kind="provider:anthropic")
     cred.set_value("fake")
     cred.save()
@@ -103,7 +103,7 @@ def test_provision_task_marks_failed_when_build_spec_raises(user, mocker):
 
 
 @pytest.mark.django_db
-def test_provision_task_marks_failed_on_no_sprites_key(user, mocker):
+def test_provision_task_marks_failed_on_no_backend_credential(user, mocker):
     """Race: backend credential revoked between session-create (which passed
     the pre-check) and provision-task pickup. The task must record
     failed-stage='no_backend_credentials' and mark provision failed."""

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -9,8 +9,8 @@ from agent_on_demand.models import (
     AgentSession,
     APIKey,
     SessionResource,
+    UserBackendCredential,
     UserCredential,
-    UserSpritesKey,
 )
 
 
@@ -36,10 +36,10 @@ def auth_headers(api_key):
 
 @pytest.fixture
 def sprites_key(user):
-    usk = UserSpritesKey(user=user)
-    usk.set_api_key("fake-sprites-token")
-    usk.save()
-    return usk
+    cred = UserBackendCredential(user=user, backend="sprites")
+    cred.set_token("fake-sprites-token")
+    cred.save()
+    return cred
 
 
 @pytest.fixture

--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -15,8 +15,8 @@ from agent_on_demand.models import (
     AgentSession,
     AgentSessionLog,
     Environment,
+    UserBackendCredential,
     UserCredential,
-    UserSpritesKey,
 )
 from agent_on_demand.runtimes import RUNTIMES
 from agent_on_demand.session_service import (
@@ -30,9 +30,9 @@ from agent_on_demand.session_service.specs import SkillSpec
 @pytest.fixture
 def user(db):
     u = User.objects.create_user(username="svc", password="p")
-    usk = UserSpritesKey(user=u)
-    usk.set_api_key("fake-sprites-token")
-    usk.save()
+    bcred = UserBackendCredential(user=u, backend="sprites")
+    bcred.set_token("fake-sprites-token")
+    bcred.save()
     cred = UserCredential(user=u, kind="provider:anthropic")
     cred.set_value("sk-xxx")
     cred.save()

--- a/tests/test_session_views.py
+++ b/tests/test_session_views.py
@@ -20,8 +20,8 @@ from agent_on_demand.models import (
     AgentSession,
     APIKey,
     SessionTurn,
+    UserBackendCredential,
     UserCredential,
-    UserSpritesKey,
 )
 
 
@@ -38,10 +38,10 @@ def auth_headers(user):
 
 @pytest.fixture
 def sprites_key(user):
-    usk = UserSpritesKey(user=user)
-    usk.set_api_key("fake-sprites")
-    usk.save()
-    return usk
+    cred = UserBackendCredential(user=user, backend="sprites")
+    cred.set_token("fake-sprites")
+    cred.save()
+    return cred
 
 
 @pytest.fixture
@@ -227,9 +227,9 @@ def test_send_prompt_to_failed_session_rejected(client, auth_headers, user):
 
 
 @pytest.mark.django_db
-def test_send_prompt_without_sprites_key_returns_400(client, auth_headers, user):
-    """A user with a `completed` session but no UserSpritesKey hits the
-    `NoBackendCredentialsError` branch synchronously: `resume_session` →
+def test_send_prompt_without_backend_credential_returns_400(client, auth_headers, user):
+    """A user with a `completed` session but no UserBackendCredential hits
+    the `NoBackendCredentialsError` branch synchronously: `resume_session` →
     `require_client` (session_service/client.py) raises before the view
     ever returns, so the 400 path runs entirely in the request thread —
     there is no worker dispatch involved. Without this branch, the SDK

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -22,8 +22,8 @@ from agent_on_demand.models import (
     AgentSessionLog,
     APIKey,
     SessionTurn,
+    UserBackendCredential,
     UserCredential,
-    UserSpritesKey,
 )
 from agent_on_demand.session_service.tasks import (
     TaggingQueueWriter,
@@ -49,9 +49,9 @@ def mock_close_old_connections(mocker):
 def user(db):
     u = User.objects.create_user(username="testuser", password="testpass")
     APIKey.create_key(u, "test-key")
-    usk = UserSpritesKey(user=u)
-    usk.set_api_key("fake-sprites-token")
-    usk.save()
+    bcred = UserBackendCredential(user=u, backend="sprites")
+    bcred.set_token("fake-sprites-token")
+    bcred.save()
     return u
 
 
@@ -334,9 +334,9 @@ def test_execute_turn_writes_log_chunks_via_tagging_writer(user, mocker):
 def provision_user(db):
     u = User.objects.create_user(username="prov", password="p")
     APIKey.create_key(u, "test-key")
-    usk = UserSpritesKey(user=u)
-    usk.set_api_key("fake-sprites-token")
-    usk.save()
+    bcred = UserBackendCredential(user=u, backend="sprites")
+    bcred.set_token("fake-sprites-token")
+    bcred.save()
     cred = UserCredential(user=u, kind="provider:anthropic")
     cred.set_value("fake-anthropic-key")
     cred.save()

--- a/tests/test_telemetry_leaks.py
+++ b/tests/test_telemetry_leaks.py
@@ -33,8 +33,8 @@ from agent_on_demand.models import (
     AgentSession,
     APIKey,
     Environment,
+    UserBackendCredential,
     UserCredential,
-    UserSpritesKey,
 )
 
 
@@ -58,9 +58,9 @@ def auth_headers(user):
 
 @pytest.fixture
 def runtime_keys(user):
-    usk = UserSpritesKey(user=user)
-    usk.set_api_key("fake-sprites")
-    usk.save()
+    bcred = UserBackendCredential(user=user, backend="sprites")
+    bcred.set_token("fake-sprites")
+    bcred.save()
     cred = UserCredential(user=user, kind="provider:anthropic")
     cred.set_value("fake-anthropic")
     cred.save()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -7,7 +7,7 @@ from agent_on_demand.models import (
     AgentSession,
     APIKey,
     Environment,
-    UserSpritesKey,
+    UserBackendCredential,
 )
 
 
@@ -70,7 +70,8 @@ def test_register_provisions_sprites_key_and_api_key(client: Client):
     assert resp.url == "/ui/welcome"
 
     charlie = User.objects.get(username="charlie")
-    assert UserSpritesKey.objects.get(user=charlie).get_api_key() == "sprites-token-xyz"
+    cred = UserBackendCredential.objects.get(user=charlie, backend="sprites")
+    assert cred.get_token() == "sprites-token-xyz"
     assert APIKey.objects.filter(user=charlie, is_active=True).count() == 1
 
 
@@ -164,9 +165,9 @@ def test_dashboard_flags_missing_sprites_key(logged_in_client):
 
 @pytest.mark.django_db
 def test_dashboard_hides_warning_when_key_set(logged_in_client, user):
-    usk = UserSpritesKey(user=user)
-    usk.set_api_key("some-token")
-    usk.save()
+    cred = UserBackendCredential(user=user, backend="sprites")
+    cred.set_token("some-token")
+    cred.save()
     resp = logged_in_client.get("/ui/")
     assert resp.status_code == 200
     assert b"don't have a Sprites API token" not in resp.content
@@ -176,14 +177,14 @@ def test_dashboard_hides_warning_when_key_set(logged_in_client, user):
 def test_sprites_key_create_and_rotate(logged_in_client, user):
     resp = logged_in_client.post("/ui/sprites-key", data={"api_key": "first-token"})
     assert resp.status_code == 302
-    usk = UserSpritesKey.objects.get(user=user)
-    assert usk.get_api_key() == "first-token"
+    cred = UserBackendCredential.objects.get(user=user, backend="sprites")
+    assert cred.get_token() == "first-token"
 
     resp = logged_in_client.post("/ui/sprites-key", data={"api_key": "rotated-token"})
     assert resp.status_code == 302
-    usk.refresh_from_db()
-    assert usk.get_api_key() == "rotated-token"
-    assert UserSpritesKey.objects.filter(user=user).count() == 1
+    cred.refresh_from_db()
+    assert cred.get_token() == "rotated-token"
+    assert UserBackendCredential.objects.filter(user=user, backend="sprites").count() == 1
 
 
 @pytest.mark.django_db

--- a/tests/test_user_backend_credential.py
+++ b/tests/test_user_backend_credential.py
@@ -1,10 +1,5 @@
-"""Tests for UserBackendCredential model, the migration backfill, and the
-backend-aware `get_client` lookup.
-
-The credential migration is a cryptographic operation — we move ciphertext
-between tables without touching `FIELD_ENCRYPTION_KEY`. The round-trip test
-proves the copy preserves the bytes Fernet expects.
-"""
+"""Tests for UserBackendCredential model and the backend-aware `get_client`
+lookup."""
 
 from __future__ import annotations
 
@@ -13,7 +8,7 @@ from django.contrib.auth.models import User
 from django.db import IntegrityError
 from django.test import Client
 
-from agent_on_demand.models import UserBackendCredential, UserSpritesKey
+from agent_on_demand.models import UserBackendCredential
 from agent_on_demand.session_service.client import get_client, require_client
 from agent_on_demand.session_service.errors import NoBackendCredentialsError
 
@@ -57,52 +52,6 @@ def test_user_backend_credential_str_includes_user_and_backend(user):
     assert "sprites" in s
 
 
-# --- Migration backfill: every UserSpritesKey becomes a sprites-backend
-# UserBackendCredential, with ciphertext preserved bit-for-bit. We exercise
-# the data migration's RunPython directly against historical models so the
-# test doesn't depend on whether the migration has already been applied to
-# the per-test schema. ---
-
-
-def _backfill_function():
-    from importlib import import_module
-
-    module = import_module("agent_on_demand.migrations.0019_user_backend_credential")
-    return module.backfill_sprites_credentials
-
-
-@pytest.mark.django_db
-def test_migration_backfill_copies_every_sprites_key():
-    users = [User.objects.create_user(username=f"backfill{i}", password="p") for i in range(3)]
-    raw_tokens = ["alpha-token", "beta-token", "gamma-token"]
-    for u, raw in zip(users, raw_tokens, strict=True):
-        usk = UserSpritesKey(user=u)
-        usk.set_api_key(raw)
-        usk.save()
-
-    UserBackendCredential.objects.all().delete()
-
-    class _Apps:
-        @staticmethod
-        def get_model(app_label, model_name):
-            assert app_label == "fairy"
-            return {
-                "UserSpritesKey": UserSpritesKey,
-                "UserBackendCredential": UserBackendCredential,
-            }[model_name]
-
-    _backfill_function()(_Apps(), schema_editor=None)
-
-    assert UserBackendCredential.objects.count() == len(users)
-    for u, raw in zip(users, raw_tokens, strict=True):
-        cred = UserBackendCredential.objects.get(user=u, backend="sprites")
-        # Ciphertext is identical to the source row — same Fernet key, no
-        # re-encryption.
-        assert bytes(cred.encrypted_token) == bytes(u.sprites_key.encrypted_key)
-        # And it round-trips to the original plaintext.
-        assert cred.get_token() == raw
-
-
 # --- get_client(user, backend) ---
 
 
@@ -127,24 +76,6 @@ def test_get_client_uses_user_backend_credential(user, mocker):
 
     assert result == "dummy-client"
     create.assert_called_once_with("from-new-table")
-
-
-def test_get_client_falls_back_to_user_sprites_key(user, mocker):
-    """Pre-backfill window: a UserSpritesKey row exists but no
-    UserBackendCredential row does. The client must fall back so users don't
-    lose access between deploy and migration completion."""
-    usk = UserSpritesKey(user=user)
-    usk.set_api_key("from-legacy-table")
-    usk.save()
-
-    create = mocker.patch(
-        "agent_on_demand.session_service.backends.sprites.SpritesBackend.create_client",
-        return_value="dummy-client",
-    )
-    result = get_client(user)
-
-    assert result == "dummy-client"
-    create.assert_called_once_with("from-legacy-table")
 
 
 def test_get_client_unknown_backend_raises(user):


### PR DESCRIPTION
## Summary

Step 2 of the credential generalization started in #256. PR #256 added `UserBackendCredential`, backfilled every `UserSpritesKey` row into it as `backend="sprites"`, and left the legacy table in place behind a `_lookup_token` fallback so no caller lost access during the deploy window. The backfill has soaked in production for ≥1 day per the rollout plan, so this forward-only migration drops the legacy table and removes the application-side fallback.

**This is the destructive step — after deploy, the `UserSpritesKey` table is gone. Forward-only.** PR #256 has merged to main, so this PR targets `main` directly (no longer stacked).

## Changes

- `migrations/0020_drop_user_sprites_key.py` — `DeleteModel(name="UserSpritesKey")` wrapped in the conditional `IgnoreMigration` pattern from `0017_add_session_backend.py` (and consistent with the #259 hotfix that made all such imports prod-safe).
- `models/auth.py` — `UserSpritesKey` model class deleted.
- `models/__init__.py` — re-export removed.
- `session_service/client.py::_lookup_token` simplified: `UserBackendCredential` is the only source. The `user.sprites_key.get_api_key()` fallback and the `UserSpritesKey` import are gone.
- `admin.py` — `UserSpritesKeyInline`, `UserSpritesKeyForm`, and `UserSpritesKeyAdmin` removed. `UserBackendCredential` admin/inline already exists from #256.
- `ui/views.py` — `register`, `dashboard`, and `sprites_key` views now read/write `UserBackendCredential(backend="sprites")`. The user-facing `/ui/sprites-key` route name is unchanged (still configures a Sprites token).
- `config/settings.py` — comment updated to reference `UserBackendCredential` rather than `UserSpritesKey`.
- Tests: every fixture that constructed a `UserSpritesKey` row now constructs a `UserBackendCredential(backend="sprites")` row. The legacy-fallback test (`test_get_client_falls_back_to_user_sprites_key`) and the migration-backfill test are deleted — the code paths they pinned no longer exist.

## Invariant

```
$ git grep UserSpritesKey src/
src/agent_on_demand/migrations/0010_userspriteskey.py:16:            name="UserSpritesKey",
src/agent_on_demand/migrations/0019_user_backend_credential.py:1:"""Generalize UserSpritesKey into UserBackendCredential.
src/agent_on_demand/migrations/0019_user_backend_credential.py:4:every existing `UserSpritesKey` row as `backend="sprites"`. The ciphertext is
src/agent_on_demand/migrations/0019_user_backend_credential.py:9:`UserSpritesKey` is intentionally left in place. A follow-up forward-only PR
src/agent_on_demand/migrations/0019_user_backend_credential.py:19:    UserSpritesKey = apps.get_model("fairy", "UserSpritesKey")
src/agent_on_demand/migrations/0019_user_backend_credential.py:21:    for sprites_key in UserSpritesKey.objects.all():
```

Hits are only in historical migrations (which reference the model via `apps.get_model` — the safe historical-models pattern). Zero hits in application code.

## Soak status

Per the rollout plan in `thoughts/plans/2026-04-27-session-backend-extraction.md`, this drop runs ≥1 day after #256 deployed.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 1186 passed
- [x] `make check-migrations` — `0020_drop_user_sprites_key`: IGNORE (consistent with 0017/0018)
- [x] `make check-schemas` — Request schemas OK
- [x] `make mutation-test` — 1138/1142 killed, 4 survivors (pre-existing, unchanged from main)
- [ ] After merge: confirm prod migration runs cleanly and `UserSpritesKey` admin route 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)