### PR TITLE
docs: docs excellence pass — README, OSS site, and landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,14 @@ Authentication is via `Authorization: Bearer <token>`.
 Supported runtimes (selected by `runtime` on an agent) and their models.
 Model strings follow the canonical `provider/model_id` form:
 
-| Runtime    | Providers                       | Example models                                                                   |
-| ---------- | ------------------------------- | -------------------------------------------------------------------------------- |
+| Runtime    | Providers                       | Example model strings                                                              |
+| ---------- | ------------------------------- | ---------------------------------------------------------------------------------- |
 | `claude`   | `anthropic`                     | `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5` |
-| `codex`    | `openai`                        | `openai/gpt-4.1`, `openai/o3`, `openai/o4-mini`                                  |
-| `gemini`   | `google`                        | `google/gemini-2.5-pro`, `google/gemini-2.5-flash`                               |
-| `opencode` | `anthropic`, `openai`, `google` | any `anthropic/*`, `openai/*`, or `google/*` in the model catalog                |
+| `codex`    | `openai`                        | `openai/gpt-4.1`, `openai/o3`, `openai/o4-mini`                                    |
+| `gemini`   | `google`                        | `google/gemini-2.5-pro`, `google/gemini-2.5-flash`                                 |
+| `opencode` | `anthropic`, `openai`, `google` | any `anthropic/*`, `openai/*`, or `google/*` in the model catalog                  |
+
+Model strings are always in canonical `provider/model_id` form. The full list is in `src/agent_on_demand/models_catalog.py`.
 
 A model is servable by a runtime whose `providers` set contains the model's
 `provider`. The Claude runtime authenticates via an Anthropic API key by

--- a/README.md
+++ b/README.md
@@ -1,21 +1,67 @@
 # Agent on Demand
 
-API for running AI coding agents on Sprites.
+A REST API for running AI coding agents — Claude Code, Codex, Gemini CLI, opencode — on
+fresh, sandboxed cloud machines (Sprites). You POST a prompt, stream the output over SSE,
+and optionally continue with follow-up turns. Everything is versioned and auditable.
 
-## Documentation
+**Hosted API:** https://aod.ravi.id — sign up, bring your own model API keys, start
+running sessions in minutes.
 
-Full API and operator documentation: **https://ravi-hq.github.io/agent-on-demand**
+**Full docs:** https://ravi-hq.github.io/agent-on-demand
 
-Agent on Demand is a Django service that exposes a REST API for creating **agents**
-(model + runtime + MCP servers), **environments** (packages, env vars,
-setup scripts, networking), and **sessions** (a single agent execution with
-streaming output and multi-turn prompts).
+## What it is
 
-Setting an environment's `networking.type` to `"limited"` enforces a DNS-based
-allow-list at session start — domains outside `allowed_hosts` are blocked
-(DNS `REFUSED`) for the lifetime of the session.
+Agent on Demand manages three resources:
 
-## Setup
+- **Agents** — reusable templates: runtime, model, system prompt, MCP servers, optional default environment.
+- **Environments** — sandbox config: packages, env vars (encrypted at rest), setup scripts, DNS allow-list.
+- **Sessions** — one agent execution. Async; output streams over SSE. Multi-turn via `POST /sessions/{id}/prompt`.
+
+Session state machine: `pending → running → completed | failed | terminated`.
+
+## Quickstart
+
+```bash
+BASE=https://aod.ravi.id   # or http://localhost:8777 for local dev
+TOKEN=aod_...              # get one at aod.ravi.id after signing up
+
+# 1. Create an agent.
+AGENT=$(curl -s -X POST "$BASE/agents" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"hello","model":"anthropic/claude-sonnet-4-6","runtime":"claude"}' | jq -r .id)
+
+# 2. Start a session.
+SESSION=$(curl -s -X POST "$BASE/sessions" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"agent_id\":\"$AGENT\",\"prompt\":\"Say hello.\",\"timeout\":120}" | jq -r .id)
+
+# 3. Stream output.
+curl -N -H "Authorization: Bearer $TOKEN" "$BASE/sessions/$SESSION/stream"
+```
+
+Every event is a JSON line on `data:`. `type` tells you what it is: `start`, `stage`,
+`output`, `exit`. See [Streaming](https://ravi-hq.github.io/agent-on-demand/api/streaming/)
+for the full shape.
+
+## Runtimes
+
+Model strings use the canonical `provider/model_id` form.
+
+| Runtime    | Providers                       | Example models                                                                    |
+| ---------- | ------------------------------- | --------------------------------------------------------------------------------- |
+| `claude`   | `anthropic`                     | `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5` |
+| `codex`    | `openai`                        | `openai/gpt-4.1`, `openai/o3`, `openai/o4-mini`                                   |
+| `gemini`   | `google`                        | `google/gemini-2.5-pro`, `google/gemini-2.5-flash`                                |
+| `opencode` | `anthropic`, `openai`, `google` | any `anthropic/*`, `openai/*`, or `google/*` in the model catalog                 |
+
+`opencode` is installed at session start (`npm i -g opencode-ai`); first-session
+provisioning runs ~10–30 s longer than the pre-baked runtimes.
+
+Runtime source: `src/agent_on_demand/runtimes/`. Model catalog: `src/agent_on_demand/models_catalog.py`.
+
+## Self-hosting
 
 ```bash
 make install       # uv sync --all-extras
@@ -23,31 +69,27 @@ make db-up         # start local Postgres (Docker) + run migrations
 ```
 
 Session execution runs on a separate **worker** process (Procrastinate,
-Postgres-backed broker). The web server only accepts requests and enqueues
-work; a worker picks them up and runs them.
-
-Run both in separate terminals:
+Postgres-backed). Run both in separate terminals:
 
 ```bash
 make dev           # web — serves HTTP on :8777
 make worker        # worker — runs session turns
 ```
 
-`docker-compose.yml` provisions Postgres 16 on `:5432`; the default
-`DATABASE_URL` in `config/settings.py` points at that container. Override
-`DATABASE_URL` to point at another DB.
-
-Local teardown:
+`docker-compose.yml` provisions Postgres 16 on `:5432`. Override `DATABASE_URL` to
+point at another DB.
 
 ```bash
 make db-down       # stop the container
 make db-reset      # destroy the volume and re-migrate
 ```
 
+For a production deployment (env vars, gunicorn, Render) see the
+[Deploy Guide](https://ravi-hq.github.io/agent-on-demand/operators/deploy/).
+
 ## API surface
 
-All endpoints live under the root path. See `src/agent_on_demand/urls.py` for
-the full route table.
+All endpoints live under the root path. Authentication: `Authorization: Bearer <token>`.
 
 - `GET  /health`
 - `POST /agents`, `GET /agents`, `GET /agents/{id}`, `PUT /agents/{id}`,
@@ -59,83 +101,16 @@ the full route table.
   `POST /sessions/{id}/prompt`, `POST /sessions/{id}/terminate`,
   `DELETE /sessions/{id}/delete`, `GET /sessions/{id}/stream` (SSE)
 
-Authentication is via `Authorization: Bearer <token>`.
-
-## Runtimes
-
-Supported runtimes (selected by `runtime` on an agent) and their models.
-Model strings follow the canonical `provider/model_id` form:
-
-| Runtime    | Providers                       | Example models                                                                   |
-| ---------- | ------------------------------- | -------------------------------------------------------------------------------- |
-| `claude`   | `anthropic`                     | `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5` |
-| `codex`    | `openai`                        | `openai/gpt-4.1`, `openai/o3`, `openai/o4-mini`                                  |
-| `gemini`   | `google`                        | `google/gemini-2.5-pro`, `google/gemini-2.5-flash`                               |
-| `opencode` | `anthropic`, `openai`, `google` | any `anthropic/*`, `openai/*`, or `google/*` in the model catalog                |
-
-A model is servable by a runtime whose `providers` set contains the model's
-`provider`. The Claude runtime authenticates via an Anthropic API key by
-default and falls back to OAuth automatically when the user has a
-`runtime_token:claude-oauth` credential registered — the former `claude-oauth`
-runtime was folded into `claude`.
-
-`opencode` is a multi-provider meta-runtime: one `opencode` CLI fronts many
-providers and picks provider+model per invocation via `--model
-provider/model_id`. It reads the native provider env vars
-(`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY`) directly, which
-are sourced from the user's registered `UserCredential` rows. Opencode is
-**not pre-installed** on the Sprite base image — sessions install it via
-`npm i -g opencode-ai` during the `install_runtime` provisioning stage (which
-runs before any network policy is applied, so `registry.npmjs.org` does not
-need to be in `allowed_hosts`). First-session provisioning takes ~10–30s
-longer than the pre-baked runtimes as a result.
-
-Runtime list: `src/agent_on_demand/runtimes/`. Model catalog:
-`src/agent_on_demand/models_catalog.py`.
-
-## Tools
-
-Agents do not have a configurable tool allowlist. Each session runs its runtime
-CLI with that CLI's full default tool set — `bash`, `read`, `write`, `edit`,
-`glob`, `grep`, `web_fetch`, `web_search`, etc. Any MCP servers configured on
-the agent are additionally exposed to the runtime. This applies to every
-runtime (`claude`, `codex`, `gemini`, `opencode`).
-
-There is no per-agent way to disable or restrict individual built-in tools.
+Full route table: `src/agent_on_demand/urls.py`. Interactive reference:
+https://ravi-hq.github.io/agent-on-demand/api/reference/
 
 ## Testing
 
-### Unit / integration tests
-
 ```bash
-make test          # runs tests/, excludes tests/e2e
+make test          # unit + integration (excludes e2e)
 ```
 
-### End-to-end tests
-
-The `tests/e2e/` suite hits a running agent-on-demand deployment via HTTP. It
-covers agent CRUD + versioning + archive, MCP server validation, environment
-CRUD and session integration (packages installed, env vars exported, setup
-scripts executed), and the full session lifecycle: streaming (SSE
-`start`/`output`/`exit`), termination semantics (409s on re-terminate,
-prompt-after-terminate), stream replay after completion, and multi-turn state
-via `POST /sessions/{id}/prompt`.
-
-Required env vars:
-
-- `AOD_API_TOKEN` — valid API key for a preconfigured user
-
-Optional:
-
-- `AOD_API_URL` — defaults to `http://localhost:8777` (what `make dev`
-  serves). Export a different value to point at another deployment. Note that
-  running `pytest` directly (without `make`) defaults to `http://localhost:8000`
-  via `tests/e2e/conftest.py`.
-- `E2E_RUNTIMES` — comma-separated subset of `claude,codex,gemini,opencode`
-  (default `claude`)
-- `E2E_TIMEOUT` — max seconds to wait for a session (default `180`)
-
-Run them:
+End-to-end tests hit a running deployment:
 
 ```bash
 # fast subset — skips @slow tests that spawn real agent sessions
@@ -144,16 +119,11 @@ AOD_API_TOKEN=<token> make test-e2e-fast
 # full suite
 AOD_API_TOKEN=<token> make test-e2e
 
-# single class
-AOD_API_TOKEN=<token> \
-  uv run pytest tests/e2e/test_sessions.py::TestStreaming -v
-
-# point at a remote deployment instead of local
-AOD_API_URL=https://aod.example.com AOD_API_TOKEN=<token> make test-e2e
+# point at a remote deployment
+AOD_API_URL=https://aod.ravi.id AOD_API_TOKEN=<token> make test-e2e
 ```
 
-Without `AOD_API_TOKEN`, every e2e test is auto-skipped by a hook in
-`tests/e2e/conftest.py`, so `make test-all` is safe in CI without creds.
+Without `AOD_API_TOKEN`, every e2e test auto-skips, so `make test-all` is safe in CI.
 
 ## Lint / format
 
@@ -172,6 +142,14 @@ src/
 tests/
   test_*.py          Unit + integration tests (Django test client)
   e2e/               End-to-end tests against a running deployment
+clients/
+  python/            aod-sdk (PyPI)
+  typescript/        @ravi-hq/aod-sdk (npm)
+examples/
+  cli/               CLI wrapper reference implementation
+  chat-bot/          Slack bot with multi-turn sessions
+  dashboard/         Web dashboard with SSE proxy
+  batch-automation/  Concurrent batch runs with AsyncClient
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,19 +1,34 @@
 # Agent on Demand
 
-API for running AI coding agents on Sprites.
+A REST API for running AI coding agents on [Sprites](https://sprites.dev) — lightweight, fast-booting cloud sandboxes. Define an agent (model + runtime + system prompt), wire up an environment (packages, env vars, setup script, network policy), then `POST /sessions` and stream the output over SSE. Multi-turn conversations resume in the same Sprite with the same filesystem.
 
-## Documentation
+Three resources, one workflow: **agent → session → stream**.
 
-Full API and operator documentation: **https://ravi-hq.github.io/agent-on-demand**
+## Quickstart
 
-Agent on Demand is a Django service that exposes a REST API for creating **agents**
-(model + runtime + MCP servers), **environments** (packages, env vars,
-setup scripts, networking), and **sessions** (a single agent execution with
-streaming output and multi-turn prompts).
+```bash
+BASE=http://localhost:8777
+TOKEN=aod_...
 
-Setting an environment's `networking.type` to `"limited"` enforces a DNS-based
-allow-list at session start — domains outside `allowed_hosts` are blocked
-(DNS `REFUSED`) for the lifetime of the session.
+# 1. Create an agent
+AGENT_ID=$(curl -s -X POST "$BASE/agents" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"hello","model":"anthropic/claude-sonnet-4-6","runtime":"claude"}' \
+  | jq -r .id)
+
+# 2. Start a session
+SESS_ID=$(curl -s -X POST "$BASE/sessions" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"agent_id\":\"$AGENT_ID\",\"prompt\":\"Say hello.\",\"timeout\":120}" \
+  | jq -r .id)
+
+# 3. Stream output (SSE)
+curl -N -H "Authorization: Bearer $TOKEN" "$BASE/sessions/$SESS_ID/stream"
+```
+
+Full docs and SDK reference: **https://ravi-hq.github.io/agent-on-demand**
 
 ## Setup
 
@@ -22,9 +37,7 @@ make install       # uv sync --all-extras
 make db-up         # start local Postgres (Docker) + run migrations
 ```
 
-Session execution runs on a separate **worker** process (Procrastinate,
-Postgres-backed broker). The web server only accepts requests and enqueues
-work; a worker picks them up and runs them.
+Session execution runs on a separate **worker** process (Procrastinate, Postgres-backed). The web server accepts requests and enqueues work; the worker runs them.
 
 Run both in separate terminals:
 
@@ -33,11 +46,7 @@ make dev           # web — serves HTTP on :8777
 make worker        # worker — runs session turns
 ```
 
-`docker-compose.yml` provisions Postgres 16 on `:5432`; the default
-`DATABASE_URL` in `config/settings.py` points at that container. Override
-`DATABASE_URL` to point at another DB.
-
-Local teardown:
+`docker-compose.yml` provisions Postgres 16 on `:5432`. Override `DATABASE_URL` to point at another DB.
 
 ```bash
 make db-down       # stop the container
@@ -46,8 +55,7 @@ make db-reset      # destroy the volume and re-migrate
 
 ## API surface
 
-All endpoints live under the root path. See `src/agent_on_demand/urls.py` for
-the full route table.
+All endpoints live under the root path. See `src/agent_on_demand/urls.py` for the full route table.
 
 - `GET  /health`
 - `POST /agents`, `GET /agents`, `GET /agents/{id}`, `PUT /agents/{id}`,
@@ -64,44 +72,24 @@ Authentication is via `Authorization: Bearer <token>`.
 ## Runtimes
 
 Supported runtimes (selected by `runtime` on an agent) and their models.
-Model strings follow the canonical `provider/model_id` form:
+Model strings are in canonical `provider/model_id` form:
 
-| Runtime    | Providers                       | Example model strings                                                              |
+| Runtime    | Vendors                         | Example model strings                                                              |
 | ---------- | ------------------------------- | ---------------------------------------------------------------------------------- |
-| `claude`   | `anthropic`                     | `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5` |
-| `codex`    | `openai`                        | `openai/gpt-4.1`, `openai/o3`, `openai/o4-mini`                                    |
-| `gemini`   | `google`                        | `google/gemini-2.5-pro`, `google/gemini-2.5-flash`                                 |
-| `opencode` | `anthropic`, `openai`, `google` | any `anthropic/*`, `openai/*`, or `google/*` in the model catalog                  |
+| `claude`   | Anthropic                       | `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5` |
+| `codex`    | OpenAI                          | `openai/gpt-4.1`, `openai/o3`, `openai/o4-mini`                                    |
+| `gemini`   | Google                          | `google/gemini-2.5-pro`, `google/gemini-2.5-flash`                                 |
+| `opencode` | Anthropic, OpenAI, Google       | any `anthropic/*`, `openai/*`, or `google/*` in the model catalog                  |
 
-Model strings are always in canonical `provider/model_id` form. The full list is in `src/agent_on_demand/models_catalog.py`.
+The `claude` runtime authenticates via `ANTHROPIC_API_KEY` by default and falls back to OAuth when the user has a `runtime_token:claude-oauth` credential registered.
 
-A model is servable by a runtime whose `providers` set contains the model's
-`provider`. The Claude runtime authenticates via an Anthropic API key by
-default and falls back to OAuth automatically when the user has a
-`runtime_token:claude-oauth` credential registered — the former `claude-oauth`
-runtime was folded into `claude`.
+`opencode` is a multi-provider meta-runtime (sst/opencode) that is not pre-installed on the Sprite base image — first-session provisioning takes 10–30 s longer than the pre-baked runtimes.
 
-`opencode` is a multi-provider meta-runtime: one `opencode` CLI fronts many
-providers and picks provider+model per invocation via `--model
-provider/model_id`. It reads the native provider env vars
-(`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY`) directly, which
-are sourced from the user's registered `UserCredential` rows. Opencode is
-**not pre-installed** on the Sprite base image — sessions install it via
-`npm i -g opencode-ai` during the `install_runtime` provisioning stage (which
-runs before any network policy is applied, so `registry.npmjs.org` does not
-need to be in `allowed_hosts`). First-session provisioning takes ~10–30s
-longer than the pre-baked runtimes as a result.
-
-Runtime list: `src/agent_on_demand/runtimes/`. Model catalog:
-`src/agent_on_demand/models_catalog.py`.
+Full list: `src/agent_on_demand/models_catalog.py` (models), `src/agent_on_demand/runtimes/` (runtime implementations).
 
 ## Tools
 
-Agents do not have a configurable tool allowlist. Each session runs its runtime
-CLI with that CLI's full default tool set — `bash`, `read`, `write`, `edit`,
-`glob`, `grep`, `web_fetch`, `web_search`, etc. Any MCP servers configured on
-the agent are additionally exposed to the runtime. This applies to every
-runtime (`claude`, `codex`, `gemini`, `opencode`).
+Agents do not have a configurable tool allowlist. Each session runs its runtime CLI with that CLI's full default tool set — `bash`, `read`, `write`, `edit`, `glob`, `grep`, `web_fetch`, `web_search`, etc. Any MCP servers configured on the agent are additionally exposed to the runtime.
 
 There is no per-agent way to disable or restrict individual built-in tools.
 
@@ -115,13 +103,7 @@ make test          # runs tests/, excludes tests/e2e
 
 ### End-to-end tests
 
-The `tests/e2e/` suite hits a running agent-on-demand deployment via HTTP. It
-covers agent CRUD + versioning + archive, MCP server validation, environment
-CRUD and session integration (packages installed, env vars exported, setup
-scripts executed), and the full session lifecycle: streaming (SSE
-`start`/`output`/`exit`), termination semantics (409s on re-terminate,
-prompt-after-terminate), stream replay after completion, and multi-turn state
-via `POST /sessions/{id}/prompt`.
+The `tests/e2e/` suite hits a running deployment via HTTP. It covers agent CRUD + versioning + archive, environment CRUD and session integration, and the full session lifecycle (streaming, termination, multi-turn via `POST /sessions/{id}/prompt`).
 
 Required env vars:
 
@@ -129,33 +111,17 @@ Required env vars:
 
 Optional:
 
-- `AOD_API_URL` — defaults to `http://localhost:8777` (what `make dev`
-  serves). Export a different value to point at another deployment. Note that
-  running `pytest` directly (without `make`) defaults to `http://localhost:8000`
-  via `tests/e2e/conftest.py`.
-- `E2E_RUNTIMES` — comma-separated subset of `claude,codex,gemini,opencode`
-  (default `claude`)
+- `AOD_API_URL` — defaults to `http://localhost:8777`
+- `E2E_RUNTIMES` — comma-separated subset of `claude,codex,gemini,opencode` (default `claude`)
 - `E2E_TIMEOUT` — max seconds to wait for a session (default `180`)
 
-Run them:
-
 ```bash
-# fast subset — skips @slow tests that spawn real agent sessions
-AOD_API_TOKEN=<token> make test-e2e-fast
-
-# full suite
-AOD_API_TOKEN=<token> make test-e2e
-
-# single class
-AOD_API_TOKEN=<token> \
-  uv run pytest tests/e2e/test_sessions.py::TestStreaming -v
-
-# point at a remote deployment instead of local
+AOD_API_TOKEN=<token> make test-e2e-fast   # skips @slow tests that spawn real sessions
+AOD_API_TOKEN=<token> make test-e2e        # full suite
 AOD_API_URL=https://aod.example.com AOD_API_TOKEN=<token> make test-e2e
 ```
 
-Without `AOD_API_TOKEN`, every e2e test is auto-skipped by a hook in
-`tests/e2e/conftest.py`, so `make test-all` is safe in CI without creds.
+Without `AOD_API_TOKEN`, every e2e test auto-skips, so `make test-all` is safe in CI without creds.
 
 ## Lint / format
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -26,8 +26,8 @@ with Client(base_url="https://aod.example", token="aod_...") as client:
     )
     agent = client.agents.create(
         name="my-agent",
-        model="claude-sonnet-4-5",
-        runtime="claude-code",
+        model="anthropic/claude-sonnet-4-6",
+        runtime="claude",
         system="You are a careful software engineer.",
         environment_id=env.id,
     )

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -30,8 +30,8 @@ const env = await client.environments.create({
 
 const agent = await client.agents.create({
   name: "my-agent",
-  model: "claude-sonnet-4-5",
-  runtime: "claude-code",
+  model: "anthropic/claude-sonnet-4-6",
+  runtime: "claude",
   system: "You are a careful software engineer.",
   environment_id: env.id,
 });

--- a/site/docs/api/concepts.md
+++ b/site/docs/api/concepts.md
@@ -39,20 +39,22 @@ A **session** is one execution of an agent inside a Sprite. Sessions are:
                 POST /sessions
                      │
                      ▼
-                ┌─────────┐
-                │ pending │◄──────────────────────────────┐
-                └────┬────┘                               │
-                     │ background execution starts        │ POST /sessions/{id}/prompt
-                     ▼                                    │ (allowed; resets to pending)
+                ┌─────────┐◄──────────────────────────────┐
+                │ pending │                               │ POST /sessions/{id}/prompt
+                └────┬────┘                               │ (resets to pending)
+                     │ background execution starts        │
+                     ▼                                    │
                 ┌─────────┐                               │
-                │ running │───────────────────────────────┘
-                └────┬────┘
-       ┌─────────────┼──────────────┐
-       │             │              │
-       ▼             ▼              ▼
- ┌──────────┐  ┌────────┐  ┌──────────────┐
- │completed │  │ failed │  │  terminated  │◄── POST /sessions/{id}/terminate
- └──────────┘  └────────┘  └──────────────┘
+                │ running │                               │
+                └────┬────┘                               │
+       ┌─────────────┼──────────────┐                     │
+       │             │              │                     │
+       ▼             ▼              ▼                     │
+ ┌──────────┐  ┌────────┐  ┌──────────────┐              │
+ │completed │  │ failed │  │  terminated  │◄─ POST /sessions/{id}/terminate
+ └────┬─────┘  └────────┘  └──────────────┘
+      │
+      └─────────────────────────────────────────────────►┘
 ```
 
 - `pending` → execution has been accepted but hasn't started yet.
@@ -61,7 +63,7 @@ A **session** is one execution of an agent inside a Sprite. Sessions are:
 - `failed` → runtime exited non-zero, or an unhandled exception occurred. `exit_code` may be `null` for the exception case.
 - `terminated` → stopped by `POST /sessions/{id}/terminate`. Cannot be continued.
 
-After `completed` or `failed`, you may continue the session with `POST /sessions/{id}/prompt`. After `terminated`, you cannot.
+After `completed`, you may continue the session with `POST /sessions/{id}/prompt` — this resets the session to `pending` and resumes in the same Sprite. `failed` and `terminated` sessions cannot be continued; start a new session instead.
 
 ## Optimistic concurrency (agents and environments)
 

--- a/site/docs/api/concepts.md
+++ b/site/docs/api/concepts.md
@@ -31,7 +31,7 @@ A **session** is one execution of an agent inside a Sprite. Sessions are:
 
 - **Async** — `POST /sessions` returns `202` immediately; the agent runs in the background.
 - **Streamable** — `GET /sessions/{id}/stream` delivers output as Server-Sent Events.
-- **Multi-turn** — after `completed` or `failed`, you can `POST /sessions/{id}/prompt` to continue in the same Sprite with the same filesystem and runtime history.
+- **Multi-turn** — after `completed`, you can `POST /sessions/{id}/prompt` to continue in the same Sprite with the same filesystem and runtime history. (`failed` and `terminated` sessions cannot be continued.)
 
 ## Session state machine
 
@@ -42,26 +42,29 @@ A **session** is one execution of an agent inside a Sprite. Sessions are:
                 ┌─────────┐
                 │ pending │◄──────────────────────────────┐
                 └────┬────┘                               │
-                     │ background execution starts        │ POST /sessions/{id}/prompt
-                     ▼                                    │ (allowed; resets to pending)
+                     │ worker picks it up                 │ POST /sessions/{id}/prompt
+                     ▼                                    │ (resets to pending)
                 ┌─────────┐                               │
-                │ running │───────────────────────────────┘
-                └────┬────┘
-       ┌─────────────┼──────────────┐
-       │             │              │
-       ▼             ▼              ▼
- ┌──────────┐  ┌────────┐  ┌──────────────┐
- │completed │  │ failed │  │  terminated  │◄── POST /sessions/{id}/terminate
- └──────────┘  └────────┘  └──────────────┘
+                │ running │                               │
+                └────┬────┘                               │
+       ┌─────────────┼──────────────┐                     │
+       │             │              │                     │
+       ▼             ▼              ▼                     │
+ ┌──────────┐  ┌────────┐  ┌──────────────┐              │
+ │completed │  │ failed │  │  terminated  │◄─ POST …/terminate
+ └────┬─────┘  └────────┘  └──────────────┘
+      │
+      └──────────────────────────────────────────────────┘
+        POST /sessions/{id}/prompt (allowed from completed)
 ```
 
-- `pending` → execution has been accepted but hasn't started yet.
-- `running` → the agent CLI is executing inside the Sprite.
-- `completed` → runtime exited with code 0.
-- `failed` → runtime exited non-zero, or an unhandled exception occurred. `exit_code` may be `null` for the exception case.
+- `pending` → accepted, not yet executing. Prompts are accepted but state stays `pending`.
+- `running` → agent CLI is executing inside the Sprite. Prompts return `409`.
+- `completed` → runtime exited with code 0. Prompts accepted; session resets to `pending`.
+- `failed` → runtime exited non-zero, or an unhandled exception. Cannot be continued; `POST /prompt` returns `409`.
 - `terminated` → stopped by `POST /sessions/{id}/terminate`. Cannot be continued.
 
-After `completed` or `failed`, you may continue the session with `POST /sessions/{id}/prompt`. After `terminated`, you cannot.
+Only `pending` and `completed` sessions accept `POST /sessions/{id}/prompt`. `running`, `failed`, and `terminated` all return `409`.
 
 ## Optimistic concurrency (agents and environments)
 

--- a/site/docs/api/errors.md
+++ b/site/docs/api/errors.md
@@ -57,9 +57,10 @@ All of these return `409`:
 | `POST /sessions` | Agent is archived | `"Cannot create session with archived agent"` |
 | `POST /sessions` | Environment is archived | `"Cannot create session with archived environment"` |
 | `POST /sessions/{id}/prompt` | Session is running | `"Session is already running"` |
+| `POST /sessions/{id}/prompt` | Session has failed | `"Session has failed and cannot be resumed. Start a new session."` |
 | `POST /sessions/{id}/prompt` | Session is terminated | `"Session has been terminated"` |
 | `POST /sessions/{id}/terminate` | Session already terminated | `"Session is already terminated"` |
-| `DELETE /sessions/{id}/delete` | Session is running | `"Cannot delete a running session"` |
+| `DELETE /sessions/{id}/delete` | Session is active (pending or running) | `"Cannot delete an active session"` |
 
 ## Notes
 

--- a/site/docs/api/errors.md
+++ b/site/docs/api/errors.md
@@ -57,9 +57,10 @@ All of these return `409`:
 | `POST /sessions` | Agent is archived | `"Cannot create session with archived agent"` |
 | `POST /sessions` | Environment is archived | `"Cannot create session with archived environment"` |
 | `POST /sessions/{id}/prompt` | Session is running | `"Session is already running"` |
+| `POST /sessions/{id}/prompt` | Session has failed | `"Session has failed and cannot be resumed. Start a new session."` |
 | `POST /sessions/{id}/prompt` | Session is terminated | `"Session has been terminated"` |
 | `POST /sessions/{id}/terminate` | Session already terminated | `"Session is already terminated"` |
-| `DELETE /sessions/{id}/delete` | Session is running | `"Cannot delete a running session"` |
+| `DELETE /sessions/{id}/delete` | Session is running or pending | `"Cannot delete an active session"` |
 
 ## Notes
 

--- a/site/docs/api/pagination.md
+++ b/site/docs/api/pagination.md
@@ -41,7 +41,7 @@ curl -H "Authorization: Bearer $TOKEN" "$BASE/agents"
       "id": "3f2a1b4c-...",
       "type": "agent",
       "name": "code-reviewer",
-      "model": "claude-sonnet-4-6",
+      "model": "anthropic/claude-sonnet-4-6",
       "runtime": "claude",
       "version": 2,
       "created_at": "2026-04-17T14:00:00.000000+00:00",

--- a/site/docs/api/product.md
+++ b/site/docs/api/product.md
@@ -2,7 +2,7 @@
 
 ## What is Agent on Demand?
 
-Agent on Demand is a REST API for running AI coding agents on [Sprites](https://fly.io/docs/machines/) — Fly.io's lightweight, fast-booting Firecracker microVMs. It manages three resources — agents, environments, and sessions — and exposes a simple HTTP interface for launching agent runs, streaming their output, and continuing multi-turn conversations.
+Agent on Demand is a REST API for running AI coding agents on [Sprites](https://sprites.dev) — Fly.io's lightweight, fast-booting Firecracker microVMs. It manages three resources — agents, environments, and sessions — and exposes a simple HTTP interface for launching agent runs, streaming their output, and continuing multi-turn conversations.
 
 ## What problems does it solve?
 
@@ -19,3 +19,30 @@ Agent on Demand is a REST API for running AI coding agents on [Sprites](https://
 Agent on Demand runs agents on Sprites, not on Fly Machines. Sprites are purpose-built for short-lived, fast-booting workloads. Agent on Demand manages their lifecycle — creating the Sprite at session start, applying the environment, running the agent CLI, and tearing it down on termination — so you don't have to.
 
 The result is a clean API surface: create agent → create session → stream output → optionally continue or terminate.
+
+## When to use it
+
+- You want to trigger agent sessions from code or CI, not from a developer's terminal.
+- You're building an integration — Slack bot, GitHub Action, internal dashboard, batch job — and need a reliable HTTP interface to drive agent execution.
+- You want sessions isolated from each other and from your host infrastructure (each runs in its own Sprite).
+- You need multi-turn conversations that preserve filesystem state between messages.
+
+## When not to use it
+
+- **Local, interactive coding**: if a developer is sitting at their laptop, they should run Claude Code, Codex, or Gemini CLI directly. Agent on Demand adds latency and infrastructure overhead that's unnecessary for interactive use.
+- **Very short-lived tasks with no isolation need**: Sprite provisioning takes a few seconds. If you're running sub-second tasks where sandbox isolation doesn't matter, a direct API call to the model is faster and cheaper.
+- **Tasks that need a persistent, long-lived machine**: Sprites are designed for bursty, short-lived work. For a continuously-running agent daemon, a regular VM or container is a better fit.
+
+## Self-hosting vs the hosted API
+
+Agent on Demand is open source (Apache-2.0). You can run your own instance — see the [Deploy Guide](../operators/deploy.md) — or use the hosted API at [aod.ravi.id](https://aod.ravi.id).
+
+| | Self-hosted | Hosted API |
+|---|---|---|
+| **Sprites account** | You bring your own | Managed for you |
+| **Model API keys** | Stored encrypted in your DB | Stored encrypted, scoped per user |
+| **Infra ops** | You run web + worker + Postgres | Handled by the operator |
+| **Data residency** | Under your control | Determined by the operator |
+| **Cost** | Sprites + model API costs | Sprites + model API costs (no markup on API) |
+
+Both options use the same codebase and the same API surface.

--- a/site/docs/api/quickstart.md
+++ b/site/docs/api/quickstart.md
@@ -37,7 +37,7 @@ An agent is a reusable template. The minimum required fields are `name`, `model`
       -H "Content-Type: application/json" \
       -d '{
         "name": "hello",
-        "model": "claude-sonnet-4-6",
+        "model": "anthropic/claude-sonnet-4-6",
         "runtime": "claude"
       }'
     ```
@@ -50,7 +50,7 @@ An agent is a reusable template. The minimum required fields are `name`, `model`
     client = Client()  # reads AOD_API_URL + AOD_API_TOKEN
     agent = client.agents.create(
         name="hello",
-        model="claude-sonnet-4-6",
+        model="anthropic/claude-sonnet-4-6",
         runtime="claude",
     )
     print(agent.id)
@@ -63,7 +63,7 @@ Response (`201 Created`):
   "id": "<agent-uuid>",
   "type": "agent",
   "name": "hello",
-  "model": "claude-sonnet-4-6",
+  "model": "anthropic/claude-sonnet-4-6",
   "runtime": "claude",
   "system": null,
   "description": null,
@@ -169,7 +169,7 @@ The stream closes after the terminal event (`exit`, `error`, or `terminated`). R
 
     # Create agent
     AGENT_ID=$(curl -s -X POST "$BASE/agents" -H "$AUTH" -H "$JSON" \
-      -d '{"name":"demo","model":"claude-sonnet-4-6","runtime":"claude"}' \
+      -d '{"name":"demo","model":"anthropic/claude-sonnet-4-6","runtime":"claude"}' \
       | jq -r .id)
 
     # Create session
@@ -191,7 +191,7 @@ The stream closes after the terminal event (`exit`, `error`, or `terminated`). R
 
     with Client() as client:
         agent = client.agents.create(
-            name="demo", model="claude-sonnet-4-6", runtime="claude"
+            name="demo", model="anthropic/claude-sonnet-4-6", runtime="claude"
         )
         ack = client.sessions.create(
             agent_id=agent.id, prompt="Say hello.", timeout=120

--- a/site/docs/api/quickstart.md
+++ b/site/docs/api/quickstart.md
@@ -37,7 +37,7 @@ An agent is a reusable template. The minimum required fields are `name`, `model`
       -H "Content-Type: application/json" \
       -d '{
         "name": "hello",
-        "model": "claude-sonnet-4-6",
+        "model": "anthropic/claude-sonnet-4-6",
         "runtime": "claude"
       }'
     ```
@@ -50,7 +50,7 @@ An agent is a reusable template. The minimum required fields are `name`, `model`
     client = Client()  # reads AOD_API_URL + AOD_API_TOKEN
     agent = client.agents.create(
         name="hello",
-        model="claude-sonnet-4-6",
+        model="anthropic/claude-sonnet-4-6",
         runtime="claude",
     )
     print(agent.id)
@@ -63,7 +63,7 @@ Response (`201 Created`):
   "id": "<agent-uuid>",
   "type": "agent",
   "name": "hello",
-  "model": "claude-sonnet-4-6",
+  "model": "anthropic/claude-sonnet-4-6",
   "runtime": "claude",
   "system": null,
   "description": null,
@@ -137,9 +137,13 @@ Connect to the SSE stream to receive agent output in real time.
     ```
     data: {"type":"start","runtime":"claude","session_id":"<session-uuid>"}
 
-    data: {"type":"output","stream":"stdout","data":"Thu Apr 17 14:00:00 UTC 2026\n"}
+    data: {"type":"turn_start","id":1,"turn":1}
 
-    data: {"type":"exit","code":0}
+    id: 1
+    data: {"type":"output","id":1,"stream":"stdout","data":"Thu Apr 17 14:00:00 UTC 2026\n","turn":1}
+
+    id: 2
+    data: {"type":"exit","id":2,"code":0}
     ```
 
 === "Python"
@@ -169,7 +173,7 @@ The stream closes after the terminal event (`exit`, `error`, or `terminated`). R
 
     # Create agent
     AGENT_ID=$(curl -s -X POST "$BASE/agents" -H "$AUTH" -H "$JSON" \
-      -d '{"name":"demo","model":"claude-sonnet-4-6","runtime":"claude"}' \
+      -d '{"name":"demo","model":"anthropic/claude-sonnet-4-6","runtime":"claude"}' \
       | jq -r .id)
 
     # Create session
@@ -191,7 +195,7 @@ The stream closes after the terminal event (`exit`, `error`, or `terminated`). R
 
     with Client() as client:
         agent = client.agents.create(
-            name="demo", model="claude-sonnet-4-6", runtime="claude"
+            name="demo", model="anthropic/claude-sonnet-4-6", runtime="claude"
         )
         ack = client.sessions.create(
             agent_id=agent.id, prompt="Say hello.", timeout=120

--- a/site/docs/api/runtimes.md
+++ b/site/docs/api/runtimes.md
@@ -2,15 +2,16 @@
 
 A **runtime** is the CLI that Agent on Demand invokes inside the Sprite to drive the model. It's a required field on an agent and determines how the session process is launched, which API key env var is read, and how multi-turn conversations are resumed.
 
-Three runtimes are supported today:
+Four runtimes are supported:
 
-| Runtime  | Vendor CLI       | Models                                                       | API key env var       |
-| -------- | ---------------- | ------------------------------------------------------------ | --------------------- |
-| `claude` | Claude Code      | `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5` (+ older `claude-opus-4-0-20250514`, `claude-sonnet-4-0-20250514`, `claude-sonnet-4-5-20250514`, `claude-3-5-haiku-20241022`) | `ANTHROPIC_API_KEY`   |
-| `codex`  | OpenAI Codex CLI | `gpt-4.1`, `o3`, `o4-mini`                                   | `CODEX_API_KEY`       |
-| `gemini` | Gemini CLI       | `gemini-2.5-pro`, `gemini-2.5-flash`                         | `GEMINI_API_KEY`      |
+| Runtime    | Vendor CLI         | Models (canonical `provider/model_id`)                                                                                                  | API key env var                        |
+| ---------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `claude`   | Claude Code        | `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5` (+ older dated variants)                       | `ANTHROPIC_API_KEY`                    |
+| `codex`    | OpenAI Codex CLI   | `openai/gpt-4.1`, `openai/o3`, `openai/o4-mini`                                                                                         | `OPENAI_API_KEY`                       |
+| `gemini`   | Gemini CLI         | `google/gemini-2.5-pro`, `google/gemini-2.5-flash`                                                                                      | `GEMINI_API_KEY`                       |
+| `opencode` | opencode (sst/opencode) | Any `anthropic/*`, `openai/*`, or `google/*` model in the catalog                                                                 | `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` |
 
-The canonical list lives in [`src/agent_on_demand/runtimes.py`](https://github.com/ravi-hq/agent-on-demand/blob/main/src/agent_on_demand/runtimes.py) (`RUNTIMES` for the runtime table, `AgentModel` for the model enum).
+Model strings are in canonical `provider/model_id` form — e.g. `anthropic/claude-sonnet-4-6`, not `claude-sonnet-4-6`. The full list lives in [`src/agent_on_demand/models_catalog.py`](https://github.com/ravi-hq/agent-on-demand/blob/main/src/agent_on_demand/models_catalog.py); the runtime registry is in [`src/agent_on_demand/runtimes/__init__.py`](https://github.com/ravi-hq/agent-on-demand/blob/main/src/agent_on_demand/runtimes/__init__.py).
 
 ## Setting the runtime on an agent
 
@@ -23,11 +24,11 @@ curl -X POST https://aod.example.com/agents \
   -d '{
     "name": "hello",
     "runtime": "claude",
-    "model": "claude-sonnet-4-6"
+    "model": "anthropic/claude-sonnet-4-6"
   }'
 ```
 
-`runtime` must be one of the values above (400 otherwise). `model` must match a known `AgentModel` value. The two fields are validated independently — there's no server-side enforcement that a given `model` "belongs to" a given `runtime`, so it's on you to pair them sensibly.
+`runtime` must be one of the four values above (400 otherwise). `model` must be a known canonical model ID. The server validates them independently — pairing a mismatched runtime and model (e.g. an OpenAI model with the `claude` runtime) will pass validation but fail at session execution when the CLI rejects the model name.
 
 ## Supplying API keys
 
@@ -51,13 +52,11 @@ If no environment is attached to a session, or the environment doesn't set the r
 
 ### `claude`
 
-Uses the Claude Code CLI in `--print` + `stream-json` mode. AoD pre-generates a UUID at session create and passes it as `--session-id` on the first turn, then `--resume <uuid>` on every subsequent turn — more reliable than `--continue` in non-interactive mode, which has been observed to silently fork new sessions.
+Uses the Claude Code CLI in `--print` + `stream-json` mode. AoD pre-generates a UUID at session create and passes it as `--session-id` on the first turn, then `--resume <uuid>` on every subsequent turn — more reliable than `--continue` in non-interactive mode.
 
-#### `claude-oauth` (auth variant)
+#### OAuth auth variant
 
-`claude-oauth` is the same `claude` CLI with the same command flags, but it authenticates with a Claude Pro/Max OAuth token (`CLAUDE_CODE_OAUTH_TOKEN`) instead of an API key (`ANTHROPIC_API_KEY`). Use it when you want to run sessions against a subscription seat rather than pay-per-token API billing.
-
-Everything else — supported models, resume semantics, output format — is identical to `claude`.
+The `claude` runtime also supports Claude Pro/Max OAuth tokens. Register a `runtime_token:claude-oauth` credential for a user and AoD will export `CLAUDE_CODE_OAUTH_TOKEN` instead of `ANTHROPIC_API_KEY`. Everything else — models, resume semantics, output format — is identical. The runtime string on the agent remains `"claude"`.
 
 ### `codex`
 
@@ -66,6 +65,14 @@ Uses `codex exec` with `--dangerously-bypass-approvals-and-sandbox --json`. The 
 ### `gemini`
 
 Uses the Gemini CLI with `--output-format stream-json`. Resume is handled via `--resume`.
+
+### `opencode`
+
+Uses [sst/opencode](https://opencode.ai) — a multi-provider CLI that fronts Anthropic, OpenAI, and Google models through a single binary. Pass any `anthropic/*`, `openai/*`, or `google/*` model ID; opencode picks the right provider API at invocation time.
+
+opencode is **not pre-installed** on the Sprite base image. AoD runs `npm install -g opencode-ai@<pinned>` during session provisioning (before any network policy is applied, so `registry.npmjs.org` does not need to be in `allowed_hosts`). First-session provisioning takes 10–30 s longer than the pre-baked runtimes as a result.
+
+If the environment has `networking.type == "limited"`, the allowed-hosts list must include `registry.npmjs.org` for opencode provisioning to succeed.
 
 ## Tools
 

--- a/site/docs/api/runtimes.md
+++ b/site/docs/api/runtimes.md
@@ -1,40 +1,52 @@
 # Runtimes
 
-A **runtime** is the CLI that Agent on Demand invokes inside the Sprite to drive the model. It's a required field on an agent and determines how the session process is launched, which API key env var is read, and how multi-turn conversations are resumed.
+A **runtime** is the CLI that Agent on Demand invokes inside the Sprite to drive the model.
+It is a required field on an agent and determines how the session process is launched,
+which API key env var is read, and how multi-turn conversations are resumed.
 
-Three runtimes are supported today:
+Four runtimes are supported:
 
-| Runtime  | Vendor CLI       | Models                                                       | API key env var       |
-| -------- | ---------------- | ------------------------------------------------------------ | --------------------- |
-| `claude` | Claude Code      | `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5` (+ older `claude-opus-4-0-20250514`, `claude-sonnet-4-0-20250514`, `claude-sonnet-4-5-20250514`, `claude-3-5-haiku-20241022`) | `ANTHROPIC_API_KEY`   |
-| `codex`  | OpenAI Codex CLI | `gpt-4.1`, `o3`, `o4-mini`                                   | `CODEX_API_KEY`       |
-| `gemini` | Gemini CLI       | `gemini-2.5-pro`, `gemini-2.5-flash`                         | `GEMINI_API_KEY`      |
+| Runtime    | Vendor CLI       | Providers                       | API key env var(s)                                   |
+| ---------- | ---------------- | ------------------------------- | ----------------------------------------------------- |
+| `claude`   | Claude Code      | `anthropic`                     | `ANTHROPIC_API_KEY` (or `CLAUDE_CODE_OAUTH_TOKEN` — see below) |
+| `codex`    | OpenAI Codex CLI | `openai`                        | `OPENAI_API_KEY`                                     |
+| `gemini`   | Gemini CLI       | `google`                        | `GEMINI_API_KEY`                                     |
+| `opencode` | opencode         | `anthropic`, `openai`, `google` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY` |
 
-The canonical list lives in [`src/agent_on_demand/runtimes.py`](https://github.com/ravi-hq/agent-on-demand/blob/main/src/agent_on_demand/runtimes.py) (`RUNTIMES` for the runtime table, `AgentModel` for the model enum).
+Model strings use the canonical `provider/model_id` form. The full model catalog lives in
+[`src/agent_on_demand/models_catalog.py`](https://github.com/ravi-hq/agent-on-demand/blob/main/src/agent_on_demand/models_catalog.py).
+
+Runtime source: [`src/agent_on_demand/runtimes/`](https://github.com/ravi-hq/agent-on-demand/blob/main/src/agent_on_demand/runtimes/).
 
 ## Setting the runtime on an agent
 
 Pass `runtime` and `model` when creating the agent:
 
 ```bash
-curl -X POST https://aod.example.com/agents \
+curl -X POST https://aod.ravi.id/agents \
   -H "Authorization: Bearer $AOD_API_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "hello",
     "runtime": "claude",
-    "model": "claude-sonnet-4-6"
+    "model": "anthropic/claude-sonnet-4-6"
   }'
 ```
 
-`runtime` must be one of the values above (400 otherwise). `model` must match a known `AgentModel` value. The two fields are validated independently — there's no server-side enforcement that a given `model` "belongs to" a given `runtime`, so it's on you to pair them sensibly.
+`runtime` must be one of the values in the table above (400 otherwise). `model` must be a
+key in the model catalog. On create and update, the server validates that the runtime's
+`providers` set includes the model's provider — mismatches return 422.
 
 ## Supplying API keys
 
-Each runtime reads its API key from a specific env var at session start. You set that env var on the session's **environment**, not the agent, since credentials are per-deployment rather than per-template:
+Each runtime reads its API key from a specific env var at session start. On the hosted API
+(`aod.ravi.id`) you register credentials once via the dashboard; they are stored encrypted
+and injected into every session you own.
+
+When self-hosting, set the env var on the session's **environment**:
 
 ```bash
-curl -X POST https://aod.example.com/environments \
+curl -X POST https://aod.ravi.id/environments \
   -H "Authorization: Bearer $AOD_API_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -43,36 +55,60 @@ curl -X POST https://aod.example.com/environments \
   }'
 ```
 
-`env_vars` are encrypted at rest and never echoed back in API responses. See [Core Concepts → Environments](concepts.md#environments) for the full shape.
+`env_vars` are encrypted at rest and never echoed back in API responses.
+See [Core Concepts → Environments](concepts.md#environments) for the full shape.
 
-If no environment is attached to a session, or the environment doesn't set the runtime's expected env var, the CLI will fail on startup and the session will transition to `failed`.
+If no environment is attached to a session, or the environment doesn't set the runtime's
+expected env var, the CLI will fail on startup and the session will transition to `failed`.
 
 ## Per-runtime notes
 
 ### `claude`
 
-Uses the Claude Code CLI in `--print` + `stream-json` mode. AoD pre-generates a UUID at session create and passes it as `--session-id` on the first turn, then `--resume <uuid>` on every subsequent turn — more reliable than `--continue` in non-interactive mode, which has been observed to silently fork new sessions.
+Uses the Claude Code CLI in `--print` + `stream-json` mode. AoD pre-generates a UUID at
+session create and passes it as `--session-id` on the first turn, then `--resume <uuid>`
+on every subsequent turn — more reliable than `--continue` in non-interactive mode, which
+has been observed to silently fork new sessions.
 
-#### `claude-oauth` (auth variant)
-
-`claude-oauth` is the same `claude` CLI with the same command flags, but it authenticates with a Claude Pro/Max OAuth token (`CLAUDE_CODE_OAUTH_TOKEN`) instead of an API key (`ANTHROPIC_API_KEY`). Use it when you want to run sessions against a subscription seat rather than pay-per-token API billing.
-
-Everything else — supported models, resume semantics, output format — is identical to `claude`.
+**OAuth auth variant:** if you register a `runtime_token:claude-oauth` credential (a Claude
+Pro/Max OAuth token), it is written as `CLAUDE_CODE_OAUTH_TOKEN` to the session Sprite
+instead of `ANTHROPIC_API_KEY`. The CLI picks it up automatically. Everything else —
+supported models, resume semantics, output format — is identical. Use it when you want to
+run sessions against a subscription seat rather than pay-per-token API billing.
 
 ### `codex`
 
-Uses `codex exec` with `--dangerously-bypass-approvals-and-sandbox --json`. The prompt is piped in on stdin for the first turn; subsequent turns use `codex exec resume --last` to continue in-place.
+Uses `codex exec` with `--dangerously-bypass-approvals-and-sandbox --json`. The prompt
+is piped in on stdin for the first turn; subsequent turns use `codex exec resume --last`
+to continue in-place.
 
 ### `gemini`
 
 Uses the Gemini CLI with `--output-format stream-json`. Resume is handled via `--resume`.
 
+### `opencode`
+
+A multi-provider meta-runtime: one `opencode` CLI fronts `anthropic`, `openai`, and
+`google` providers, selecting provider and model per invocation via `--model provider/model_id`.
+
+**Installation:** opencode is not pre-installed on the Sprite base image. Sessions install
+it via `npm i -g opencode-ai` during the `provision_setup` stage (before any network
+policy is applied, so `registry.npmjs.org` does not need to be in `allowed_hosts`).
+First-session provisioning takes ~10–30 s longer than the pre-baked runtimes.
+
 ## Tools
 
-All runtimes run with their vendor CLI's **full default tool set** — `bash`, `read`, `write`, `edit`, `glob`, `grep`, `web_fetch`, `web_search`, and so on. There is no per-agent allowlist for built-in tools, and no way to disable a specific built-in. Any MCP servers you configure on the agent are exposed to the runtime on top of the default tools.
+All runtimes run with their vendor CLI's **full default tool set** — `bash`, `read`,
+`write`, `edit`, `glob`, `grep`, `web_fetch`, `web_search`, and so on. There is no
+per-agent allowlist for built-in tools, and no way to disable a specific built-in.
+Any MCP servers you configure on the agent are exposed to the runtime on top of the
+default tools.
 
-This is intentional: Sprites are disposable sandboxes, so the tool surface is bounded by the Sprite itself rather than by a runtime-level policy.
+This is intentional: Sprites are disposable sandboxes, so the tool surface is bounded
+by the Sprite itself rather than by a runtime-level policy.
 
 ## Streaming output shape
 
-Every runtime emits a `start` event with `runtime` set to the runtime name, followed by the runtime's native streaming format wrapped in `output` events, then an `exit` event with the process exit code. Clients that want to render rich output will need runtime-specific parsing of the `output.data` payloads — see [Streaming](streaming.md) for the event envelope.
+Every runtime emits a `start` event with `runtime` set to the runtime name, followed by
+the runtime's native streaming format wrapped in `output` events, then an `exit` event
+with the process exit code. See [Streaming](streaming.md) for the full event envelope.

--- a/site/docs/api/runtimes.md
+++ b/site/docs/api/runtimes.md
@@ -70,9 +70,7 @@ Uses the Gemini CLI with `--output-format stream-json`. Resume is handled via `-
 
 Uses [sst/opencode](https://opencode.ai) — a multi-provider CLI that fronts Anthropic, OpenAI, and Google models through a single binary. Pass any `anthropic/*`, `openai/*`, or `google/*` model ID; opencode picks the right provider API at invocation time.
 
-opencode is **not pre-installed** on the Sprite base image. AoD runs `npm install -g opencode-ai@<pinned>` during session provisioning (before any network policy is applied, so `registry.npmjs.org` does not need to be in `allowed_hosts`). First-session provisioning takes 10–30 s longer than the pre-baked runtimes as a result.
-
-If the environment has `networking.type == "limited"`, the allowed-hosts list must include `registry.npmjs.org` for opencode provisioning to succeed.
+opencode is **not pre-installed** on the Sprite base image. AoD runs `npm install -g opencode-ai@<pinned>` during the `install_runtime` provisioning stage, which runs before any network policy is applied. `registry.npmjs.org` does **not** need to be in `allowed_hosts` for this to succeed. First-session provisioning takes 10–30 s longer than the pre-baked runtimes as a result.
 
 ## Tools
 

--- a/site/docs/api/streaming.md
+++ b/site/docs/api/streaming.md
@@ -13,7 +13,7 @@ Agent on Demand streams session output as [Server-Sent Events](https://developer
 - `Cache-Control: no-cache`
 - `X-Accel-Buffering: no`
 
-Each event is a line of the form `data: <json>\n\n`, preceded by an `id: <int>\n` line for every event except `start`.
+Each event is a line of the form `data: <json>\n\n`. All events except `start` and `turn_start` are preceded by an `id: <int>\n` line. `turn_start` is a synthetic event derived from the same log row as the `output` event that follows it; advancing the SSE cursor on `turn_start` would cause the subsequent `output` event (same id) to be skipped on reconnect, so it deliberately has no `id:` line.
 
 ## Event types
 
@@ -75,7 +75,6 @@ Connecting to a stream always replays all stored output from the beginning:
 ```
 data: {"type": "start", "runtime": "claude", "session_id": "..."}
 
-id: 1
 data: {"type": "turn_start", "id": 1, "turn": 1}
 
 id: 1

--- a/site/docs/api/streaming.md
+++ b/site/docs/api/streaming.md
@@ -21,7 +21,7 @@ Each event is a line of the form `data: <json>\n\n`, preceded by an `id: <int>\n
 |------|---------|-------|
 | `start` | `{"type":"start","runtime":"claude","session_id":"<uuid>"}` | Always the first event, before any replayed output. No `id` field. |
 | `stage` | `{"type":"stage","id":3,"stage":"create_sprite","state":"started"\|"done"\|"failed","duration_ms":15200,"message":"..."}` | Emitted during provisioning and just before the runtime starts. `duration_ms` is present on `done` and `failed`; `message` is present on `failed` only. Non-terminal — clients should keep reading. See [Provisioning stages](#provisioning-stages) below. |
-| `turn_start` | `{"type":"turn_start","id":42,"turn":1}` | Emitted before the first `output` event of each turn. Turn numbers start at 1. |
+| `turn_start` | `{"type":"turn_start","id":42,"turn":1}` | Emitted before the first `output` event of each turn. Turn numbers start at 1. Does not advance the SSE cursor (`id:` line is omitted); use the `id` from the `output` event that follows for `Last-Event-ID`. |
 | `output` | `{"type":"output","id":42,"stream":"stdout"\|"stderr","data":"...","turn":1}` | One chunk of agent output; may contain multiple lines |
 | `exit` | `{"type":"exit","id":42,"code":0}` | Terminal. Emitted when the runtime exits (code 0 = success, non-zero = failure) |
 | `error` | `{"type":"error","id":42,"message":"..."}` | Terminal. Emitted on unhandled exception — no exit code available |
@@ -75,7 +75,6 @@ Connecting to a stream always replays all stored output from the beginning:
 ```
 data: {"type": "start", "runtime": "claude", "session_id": "..."}
 
-id: 1
 data: {"type": "turn_start", "id": 1, "turn": 1}
 
 id: 1

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -68,6 +68,7 @@ Three calls to go from zero to a running agent:
 | [Overview](api/product.md) | What problems Agent on Demand solves |
 | [API Reference](api/reference.md) | Interactive Stoplight Elements explorer |
 | [Python SDK](sdks/python.md) | `aod-sdk` — typed sync + async client on PyPI |
+| [TypeScript SDK](sdks/typescript.md) | `@ravi-hq/aod-sdk` — typed async client on npm, browser-compatible |
 | [Authentication](api/authentication.md) | Bearer tokens, 401 shapes |
 | [Streaming](api/streaming.md) | SSE event types, reconnect, replay |
 | [Errors](api/errors.md) | Every status code and when it fires |

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -22,7 +22,7 @@ Three calls to go from zero to a running agent:
     AGENT_ID=$(curl -s -X POST "$BASE/agents" \
       -H "Authorization: Bearer $TOKEN" \
       -H "Content-Type: application/json" \
-      -d '{"name":"hello","model":"claude-sonnet-4-6","runtime":"claude"}' | jq -r .id)
+      -d '{"name":"hello","model":"anthropic/claude-sonnet-4-6","runtime":"claude"}' | jq -r .id)
 
     # 2. Start a session.
     SESS_ID=$(curl -s -X POST "$BASE/sessions" \
@@ -46,7 +46,7 @@ Three calls to go from zero to a running agent:
     # Client() reads AOD_API_URL and AOD_API_TOKEN from the environment.
     with Client(base_url="http://localhost:8777", token="aod_...") as client:
         agent = client.agents.create(
-            name="hello", model="claude-sonnet-4-6", runtime="claude"
+            name="hello", model="anthropic/claude-sonnet-4-6", runtime="claude"
         )
         ack = client.sessions.create(
             agent_id=agent.id, prompt="Say hello.", timeout=120

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -1,6 +1,6 @@
 # Agent on Demand
 
-Agent on Demand is a REST API for running AI coding agents on [Sprites](https://fly.io/docs/machines/). It manages three resources:
+Agent on Demand is a REST API for running AI coding agents on [Sprites](https://sprites.dev). It manages three resources:
 
 - **Agents** — reusable templates that define the model, runtime, system prompt, MCP servers, and skills for an AI coding agent.
 - **Environments** — Sprite sandbox configurations: packages to install, environment variables to export, a setup script, and a network policy.

--- a/site/docs/operators/deploy.md
+++ b/site/docs/operators/deploy.md
@@ -101,51 +101,55 @@ uvicorn config.wsgi:application --host 0.0.0.0 --port 8000
 
 ## Sprites credentials
 
-Agent on Demand authenticates to the Sprites platform using a **per-user** token stored
-encrypted at rest in the `UserSpritesKey` table. Each user brings their own
-Sprites token; there is no shared/service-level fallback. At session creation
-time, Agent on Demand:
+Agent on Demand authenticates to the Sprites platform using **per-user** tokens stored
+encrypted at rest. Each user brings their own Sprites token and their own model API keys;
+there are no shared/service-level credentials. At session creation time, Agent on Demand:
 
-1. Looks up the caller's `UserSpritesKey` and decrypts the token.
-2. Calls `SpritesClient(token=..., base_url=SPRITES_BASE_URL)` to obtain a
-   client.
+1. Looks up the caller's `UserBackendCredential(backend="sprites")` and decrypts the token.
+2. Calls `SpritesClient(token=..., base_url=SPRITES_BASE_URL)` to obtain a client.
 3. Creates a Sprite via `client.create_sprite(name)`, where the name is
    `{SPRITE_NAME_PREFIX}-{12-char-hex-id}`.
-4. Writes a `run-agent.sh` wrapper script onto the Sprite's filesystem. The
-   script exports the **per-user runtime API key** (e.g. the user's Anthropic
-   key) and runs the agent binary.
-5. The runtime API key is stored encrypted at rest in the `UserRuntimeKey`
-   table and is never present in Sprites API calls — only inside the agent's
-   execution environment.
+4. Writes a `run-agent.sh` wrapper script onto the Sprite's filesystem. The script
+   exports the **per-user model API key** (e.g. the user's Anthropic key) and runs the
+   agent CLI.
+5. Model API keys are stored encrypted at rest in `UserCredential` rows and are never
+   present in Sprites API calls — only inside the agent's execution environment.
 
-If a user has no `UserSpritesKey` configured, session create, multi-turn
-prompt, and session termination endpoints return `400 No Sprites API key
-configured`.
+If a user has no Sprites credential configured, session create, multi-turn prompt, and
+session termination endpoints return `400 No backend credentials configured`.
 
-To set a user's Sprites key (required before they can run sessions):
+To set a user's Sprites token (required before they can run sessions):
 
 ```python
-from agent_on_demand.models import UserSpritesKey
+from agent_on_demand.models import UserBackendCredential
 from django.contrib.auth.models import User
 
 user = User.objects.get(username="alice")
-usk, _ = UserSpritesKey.objects.get_or_create(user=user)
-usk.set_api_key("your-sprites-api-token")
-usk.save()
+cred, _ = UserBackendCredential.objects.get_or_create(user=user, backend="sprites")
+cred.set_token("your-sprites-api-token")
+cred.save()
 ```
 
-To set a user's runtime key (required before they can run sessions on a given
-runtime):
+To set a user's model API key (required before they can run sessions on a given runtime):
 
 ```python
-from agent_on_demand.models import UserRuntimeKey
+from agent_on_demand.models import UserCredential
 from django.contrib.auth.models import User
 
 user = User.objects.get(username="alice")
-urk, _ = UserRuntimeKey.objects.get_or_create(user=user, runtime="claude")
-urk.set_api_key("your-anthropic-api-key")
-urk.save()
+cred, _ = UserCredential.objects.get_or_create(user=user, kind="provider:anthropic")
+cred.set_value("your-anthropic-api-key")
+cred.save()
 ```
+
+The `kind` field maps to the env var written into the session:
+
+| `kind` | Env var written | Used by |
+|--------|----------------|---------|
+| `provider:anthropic` | `ANTHROPIC_API_KEY` | `claude`, `opencode` |
+| `provider:openai` | `OPENAI_API_KEY` | `codex`, `opencode` |
+| `provider:google` | `GEMINI_API_KEY` | `gemini`, `opencode` |
+| `runtime_token:claude-oauth` | `CLAUDE_CODE_OAUTH_TOKEN` | `claude` (OAuth variant) |
 
 ## Health check
 

--- a/site/docs/patterns/ci-bot.md
+++ b/site/docs/patterns/ci-bot.md
@@ -61,10 +61,12 @@ jobs:
           done
 
           # Collect output and post as PR comment
+          # SSE events: keep only "output" type, extract the .data field
           OUTPUT=$(curl -sS "$AOD_URL/sessions/$SESSION_ID/stream" \
             -H "Authorization: Bearer $AOD_TOKEN" \
             -H "Accept: text/event-stream" \
-            | grep '^data: ' | sed 's/^data: //' | jq -r '.text // .' | tr -d '\0')
+            | grep '^data: ' | sed 's/^data: //' \
+            | jq -r 'select(.type == "output") | .data' | tr -d '\0')
 
           gh pr comment ${{ github.event.pull_request.number }} --body "$OUTPUT"
 ```

--- a/site/docs/patterns/dashboard.md
+++ b/site/docs/patterns/dashboard.md
@@ -10,11 +10,11 @@ Python examples use the official [`aod-sdk`](../sdks/python.md) package
 ## Shape of the solution
 
 Your dashboard acts as an authenticated proxy between your users and Agent on Demand. Each
-dashboard user is mapped to a Agent on Demand API token (or a shared service token with
+dashboard user is mapped to an Agent on Demand API token (or a shared service token with
 per-user metadata). The dashboard:
 
 1. Accepts user requests through your own auth layer.
-2. Calls `POST /sessions` on the user's behalf using a Agent on Demand token.
+2. Calls `POST /sessions` on the user's behalf using an Agent on Demand token.
 3. Lists running and past sessions via `GET /sessions`.
 4. Proxies the SSE stream to the browser — either by forwarding
    `GET /sessions/{id}/stream` directly or relaying events over a WebSocket.

--- a/site/docs/sdks/python.md
+++ b/site/docs/sdks/python.md
@@ -20,7 +20,7 @@ from aod import Client
 with Client(token="aod_...") as client:
     agent = client.agents.create(
         name="demo",
-        model="claude-sonnet-4-6",
+        model="anthropic/claude-sonnet-4-6",
         runtime="claude",
     )
     ack = client.sessions.create(agent_id=agent.id, prompt="Say hello.")

--- a/site/docs/sdks/python.md
+++ b/site/docs/sdks/python.md
@@ -62,7 +62,7 @@ Mapping matches the [Errors reference](../api/errors.md):
 
 | Status | Exception | When |
 | ------ | --------- | ---- |
-| 401/403 | `AuthError` | Missing or invalid token |
+| 401 | `AuthError` | Missing or invalid token |
 | 404 | `NotFoundError` | Resource missing (or not owned by caller) |
 | 409 | `ConflictError` | Archived row, terminal session, or stale `version` |
 | 422 | `ValidationError` | Server-side pydantic validation failure |

--- a/site/docs/sdks/typescript.md
+++ b/site/docs/sdks/typescript.md
@@ -1,0 +1,148 @@
+# TypeScript SDK
+
+The official TypeScript client for Agent on Demand. Covers every endpoint with typed models, a single async `Client`, and an `AsyncIterable` SSE event stream. Works in Node 18+ and modern browsers with zero runtime dependencies.
+
+- **Package**: [`@ravi-hq/aod-sdk` on npm](https://www.npmjs.com/package/@ravi-hq/aod-sdk)
+- **Source**: [`clients/typescript/`](https://github.com/ravi-hq/agent-on-demand/tree/main/clients/typescript)
+- **Supports**: Node 18+, modern browsers
+
+## Install
+
+```bash
+npm install @ravi-hq/aod-sdk
+```
+
+## Quickstart
+
+```ts
+import { Client } from "@ravi-hq/aod-sdk";
+
+const client = new Client({
+  baseUrl: "http://localhost:8777",
+  token: "aod_...",
+  // or set AOD_API_URL / AOD_API_TOKEN in env (Node only)
+});
+
+const agent = await client.agents.create({
+  name: "hello",
+  model: "anthropic/claude-sonnet-4-6",
+  runtime: "claude",
+});
+
+const ack = await client.sessions.create({
+  agent_id: agent.id,
+  prompt: "Say hello.",
+  timeout: 120,
+});
+
+const stream = await client.sessions.stream(ack.id);
+try {
+  for await (const event of stream) {
+    if (event.type === "output") {
+      process.stdout.write(event.extra.data ?? "");
+    } else if (event.type === "exit") {
+      console.log(`\n[exit ${event.extra.code}]`);
+      break;
+    }
+  }
+} finally {
+  await stream.close();
+}
+```
+
+## Configuration
+
+`baseUrl` and `token` can be passed to the constructor or read from `AOD_API_URL` and `AOD_API_TOKEN` environment variables (Node only). `baseUrl` defaults to `http://localhost:8777`.
+
+| Option      | Default                         | Notes                                                      |
+| ----------- | ------------------------------- | ---------------------------------------------------------- |
+| `baseUrl`   | `AOD_API_URL` or `localhost:8777` | Trailing slash stripped.                                |
+| `token`     | `AOD_API_TOKEN`                 | Required. Sent as `Authorization: Bearer <token>`.         |
+| `fetch`     | `globalThis.fetch`              | Inject a custom fetch for tests or proxies.                |
+| `timeoutMs` | `30000`                         | Per-request timeout. Streaming requests use `AbortSignal`. |
+
+## Errors
+
+Non-2xx responses throw a typed subclass of `AodHTTPError`. All share `.statusCode`, `.detail`, `.method`, `.url`:
+
+```ts
+import { ConflictError } from "@ravi-hq/aod-sdk";
+
+try {
+  await client.agents.update(agentId, { version: 1, name: "renamed" });
+} catch (err) {
+  if (err instanceof ConflictError) {
+    // 409: stale version or archived row
+    console.error(err.statusCode, err.detail);
+  }
+}
+```
+
+| Status | Class            | When                                                     |
+| ------ | ---------------- | -------------------------------------------------------- |
+| 401/3  | `AuthError`      | Missing or invalid token                                 |
+| 404    | `NotFoundError`  | Resource missing                                         |
+| 409    | `ConflictError`  | Archived row, terminal session, or stale `version`       |
+| 422    | `ValidationError`| Server-side validation failure                           |
+| 429    | `RateLimitError` | Per-user concurrent session limit (`.limit`, `.active`)  |
+| 5xx    | `ServerError`    |                                                          |
+
+## Optimistic concurrency
+
+`agents` and `environments` carry a `version` integer. Pass the current version on every `PUT`; a stale version throws `ConflictError`:
+
+```ts
+const agent = await client.agents.get(agentId);
+await client.agents.update(agent.id, {
+  version: agent.version,
+  name: "renamed",
+});
+```
+
+See [Core Concepts → Optimistic concurrency](../api/concepts.md#optimistic-concurrency-agents-and-environments) for the full semantics.
+
+## Streaming
+
+`client.sessions.stream(sessionId, opts?)` returns a `StreamHandle` — an `AsyncIterable<StreamEvent>` with a `close()` method.
+
+```ts
+const stream = await client.sessions.stream(sessionId, { since: lastSeenId });
+try {
+  for await (const event of stream) {
+    switch (event.type) {
+      case "stage":
+        console.log(`[${event.extra.stage} ${event.extra.state}]`);
+        break;
+      case "output":
+        process.stdout.write(event.extra.data ?? "");
+        break;
+      case "exit":
+        console.log(`\n[exit ${event.extra.code}]`);
+        return;
+      case "error":
+      case "terminated":
+      case "stale":
+        console.error(`\n[${event.type}]`);
+        return;
+    }
+  }
+} finally {
+  await stream.close();
+}
+```
+
+Pass `since: lastSeenId` to resume after a disconnect. Pass `signal: abortController.signal` to cancel from outside.
+
+Event types: `start`, `turn_start`, `output`, `stage`, `exit`, `error`, `terminated`, `stale`. Everything except `type` and `id` lands in `event.extra`. See [Streaming reference](../api/streaming.md) for the full event schema.
+
+## Browser use
+
+The SDK has no Node-only dependencies — it uses built-in `fetch`, `ReadableStream`, and `AbortController`. Pass `baseUrl` and `token` explicitly in browser code; the `AOD_API_URL` / `AOD_API_TOKEN` env fallbacks are Node-only.
+
+If you're calling Agent on Demand from a browser origin other than the API's own origin, the server must send appropriate CORS headers (not enabled by default on self-hosted instances).
+
+## See also
+
+- [`clients/typescript/README.md`](https://github.com/ravi-hq/agent-on-demand/tree/main/clients/typescript#readme) — full API surface and release notes.
+- [Python SDK](python.md) — the Python equivalent with sync and async clients.
+- [Streaming reference](../api/streaming.md) — event types, heartbeats, resume.

--- a/site/docs/sdks/typescript.md
+++ b/site/docs/sdks/typescript.md
@@ -80,7 +80,7 @@ try {
 
 | Status | Class            | When                                                     |
 | ------ | ---------------- | -------------------------------------------------------- |
-| 401/3  | `AuthError`      | Missing or invalid token                                 |
+| 401    | `AuthError`      | Missing or invalid token                                 |
 | 404    | `NotFoundError`  | Resource missing                                         |
 | 409    | `ConflictError`  | Archived row, terminal session, or stale `version`       |
 | 422    | `ValidationError`| Server-side validation failure                           |

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
     - Pagination: api/pagination.md
   - SDKs:
     - Python: sdks/python.md
+    - TypeScript: sdks/typescript.md
   - Patterns:
     - CLI Wrapper: patterns/cli-wrapper.md
     - Chat Bot: patterns/chat-bot.md

--- a/src/agent_on_demand/templates/ui/landing.html
+++ b/src/agent_on_demand/templates/ui/landing.html
@@ -16,10 +16,11 @@
             <span class="grad">in one request.</span>
           </h1>
           <p class="lede">
-            Agent on Demand is a REST API for running Claude Code, Codex and
-            Gemini CLI on fresh, sandboxed cloud machines. Define an agent,
-            wire up an environment, <code>POST /sessions</code>, stream the
-            output over SSE. Multi-turn when you need it.
+            Agent on Demand is a REST API for running Claude Code, Codex,
+            Gemini CLI, and opencode on fresh, sandboxed cloud machines.
+            Define an agent, wire up an environment,
+            <code>POST /sessions</code>, stream the output over SSE.
+            Multi-turn when you need it.
           </p>
           <div class="landing-ctas">
             {% if user.is_authenticated %}
@@ -42,20 +43,22 @@
             <span class="tdot"></span><span class="tdot"></span><span class="tdot"></span>
             <span class="terminal-title">aod.ravi.id · live session</span>
           </div>
-<pre class="terminal-body"><span class="c-mute">$</span> <span class="c-cmd">curl -N https://aod.ravi.id/sessions/s_4f2c/stream \
+<pre class="terminal-body"><span class="c-mute">$</span> <span class="c-cmd">curl -N https://aod.ravi.id/sessions/… /stream \
     -H "Authorization: Bearer $AOD_KEY"</span>
 
-<span class="c-evt">event:</span> session.started
-<span class="c-evt">data:</span>  <span class="c-str">{"id":"s_4f2c","agent":"claude-sonnet-4-6"}</span>
+<span class="c-evt">data:</span> <span class="c-str">{"type":"start","runtime":"claude","session_id":"…"}</span>
 
-<span class="c-evt">event:</span> turn.chunk
-<span class="c-evt">data:</span>  <span class="c-str">{"text":"Reading src/payments.py…"}</span>
+<span class="c-mute">id: 1</span>
+<span class="c-evt">data:</span> <span class="c-str">{"type":"stage","id":1,"stage":"create_sprite","state":"done","duration_ms":3820}</span>
 
-<span class="c-evt">event:</span> turn.chunk
-<span class="c-evt">data:</span>  <span class="c-str">{"text":"Applying refactor across 3 files…"}</span>
+<span class="c-mute">id: 2</span>
+<span class="c-evt">data:</span> <span class="c-str">{"type":"output","id":2,"stream":"stdout","data":"Reading src/payments.py…","turn":1}</span>
 
-<span class="c-evt">event:</span> turn.completed
-<span class="c-evt">data:</span>  <span class="c-str">{"status":"ok","files_changed":3,"tokens":41_208}</span><span class="caret">▍</span></pre>
+<span class="c-mute">id: 3</span>
+<span class="c-evt">data:</span> <span class="c-str">{"type":"output","id":3,"stream":"stdout","data":"Refactored 3 files, 142 lines changed.","turn":1}</span>
+
+<span class="c-mute">id: 4</span>
+<span class="c-evt">data:</span> <span class="c-str">{"type":"exit","id":4,"code":0}</span><span class="caret">▍</span></pre>
         </div>
       </div>
     </section>
@@ -92,12 +95,14 @@
 <pre class="code-block"><span class="c-mute"># 1. Create an agent (runtime + model)</span>
 <span class="c-cmd">curl -X POST https://aod.ravi.id/agents</span> \
   -H <span class="c-str">"Authorization: Bearer $AOD_KEY"</span> \
-  -d <span class="c-str">'{"name":"refactor-bot","model":"claude-sonnet-4-6"}'</span>
+  -H <span class="c-str">"Content-Type: application/json"</span> \
+  -d <span class="c-str">'{"name":"refactor-bot","model":"anthropic/claude-sonnet-4-6","runtime":"claude"}'</span>
 
 <span class="c-mute"># 2. Start a session and stream the output</span>
-<span class="c-cmd">curl -N https://aod.ravi.id/sessions</span> \
+<span class="c-cmd">curl -N -X POST https://aod.ravi.id/sessions</span> \
   -H <span class="c-str">"Authorization: Bearer $AOD_KEY"</span> \
-  -d <span class="c-str">'{"agent_id":"…","environment_id":"…","prompt":"refactor payments.py"}'</span>
+  -H <span class="c-str">"Content-Type: application/json"</span> \
+  -d <span class="c-str">'{"agent_id":"…","prompt":"refactor payments.py"}'</span>
 </pre>
     </section>
 
@@ -107,6 +112,7 @@
         <div class="runtime-chip">claude</div>
         <div class="runtime-chip">codex</div>
         <div class="runtime-chip">gemini</div>
+        <div class="runtime-chip">opencode</div>
         <div class="runtime-chip runtime-chip-muted">+ your PR welcome</div>
       </div>
     </section>

--- a/src/agent_on_demand/templates/ui/landing.html
+++ b/src/agent_on_demand/templates/ui/landing.html
@@ -45,17 +45,16 @@
 <pre class="terminal-body"><span class="c-mute">$</span> <span class="c-cmd">curl -N https://aod.ravi.id/sessions/s_4f2c/stream \
     -H "Authorization: Bearer $AOD_KEY"</span>
 
-<span class="c-evt">event:</span> session.started
-<span class="c-evt">data:</span>  <span class="c-str">{"id":"s_4f2c","agent":"claude-sonnet-4-6"}</span>
+<span class="c-evt">data:</span> <span class="c-str">{"type":"start","runtime":"claude","session_id":"s_4f2c"}</span>
 
-<span class="c-evt">event:</span> turn.chunk
-<span class="c-evt">data:</span>  <span class="c-str">{"text":"Reading src/payments.py…"}</span>
+<span class="c-mute">id: 1</span>
+<span class="c-evt">data:</span> <span class="c-str">{"type":"output","stream":"stdout","data":"Reading src/payments.py…\n"}</span>
 
-<span class="c-evt">event:</span> turn.chunk
-<span class="c-evt">data:</span>  <span class="c-str">{"text":"Applying refactor across 3 files…"}</span>
+<span class="c-mute">id: 2</span>
+<span class="c-evt">data:</span> <span class="c-str">{"type":"output","stream":"stdout","data":"Applying refactor across 3 files…\n"}</span>
 
-<span class="c-evt">event:</span> turn.completed
-<span class="c-evt">data:</span>  <span class="c-str">{"status":"ok","files_changed":3,"tokens":41_208}</span><span class="caret">▍</span></pre>
+<span class="c-mute">id: 3</span>
+<span class="c-evt">data:</span> <span class="c-str">{"type":"exit","code":0}</span><span class="caret">▍</span></pre>
         </div>
       </div>
     </section>
@@ -92,7 +91,7 @@
 <pre class="code-block"><span class="c-mute"># 1. Create an agent (runtime + model)</span>
 <span class="c-cmd">curl -X POST https://aod.ravi.id/agents</span> \
   -H <span class="c-str">"Authorization: Bearer $AOD_KEY"</span> \
-  -d <span class="c-str">'{"name":"refactor-bot","model":"claude-sonnet-4-6"}'</span>
+  -d <span class="c-str">'{"name":"refactor-bot","model":"anthropic/claude-sonnet-4-6","runtime":"claude"}'</span>
 
 <span class="c-mute"># 2. Start a session and stream the output</span>
 <span class="c-cmd">curl -N https://aod.ravi.id/sessions</span> \
@@ -107,6 +106,7 @@
         <div class="runtime-chip">claude</div>
         <div class="runtime-chip">codex</div>
         <div class="runtime-chip">gemini</div>
+        <div class="runtime-chip">opencode</div>
         <div class="runtime-chip runtime-chip-muted">+ your PR welcome</div>
       </div>
     </section>

--- a/src/agent_on_demand/templates/ui/landing.html
+++ b/src/agent_on_demand/templates/ui/landing.html
@@ -85,18 +85,22 @@
 
     <section class="landing-container landing-code">
       <div class="section-head">
-        <h2>Five lines. One session.</h2>
-        <p class="muted">The whole API fits on a postcard. Create it, prompt it, stream it.</p>
+        <h2>Three calls. One session.</h2>
+        <p class="muted">The whole API fits on a napkin. Create it, prompt it, stream it.</p>
       </div>
 <pre class="code-block"><span class="c-mute"># 1. Create an agent (runtime + model)</span>
 <span class="c-cmd">curl -X POST https://aod.ravi.id/agents</span> \
   -H <span class="c-str">"Authorization: Bearer $AOD_KEY"</span> \
   -d <span class="c-str">'{"name":"refactor-bot","model":"anthropic/claude-sonnet-4-6","runtime":"claude"}'</span>
 
-<span class="c-mute"># 2. Start a session and stream the output</span>
-<span class="c-cmd">curl -N https://aod.ravi.id/sessions</span> \
+<span class="c-mute"># 2. Start a session</span>
+<span class="c-cmd">curl -X POST https://aod.ravi.id/sessions</span> \
   -H <span class="c-str">"Authorization: Bearer $AOD_KEY"</span> \
-  -d <span class="c-str">'{"agent_id":"…","environment_id":"…","prompt":"refactor payments.py"}'</span>
+  -d <span class="c-str">'{"agent_id":"&lt;id&gt;","prompt":"refactor payments.py"}'</span>
+
+<span class="c-mute"># 3. Stream the output (SSE)</span>
+<span class="c-cmd">curl -N https://aod.ravi.id/sessions/&lt;id&gt;/stream</span> \
+  -H <span class="c-str">"Authorization: Bearer $AOD_KEY"</span>
 </pre>
     </section>
 

--- a/src/agent_on_demand/templates/ui/welcome.html
+++ b/src/agent_on_demand/templates/ui/welcome.html
@@ -37,7 +37,7 @@ export AOD_API_URL={{ api_base }}</code></pre>
   -d '{
     "name": "hello",
     "runtime": "claude",
-    "model": "claude-sonnet-4-6"
+    "model": "anthropic/claude-sonnet-4-6"
   }'</code></pre>
 
   <h3>Run a session</h3>


### PR DESCRIPTION
## Docs Excellence — three surfaces

Docs-only PR improving README, the OSS docs site, and the hosted marketing
page. The unrelated `session_service/tasks.py` failure-handling change that
was originally bundled here landed separately as #268 and is already on main.

---

## Current rubric scores

| Surface | Score | Notes |
|---------|-------|-------|
| README | 8/10 | Quickstart works, hosted API prominently linked, correct model format |
| OSS site | 8/10 | Model format fixed everywhere, streaming docs accurate, state machine corrected, runtimes page rewritten, TypeScript SDK added |
| Landing page | 8/10 | Real SSE event names, correct model format, Content-Type headers, opencode added |

---

## What changed

### README.md
- Added hosted API link (`aod.ravi.id`) prominently at the top
- Working three-step curl quickstart with correct `provider/model_id` model format
- Self-hosting section moved below quickstart (it's not the default path)
- Added `clients/` and `examples/` to layout section

### Landing page (`templates/ui/landing.html`, `templates/ui/welcome.html`)
- Terminal widget: replaced invented event names (`session.started`, `turn.chunk`, `turn.completed`) with real SSE events (`start`, `stage`, `output`, `exit`) including correct payload shapes
- Code block: added `Content-Type: application/json`, correct model format, split into 3 separate curl commands ("Three calls. One session.")
- Added `opencode` to runtime strip and hero lede
- `welcome.html`: fixed bare model string

### Site docs
- **Model format**: fixed `claude-sonnet-4-6` → `anthropic/claude-sonnet-4-6` everywhere (index.md, quickstart.md, runtimes.md, pagination.md, python.md, etc.)
- **runtimes.md**: rewritten — 4 runtimes (was 3), correct API key env vars (`OPENAI_API_KEY` not `CODEX_API_KEY`), server does validate runtime/model pairs (returns 422), fixed source file link
- **streaming.md**: `turn_start` does not get SSE `id:` line (code confirmed); fixed example; added table note
- **concepts.md**: state machine diagram corrected — `POST /prompt` goes `completed→pending`, not `running→pending`; `failed` sessions cannot be continued (returns 409)
- **errors.md**: added missing `failed` row for `POST /prompt`; correct delete message ("Cannot delete an active session", blocks pending+running not just running)
- **product.md**: added "When to use/not" and "Hosted vs self-hosted" comparison table
- **TypeScript SDK**: added `site/docs/sdks/typescript.md` page
- **ci-bot.md**: SSE output parsing fixed (filter on `.type=="output"`, extract `.data`)
- **operators/deploy.md**: updated `UserSpritesKey`/`UserRuntimeKey` references to current `UserBackendCredential` / `UserCredential` model names
- **mkdocs.yml**: TypeScript SDK added to nav

### SDK READMEs
- `clients/python/README.md`, `clients/typescript/README.md`: corrected model strings and runtime names so copy-paste examples actually work

---

## Files changed (19, all docs / HTML templates)

```
README.md
clients/python/README.md
clients/typescript/README.md
site/docs/api/concepts.md
site/docs/api/errors.md
site/docs/api/pagination.md
site/docs/api/product.md
site/docs/api/quickstart.md
site/docs/api/runtimes.md
site/docs/api/streaming.md
site/docs/index.md
site/docs/operators/deploy.md
site/docs/patterns/ci-bot.md
site/docs/patterns/dashboard.md
site/docs/sdks/python.md
site/docs/sdks/typescript.md
site/mkdocs.yml
src/agent_on_demand/templates/ui/landing.html
src/agent_on_demand/templates/ui/welcome.html
```