### PR TITLE
docs(quickstart): fix prerequisites — name the hosted API, replace APIKey.create_key with the actual sign-up flow

### DIFF
--- a/site/docs/api/quickstart.md
+++ b/site/docs/api/quickstart.md
@@ -6,21 +6,23 @@ Python examples use the official [`aod-sdk`](../sdks/python.md) package (`pip in
 
 ## Prerequisites
 
-- **Local**: run `make dev` — the server starts on `http://localhost:8777`.
-- **Remote**: set `BASE` to your deployment URL.
-- A valid API token (created server-side via `APIKey.create_key`).
+Choose a deployment:
+
+- **Hosted API** (`https://aod.ravi.id`): [sign up](https://aod.ravi.id/ui/register) — your token is shown once on the welcome screen. Create more at `/ui/api-keys`.
+- **Local dev**: run `make dev` (server on `http://localhost:8777`), then register at `http://localhost:8777/ui/register` to get a token.
+- **Self-hosted**: set `BASE` to your deployment URL and follow the same sign-up flow.
 
 === "curl"
 
     ```bash
-    BASE=http://localhost:8777
+    BASE=https://aod.ravi.id   # or http://localhost:8777 for local dev
     TOKEN=aod_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     ```
 
 === "Python"
 
     ```bash
-    export AOD_API_URL=http://localhost:8777
+    export AOD_API_URL=https://aod.ravi.id   # or http://localhost:8777 for local dev
     export AOD_API_TOKEN=aod_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     pip install aod-sdk
     ```


### PR DESCRIPTION
## What was wrong

The Prerequisites section of `site/docs/api/quickstart.md` had two problems:

**1. Invented token-creation instruction.** It said:

> A valid API token (created server-side via `APIKey.create_key`).

`APIKey.create_key` is an internal Python method (`models/auth.py:31`). No user ever calls it directly. The real flow, confirmed in `views.py` and `welcome.html`:

- Register at `/ui/register` → token shown once on the welcome screen.
- Create more at `/ui/api-keys`.

**2. Hosted API URL was absent.** The README and marketing page both send users to `https://aod.ravi.id`, but the quickstart prerequisites only said "set BASE to your deployment URL" — leaving hosted API users with no concrete starting point. `http://localhost:8777` was the only explicit URL.

## What changed

- Prerequisites now name all three paths: hosted API, local dev, self-hosted.
- Hosted API token flow described correctly (sign up → welcome screen → `/ui/api-keys`).
- `BASE` env var in the curl/Python blocks defaults to `https://aod.ravi.id` with a comment for local dev, so the example works out of the box for the most common case.

## How I verified

- `views.py` `register()` calls `APIKey.create_key()` and stores the raw key in session for display on the welcome page — confirms the sign-up flow.
- `welcome.html` shows the token once with "copy it now" warning — confirms the token display step.
- `https://aod.ravi.id` is the canonical hosted URL per README and `landing.html`.
- No open PRs touch `site/docs/api/quickstart.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)