### PR TITLE
observability: wrap worker tasks in CONSUMER spans + propagate trace context

### DIFF
--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -55,6 +55,10 @@ from .turn_executor import TurnExecutor
 logger = logging.getLogger(__name__)
 
 
+# `@procrastinate_app.task` must wrap `@traced_task` so the registered task body
+# is the traced wrapper, not the bare function. `_otel_carrier` is consumed and
+# stripped by `@traced_task`; declared explicitly so `inspect.signature(...)`
+# (which follows `functools.wraps.__wrapped__`) reflects the real call surface.
 @procrastinate_app.task(queue="sessions", name="provision_session", pass_context=False)
 @traced_task("provision_session")
 def provision_session_task(
@@ -64,6 +68,7 @@ def provision_session_task(
     prompt: str,
     mode: str,
     timeout: float,
+    _otel_carrier: dict | None = None,
 ) -> None:
     """Provision the Sprite on the worker, then enqueue the first turn.
 
@@ -211,6 +216,7 @@ def _fail_pending_turn(session: AgentSession, turn: SessionTurn, message: str) -
     turn.save(update_fields=["status", "ended_at"])
 
 
+# Decorator order + `_otel_carrier`: see note on `provision_session_task` above.
 @procrastinate_app.task(queue="sessions", name="execute_turn", pass_context=False)
 @traced_task("execute_turn")
 def execute_turn(
@@ -220,6 +226,7 @@ def execute_turn(
     prompt: str,
     mode: str,
     timeout: float,
+    _otel_carrier: dict | None = None,
 ) -> None:
     """Run one turn. Arguments are JSON-serializable primitives; we re-fetch
     ORM rows and re-open the Sprite handle inside the task.
@@ -290,9 +297,10 @@ def _execute_turn_inner(
         TurnExecutor(session, turn, spec, handle, prompt, mode, timeout, span).run()
 
 
+# Decorator order + `_otel_carrier`: see note on `provision_session_task` above.
 @procrastinate_app.task(queue="sessions", name="destroy_session", pass_context=False)
 @traced_task("destroy_session")
-def destroy_session_task(*, user_id: int, handle: str) -> None:
+def destroy_session_task(*, user_id: int, handle: str, _otel_carrier: dict | None = None) -> None:
     """Delete a backend session on the worker. Best-effort — failures are
     logged, not retried, matching the pre-existing `destroy_session` contract.
 

--- a/src/agent_on_demand/session_service/tasks.py
+++ b/src/agent_on_demand/session_service/tasks.py
@@ -49,12 +49,14 @@ from .provisioning import (
     resume_session,
 )
 from .specs import build_spec_for_session
+from .tracing import inject_carrier, traced_task
 from .turn_executor import TurnExecutor
 
 logger = logging.getLogger(__name__)
 
 
 @procrastinate_app.task(queue="sessions", name="provision_session", pass_context=False)
+@traced_task("provision_session")
 def provision_session_task(
     *,
     session_id: str,
@@ -149,6 +151,7 @@ def _provision_session_inner(
         prompt=prompt,
         mode=mode,
         timeout=timeout,
+        _otel_carrier=inject_carrier(),
     )
 
 
@@ -209,6 +212,7 @@ def _fail_pending_turn(session: AgentSession, turn: SessionTurn, message: str) -
 
 
 @procrastinate_app.task(queue="sessions", name="execute_turn", pass_context=False)
+@traced_task("execute_turn")
 def execute_turn(
     *,
     session_id: str,
@@ -287,6 +291,7 @@ def _execute_turn_inner(
 
 
 @procrastinate_app.task(queue="sessions", name="destroy_session", pass_context=False)
+@traced_task("destroy_session")
 def destroy_session_task(*, user_id: int, handle: str) -> None:
     """Delete a backend session on the worker. Best-effort — failures are
     logged, not retried, matching the pre-existing `destroy_session` contract.

--- a/src/agent_on_demand/session_service/tracing.py
+++ b/src/agent_on_demand/session_service/tracing.py
@@ -1,0 +1,82 @@
+"""Worker task tracing: outer span + W3C trace propagation across the queue.
+
+Every Procrastinate task runs in the worker process where psycopg
+auto-instrumentation would otherwise emit each SQL query as a root span.
+`@traced_task` wraps the task body in a CONSUMER-kind span so those queries
+become children — and pulls a W3C traceparent out of `_otel_carrier` (when the
+enqueue site injected one) so the worker span attaches to the originating
+request's trace instead of starting a fresh root.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
+
+from opentelemetry.trace import SpanKind, Status, StatusCode
+
+from agent_on_demand.observability import get_tracer
+
+_KW_TO_ATTR = {
+    "session_id": "aod.session_id",
+    "user_id": "aod.user_id",
+    "turn_id": "aod.turn_id",
+    "handle": "aod.handle",
+}
+
+
+def traced_task(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Wrap a Procrastinate task body in a CONSUMER span.
+
+    The wrapper accepts an optional `_otel_carrier` kwarg (W3C traceparent
+    dict from `inject_carrier()`). When present, the new span is attached to
+    that remote context so the worker trace hangs off the request that
+    enqueued it. When absent, the span is a fresh root.
+
+    `_otel_carrier` is stripped before delegation — wrapped functions never
+    see it.
+    """
+
+    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            carrier = kwargs.pop("_otel_carrier", None)
+            tracer = get_tracer()
+
+            span_kwargs: dict[str, Any] = {"kind": SpanKind.CONSUMER}
+            if carrier:
+                from opentelemetry.trace.propagation.tracecontext import (
+                    TraceContextTextMapPropagator,
+                )
+
+                span_kwargs["context"] = TraceContextTextMapPropagator().extract(carrier)
+
+            with tracer.start_as_current_span(f"task {name}", **span_kwargs) as span:
+                span.set_attribute("procrastinate.task.name", name)
+                for kwarg_name, attr_name in _KW_TO_ATTR.items():
+                    if kwarg_name in kwargs and kwargs[kwarg_name] is not None:
+                        span.set_attribute(attr_name, kwargs[kwarg_name])
+                try:
+                    return fn(*args, **kwargs)
+                except Exception as e:
+                    span.record_exception(e)
+                    span.set_status(Status(StatusCode.ERROR))
+                    raise
+
+        return wrapper
+
+    return decorator
+
+
+def inject_carrier() -> dict[str, str]:
+    """Snapshot the current OTel context into a W3C traceparent dict.
+
+    Returns `{}` when there's no active span — the worker side treats an
+    empty carrier as "no parent" and starts a root span.
+    """
+    from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+    carrier: dict[str, str] = {}
+    TraceContextTextMapPropagator().inject(carrier)
+    return carrier

--- a/src/agent_on_demand/session_service/turn/enqueue.py
+++ b/src/agent_on_demand/session_service/turn/enqueue.py
@@ -21,6 +21,7 @@ def run_turn(
     # Local import: `tasks` imports `turn.argv` / `turn.outcome`, so a
     # top-level import here would cycle through the `turn` package init.
     from agent_on_demand.session_service.tasks import execute_turn
+    from agent_on_demand.session_service.tracing import inject_carrier
 
     execute_turn.defer(
         session_id=str(session.id),
@@ -28,4 +29,5 @@ def run_turn(
         prompt=prompt,
         mode=mode,
         timeout=float(timeout),
+        _otel_carrier=inject_carrier(),
     )

--- a/src/agent_on_demand/signals.py
+++ b/src/agent_on_demand/signals.py
@@ -3,6 +3,7 @@ from django.dispatch import receiver
 
 from agent_on_demand import session_service
 from agent_on_demand.models import AgentSession
+from agent_on_demand.session_service.tracing import inject_carrier
 
 
 @receiver(pre_delete, sender=AgentSession)
@@ -13,4 +14,8 @@ def delete_sprite_on_session_delete(sender, instance, **kwargs):
     handle = instance.backend_handle
     if not handle:
         return
-    session_service.destroy_session_task.defer(user_id=instance.user_id, handle=handle)
+    session_service.destroy_session_task.defer(
+        user_id=instance.user_id,
+        handle=handle,
+        _otel_carrier=inject_carrier(),
+    )

--- a/src/agent_on_demand/views/sessions/create.py
+++ b/src/agent_on_demand/views/sessions/create.py
@@ -19,6 +19,7 @@ from agent_on_demand.models import (
 from agent_on_demand.models.auth import CREDENTIAL_ENV_VAR, UserCredential
 from agent_on_demand.models_catalog import MODELS
 from agent_on_demand.runtimes import RUNTIMES
+from agent_on_demand.session_service.tracing import inject_carrier
 from agent_on_demand.views._helpers import parse_request_body
 
 from .schemas import RunRequest
@@ -187,6 +188,7 @@ def _create_session(request):
             prompt=effective_prompt,
             mode="run",
             timeout=float(req.timeout),
+            _otel_carrier=inject_carrier(),
         )
 
     posthog_capture(

--- a/src/agent_on_demand/views/sessions/lifecycle.py
+++ b/src/agent_on_demand/views/sessions/lifecycle.py
@@ -8,6 +8,7 @@ from agent_on_demand import session_service
 from agent_on_demand.analytics import capture as posthog_capture
 from agent_on_demand.auth import require_api_key
 from agent_on_demand.models import AgentSession, SessionTurn
+from agent_on_demand.session_service.tracing import inject_carrier
 from agent_on_demand.views._helpers import parse_request_body
 
 from .schemas import PromptRequest
@@ -163,7 +164,11 @@ def terminate_session(request, session_id):
         return JsonResponse({"detail": "Session not found"}, status=404)
 
     if handle:
-        session_service.destroy_session_task.defer(user_id=request.user.id, handle=handle)
+        session_service.destroy_session_task.defer(
+            user_id=request.user.id,
+            handle=handle,
+            _otel_carrier=inject_carrier(),
+        )
 
     posthog_capture(
         request.user,

--- a/tests/test_otel_task_tracing.py
+++ b/tests/test_otel_task_tracing.py
@@ -1,0 +1,149 @@
+"""Tests for the `traced_task` decorator and `inject_carrier` helper.
+
+These tests stand up an in-memory OTel tracer provider so we can introspect
+the spans that the decorator produces — name, kind, attributes, parent
+linkage, and error status.
+"""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind, StatusCode
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+from agent_on_demand.session_service.tracing import inject_carrier, traced_task
+
+
+@pytest.fixture
+def memory_tracer():
+    """Replace the global tracer provider with an in-memory one for the test.
+
+    OTel guards `set_tracer_provider` with a `Once`; we reset it both before
+    and after so the swap takes effect and so the next test (or production
+    code path) can re-set the provider.
+    """
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(resource=Resource.create({"service.name": "aod-test"}))
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    previous = trace.get_tracer_provider()
+    trace._TRACER_PROVIDER_SET_ONCE._done = False
+    trace._TRACER_PROVIDER = None
+    trace.set_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        provider.shutdown()
+        trace._TRACER_PROVIDER_SET_ONCE._done = False
+        trace._TRACER_PROVIDER = None
+        trace.set_tracer_provider(previous)
+
+
+def test_decorator_creates_consumer_span_with_task_name(memory_tracer):
+    @traced_task("provision_session")
+    def my_task(*, session_id: str) -> str:
+        return session_id
+
+    result = my_task(session_id="sess-1")
+    assert result == "sess-1"
+
+    spans = memory_tracer.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "task provision_session"
+    assert span.kind == SpanKind.CONSUMER
+
+
+def test_decorator_sets_attributes_from_kwargs(memory_tracer):
+    @traced_task("execute_turn")
+    def my_task(*, session_id: str, turn_id: int, mode: str) -> None:
+        return None
+
+    my_task(session_id="sess-2", turn_id=42, mode="run")
+
+    span = memory_tracer.get_finished_spans()[0]
+    assert span.attributes["procrastinate.task.name"] == "execute_turn"
+    assert span.attributes["aod.session_id"] == "sess-2"
+    assert span.attributes["aod.turn_id"] == 42
+    # Kwargs not in the attribute map shouldn't appear.
+    assert "aod.mode" not in span.attributes
+
+
+def test_decorator_sets_user_id_and_handle_when_present(memory_tracer):
+    @traced_task("destroy_session")
+    def my_task(*, user_id: int, handle: str) -> None:
+        return None
+
+    my_task(user_id=7, handle="sprite-abc")
+
+    span = memory_tracer.get_finished_spans()[0]
+    assert span.attributes["aod.user_id"] == 7
+    assert span.attributes["aod.handle"] == "sprite-abc"
+
+
+def test_decorator_strips_otel_carrier_before_calling_wrapped(memory_tracer):
+    seen_kwargs: dict = {}
+
+    @traced_task("execute_turn")
+    def my_task(**kwargs) -> None:
+        seen_kwargs.update(kwargs)
+
+    my_task(session_id="s", _otel_carrier={"traceparent": "ignored"})
+
+    assert "_otel_carrier" not in seen_kwargs
+    assert seen_kwargs == {"session_id": "s"}
+
+
+def test_decorator_attaches_span_to_carrier_parent(memory_tracer):
+    """When a carrier is provided, the resulting span's parent.trace_id
+    must match the carrier's trace context — that's what stitches the worker
+    trace to the originating request."""
+    tracer = trace.get_tracer("test")
+    carrier: dict[str, str] = {}
+    with tracer.start_as_current_span("parent") as parent:
+        parent_trace_id = parent.get_span_context().trace_id
+        TraceContextTextMapPropagator().inject(carrier)
+
+    @traced_task("execute_turn")
+    def my_task(*, session_id: str) -> None:
+        return None
+
+    my_task(session_id="s", _otel_carrier=carrier)
+
+    task_spans = [s for s in memory_tracer.get_finished_spans() if s.name == "task execute_turn"]
+    assert len(task_spans) == 1
+    task_span = task_spans[0]
+    assert task_span.parent is not None
+    assert task_span.parent.trace_id == parent_trace_id
+
+
+def test_decorator_records_exception_and_sets_error_status(memory_tracer):
+    @traced_task("execute_turn")
+    def boom(*, session_id: str) -> None:
+        raise RuntimeError("kaboom")
+
+    with pytest.raises(RuntimeError, match="kaboom"):
+        boom(session_id="s")
+
+    span = memory_tracer.get_finished_spans()[0]
+    assert span.status.status_code == StatusCode.ERROR
+    # `record_exception` adds an event with the exception type.
+    event_names = [e.name for e in span.events]
+    assert "exception" in event_names
+
+
+def test_inject_carrier_returns_traceparent_inside_span(memory_tracer):
+    tracer = trace.get_tracer("test")
+    with tracer.start_as_current_span("parent"):
+        carrier = inject_carrier()
+    assert "traceparent" in carrier
+
+
+def test_inject_carrier_returns_empty_outside_span(memory_tracer):
+    carrier = inject_carrier()
+    assert carrier == {}


### PR DESCRIPTION
## Summary

- Wraps each Procrastinate task (`provision_session_task`, `execute_turn`, `destroy_session_task`) in a `task <name>` CONSUMER span via a new `traced_task` decorator in `session_service/tracing.py`. Pre-span DB lookups in `_provision_session_inner` / `_execute_turn_inner` (and the queries inside `build_spec_for_session`) now have a parent — they previously emitted as orphan spans.
- Propagates W3C trace context across the enqueue boundary via an optional `_otel_carrier` task kwarg, so `POST /sessions` → `provision_session_task` → `execute_turn` lands as a single trace in Honeycomb. Threaded through all 5 `.defer(...)` sites.
- Existing inner spans (`session.provision_task`, `session.execute_turn`) remain untouched and become natural children — they hold post-fetch attributes the outer span can't have.

## Why

Honeycomb shows ~7,300 orphan SQL spans/hr from the worker. Half is Procrastinate polling (handled by #other-PR — orphan-psycopg filter); the other half is real in-task SQL that fired before the existing inner span opened. This PR closes the second gap by ensuring every code path inside a Procrastinate task runs under a span.

Pairs with the orphan-psycopg-filter PR — together they leave only fully-attached, useful traces.

## Test plan

- [x] `make test` — 1,202 passed (8 new tests in `tests/test_otel_task_tracing.py`)
- [x] `make lint` — clean
- [ ] After merge: confirm in Honeycomb that orphan SQL drops and `POST /sessions` traces include downstream worker spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)