### PR TITLE
Mark session failed on unexpected provision_session_task error

### DIFF
--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -131,6 +131,16 @@ def _provision_session_inner(
             logger.warning("provision failed at stage=%s: %s", e.stage, e)
             _mark_provision_failed(session, turn_id, str(e))
             return
+        except Exception as e:
+            # Without this, an unexpected error (Sprites SDK fault, DB
+            # blip, anything other than the two typed errors above)
+            # propagates out and Procrastinate marks the job failed —
+            # but the session row stays `pending` forever. The API
+            # client polls a session that will never complete.
+            span.set_attribute("aod.failure_stage", "unexpected")
+            logger.exception("unexpected provision failure for session %s", session_id)
+            _mark_provision_failed(session, turn_id, f"unexpected error: {e}")
+            raise
 
     execute_turn.defer(
         session_id=session_id,

--- a/tests/test_provision_task_failures.py
+++ b/tests/test_provision_task_failures.py
@@ -103,6 +103,38 @@ def test_provision_task_marks_failed_when_build_spec_raises(user, mocker):
 
 
 @pytest.mark.django_db
+def test_provision_task_marks_failed_on_unexpected_error(user, mocker):
+    """Anything other than the two typed errors (Sprites SDK fault, DB
+    blip, etc.) used to propagate out and leave the session row at
+    `pending` forever — Procrastinate marked the job failed, but the
+    API client polled a row that would never complete. The catch-all
+    must mark the session+turn `failed` so the client unblocks; the
+    raise preserves the procrastinate `failed` signal for operators."""
+    session, turn = _make_session_and_turn(user)
+    mocker.patch(
+        "agent_on_demand.session_service.tasks.provision_session",
+        side_effect=RuntimeError("sdk blew up"),
+    )
+
+    with pytest.raises(RuntimeError, match="sdk blew up"):
+        _provision_session_inner(
+            session_id=str(session.id),
+            turn_id=turn.id,
+            prompt="t",
+            mode="run",
+            timeout=10.0,
+        )
+
+    session.refresh_from_db()
+    assert session.status == "failed"
+    turn.refresh_from_db()
+    assert turn.status == "failed"
+    log = AgentSessionLog.objects.filter(session=session).order_by("id").first()
+    assert log is not None
+    assert "sdk blew up" in log.data
+
+
+@pytest.mark.django_db
 def test_provision_task_marks_failed_on_no_backend_credential(user, mocker):
     """Race: backend credential revoked between session-create (which passed
     the pre-check) and provision-task pickup. The task must record


### PR DESCRIPTION
## Summary

- Found 3 zombie `pending` sessions in prod whose `provision_session` Procrastinate jobs were `status=failed` (attempts=1) but the `agent_sessions` rows were stuck at `status=pending` with empty `backend_handle`. The API client would poll forever.
- Root cause: `_provision_session_inner` only catches `ProvisionError` and `NoBackendCredentialsError`. Any other exception (Sprites SDK fault, DB blip, span cleanup, etc.) propagates out — Procrastinate marks the job failed, but `_mark_provision_failed` never runs so the session row is stranded.
- Fix: add a final `except Exception` that marks session+turn `failed` and writes a stderr log chunk, then re-raises so the procrastinate `failed` signal is preserved for operator dashboards (and posthog `capture_exceptions=True` still fires).

## Why re-raise

The two existing branches (`ProvisionError`, `NoBackendCredentialsError`) `return` because those are *expected* failure modes — the procrastinate job is "done" successfully. An unexpected error is operator-visible signal worth keeping in the procrastinate dashboard, hence `raise` instead of `return`.

## Test plan

- [x] New unit test `test_provision_task_marks_failed_on_unexpected_error` simulates a `RuntimeError` from `provision_session`, asserts session+turn end up `failed`, asserts the error message lands in `AgentSessionLog`, and asserts the exception still bubbles out (procrastinate signal preserved).
- [x] `make test` — 1180 passed.
- [x] `make lint` clean.

## Related

The 3 zombie sessions still in the prod DB (IDs `03c69f85…`, `6935ce53…`, `ca617d86…`) need a manual cleanup; this PR only stops new ones from accumulating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)