### PR TITLE
fix(examples/cli): correct model format and runtime name

### DIFF
--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -100,7 +100,7 @@ Safe to chain: `./example-cli.py "fix the lint" && git diff`.
 
 ## What's in the agent
 
-- **Model + runtime**: `claude-sonnet-4-6` via the `claude` runtime.
+- **Model + runtime**: `anthropic/claude-sonnet-4-6` via the `claude` runtime.
 - **MCP servers**: [Context7](https://context7.com) (`https://mcp.context7.com/mcp`)
   for up-to-date library docs. Add more entries to the `mcp_servers` list in
   the `AGENT` block.

--- a/examples/cli/example-cli.py
+++ b/examples/cli/example-cli.py
@@ -29,8 +29,8 @@ from aod.pretty.claude import ClaudeFormatter
 
 AGENT: dict[str, Any] = {
     "name": "example-cli",
-    "model": "claude-sonnet-4-6",
-    "runtime": "claude-oauth",
+    "model": "anthropic/claude-sonnet-4-6",
+    "runtime": "claude",
     "system": (
         "You are a senior engineer working inside a Sprite sandbox. "
         "Investigate thoroughly before editing. Keep changes minimal and "


### PR DESCRIPTION
## What was wrong

`examples/cli/example-cli.py` had two values in the `AGENT` config block that cause immediate API failures when a developer runs the example:

| Field | Was | Should be | Error |
|---|---|---|---|
| `model` | `"claude-sonnet-4-6"` | `"anthropic/claude-sonnet-4-6"` | 422 — `field_validator` rejects bare model ids not in `MODELS` |
| `runtime` | `"claude-oauth"` | `"claude"` | 400 — `claude-oauth` was folded into `claude`; it's no longer in `RUNTIMES` |

`examples/cli/README.md` also showed `claude-sonnet-4-6` (without prefix) in the "What's in the agent" section.

## What changed

- `examples/cli/example-cli.py`: `model` → `"anthropic/claude-sonnet-4-6"`, `runtime` → `"claude"`
- `examples/cli/README.md`: corrected model string in the config summary

## How verified

Checked `src/agent_on_demand/models_catalog.py` — only `provider/model_id` keys exist. Checked `src/agent_on_demand/runtimes/__init__.py` — `RUNTIMES` dict contains `claude`, `codex`, `gemini`, `opencode`; no `claude-oauth`. Checked `src/agent_on_demand/views/agents.py` — `field_validator("model")` raises on unknown models; runtime validated at line 164.

No overlap with PR #267 (feature/docs-excellence), which does not touch the `examples/` directory.