### PR TITLE
docs(quickstart): add missing current_turn to POST /sessions response example

### DIFF
--- a/site/docs/api/quickstart.md
+++ b/site/docs/api/quickstart.md
@@ -116,7 +116,8 @@ Response (`202 Accepted`):
   "status": "pending",
   "stream_url": "/sessions/<session-uuid>/stream",
   "environment_id": null,
-  "resources": []
+  "resources": [],
+  "current_turn": 1
 }
 ```
 


### PR DESCRIPTION
## What was wrong

The `POST /sessions` response example in `site/docs/api/quickstart.md` was missing the `current_turn` field. The actual view (`src/agent_on_demand/views/sessions/create.py`, line 217) always returns it:

```python
return JsonResponse(
    {
        "id": str(session.id),
        "status": "pending",
        "stream_url": f"/sessions/{session.id}/stream",
        "environment_id": ...,
        "resources": ...,
        "current_turn": turn.turn_number,   # always 1 on create
    },
    status=202,
)
```

The openapi.yaml schema (`SessionAck`) already has `current_turn`, and so does the Python SDK model. Only the human-readable quickstart example was stale.

## What changed

Added `"current_turn": 1` to the `202 Accepted` JSON example in `site/docs/api/quickstart.md`.

## How I verified

Compared the example against `create.py` lines 210–220. The field is unconditionally set to `turn.turn_number`, which is `1` for every freshly created session (first turn is created in the same transaction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)