### PR TITLE
observability: drop orphan psycopg CLIENT spans before export

### DIFF
--- a/src/agent_on_demand/observability.py
+++ b/src/agent_on_demand/observability.py
@@ -10,13 +10,62 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from opentelemetry.context import Context
+    from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 
 logger = logging.getLogger(__name__)
 
 HONEYCOMB_OTLP_ENDPOINT = "https://api.honeycomb.io"
 TRACER_NAME = "agent_on_demand"
+PSYCOPG_INSTRUMENTATION_SCOPE = "opentelemetry.instrumentation.psycopg"
 
 _otel_initialized = False
+
+
+def _make_orphan_psycopg_filter(wrapped: SpanProcessor) -> SpanProcessor:
+    """Wrap `wrapped` so orphan psycopg CLIENT spans are dropped before export.
+
+    The Procrastinate worker loop (poll / heartbeat / LISTEN / abort-poll, plus
+    the unnamed BEGIN/COMMIT statements that surface as `name="<dbname>_xxxx"`)
+    runs outside any task span. Auto-instrumented psycopg turns each statement
+    into a single-span trace, which floods Honeycomb (~7.3k orphan spans/hour)
+    while carrying no debugging signal. Real in-task SQL is parented by the
+    per-task span set up around `execute_turn`, so anything still parentless
+    at this point is polling we don't want.
+    """
+    from opentelemetry.sdk.trace import SpanProcessor
+    from opentelemetry.trace import SpanKind
+
+    class _OrphanPsycopgFilter(SpanProcessor):
+        def on_start(
+            self, span: Span, parent_context: Context | None = None
+        ) -> None:
+            wrapped.on_start(span, parent_context)
+
+        def on_end(self, span: ReadableSpan) -> None:
+            if _is_orphan_psycopg_client_span(span):
+                return
+            wrapped.on_end(span)
+
+        def shutdown(self) -> None:
+            wrapped.shutdown()
+
+        def force_flush(self, timeout_millis: int = 30000) -> bool:
+            return wrapped.force_flush(timeout_millis)
+
+    def _is_orphan_psycopg_client_span(span: ReadableSpan) -> bool:
+        if span.kind != SpanKind.CLIENT:
+            return False
+        scope = span.instrumentation_scope
+        if scope is None or scope.name != PSYCOPG_INSTRUMENTATION_SCOPE:
+            return False
+        parent = span.parent
+        return parent is None or not parent.is_valid
+
+    return _OrphanPsycopgFilter()
 
 
 def init_otel(service_name: str | None = None) -> None:
@@ -47,14 +96,13 @@ def init_otel(service_name: str | None = None) -> None:
     headers = {"x-honeycomb-team": api_key}
 
     tracer_provider = TracerProvider(resource=resource)
-    tracer_provider.add_span_processor(
-        BatchSpanProcessor(
-            OTLPSpanExporter(
-                endpoint=f"{HONEYCOMB_OTLP_ENDPOINT}/v1/traces",
-                headers=headers,
-            )
+    batch_processor = BatchSpanProcessor(
+        OTLPSpanExporter(
+            endpoint=f"{HONEYCOMB_OTLP_ENDPOINT}/v1/traces",
+            headers=headers,
         )
     )
+    tracer_provider.add_span_processor(_make_orphan_psycopg_filter(batch_processor))
     trace.set_tracer_provider(tracer_provider)
 
     logger_provider = LoggerProvider(resource=resource)

--- a/src/agent_on_demand/observability.py
+++ b/src/agent_on_demand/observability.py
@@ -40,9 +40,7 @@ def _make_orphan_psycopg_filter(wrapped: SpanProcessor) -> SpanProcessor:
     from opentelemetry.trace import SpanKind
 
     class _OrphanPsycopgFilter(SpanProcessor):
-        def on_start(
-            self, span: Span, parent_context: Context | None = None
-        ) -> None:
+        def on_start(self, span: Span, parent_context: Context | None = None) -> None:
             wrapped.on_start(span, parent_context)
 
         def on_end(self, span: ReadableSpan) -> None:

--- a/tests/test_observability_filter.py
+++ b/tests/test_observability_filter.py
@@ -9,11 +9,13 @@ they reach the BatchSpanProcessor; real in-task SQL is parented and unaffected.
 
 from __future__ import annotations
 
+from opentelemetry import context as otel_context
+from opentelemetry import trace
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
-from opentelemetry.trace import SpanKind
+from opentelemetry.trace import NonRecordingSpan, SpanContext, SpanKind, TraceFlags
 
 from agent_on_demand.observability import _make_orphan_psycopg_filter
 
@@ -62,6 +64,26 @@ def test_orphan_non_psycopg_span_is_exported():
 
     finished = exporter.get_finished_spans()
     assert [span.name for span in finished] == ["GET https://example.com"]
+
+
+def test_psycopg_client_span_with_invalid_parent_is_dropped():
+    """Remote propagation can deliver an all-zero/malformed traceparent, which
+    extracts to a SpanContext that is not None but `.is_valid == False`. That
+    second branch of the orphan check needs its own coverage — `parent is None`
+    isn't the only orphan shape."""
+    provider, exporter = _build_provider()
+    psycopg_tracer = provider.get_tracer("opentelemetry.instrumentation.psycopg")
+
+    invalid_ctx = SpanContext(trace_id=0, span_id=0, is_remote=False, trace_flags=TraceFlags(0))
+    invalid_parent = NonRecordingSpan(invalid_ctx)
+    token = otel_context.attach(trace.set_span_in_context(invalid_parent))
+    try:
+        with psycopg_tracer.start_as_current_span("SELECT 1", kind=SpanKind.CLIENT):
+            pass
+    finally:
+        otel_context.detach(token)
+
+    assert exporter.get_finished_spans() == ()
 
 
 def test_orphan_psycopg_internal_span_is_exported():

--- a/tests/test_observability_filter.py
+++ b/tests/test_observability_filter.py
@@ -1,0 +1,78 @@
+"""Orphan-psycopg-span filter for the worker process.
+
+The Procrastinate worker loop generates ~7.3k orphan psycopg CLIENT spans/hour
+(poll/heartbeat/LISTEN/abort-poll plus unnamed BEGIN/COMMIT). Each becomes the
+root of its own single-span trace in Honeycomb — pure noise. The filter
+installed by `_make_orphan_psycopg_filter` drops exactly those spans before
+they reach the BatchSpanProcessor; real in-task SQL is parented and unaffected.
+"""
+
+from __future__ import annotations
+
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind
+
+from agent_on_demand.observability import _make_orphan_psycopg_filter
+
+
+def _build_provider() -> tuple[TracerProvider, InMemorySpanExporter]:
+    """Wire SimpleSpanProcessor → InMemorySpanExporter, behind the orphan filter,
+    so each test sees exactly the spans the filter let through."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(resource=Resource.create({"service.name": "test"}))
+    provider.add_span_processor(_make_orphan_psycopg_filter(SimpleSpanProcessor(exporter)))
+    return provider, exporter
+
+
+def test_orphan_psycopg_client_span_is_dropped():
+    provider, exporter = _build_provider()
+    psycopg_tracer = provider.get_tracer("opentelemetry.instrumentation.psycopg")
+
+    with psycopg_tracer.start_as_current_span("SELECT 1", kind=SpanKind.CLIENT):
+        pass
+
+    assert exporter.get_finished_spans() == ()
+
+
+def test_parented_psycopg_client_span_is_exported():
+    provider, exporter = _build_provider()
+    app_tracer = provider.get_tracer("agent_on_demand")
+    psycopg_tracer = provider.get_tracer("opentelemetry.instrumentation.psycopg")
+
+    with app_tracer.start_as_current_span("execute_turn"):
+        with psycopg_tracer.start_as_current_span("SELECT 1", kind=SpanKind.CLIENT):
+            pass
+
+    finished = exporter.get_finished_spans()
+    names = sorted(span.name for span in finished)
+    assert names == ["SELECT 1", "execute_turn"]
+
+
+def test_orphan_non_psycopg_span_is_exported():
+    """Filter targets psycopg only — orphan spans from other instrumentors
+    (requests, django, etc.) must pass through unchanged."""
+    provider, exporter = _build_provider()
+    requests_tracer = provider.get_tracer("opentelemetry.instrumentation.requests")
+
+    with requests_tracer.start_as_current_span("GET https://example.com", kind=SpanKind.CLIENT):
+        pass
+
+    finished = exporter.get_finished_spans()
+    assert [span.name for span in finished] == ["GET https://example.com"]
+
+
+def test_orphan_psycopg_internal_span_is_exported():
+    """Filter targets CLIENT spans only — INTERNAL psycopg spans (e.g. wrapper
+    spans the instrumentation may emit around connection setup) are not the
+    polling-loop noise we're filtering."""
+    provider, exporter = _build_provider()
+    psycopg_tracer = provider.get_tracer("opentelemetry.instrumentation.psycopg")
+
+    with psycopg_tracer.start_as_current_span("connect", kind=SpanKind.INTERNAL):
+        pass
+
+    finished = exporter.get_finished_spans()
+    assert [span.name for span in finished] == ["connect"]


### PR DESCRIPTION
## Summary

- Adds a `SpanProcessor` filter wrapping `BatchSpanProcessor` that drops spans where all of: kind is CLIENT, instrumentation scope is `opentelemetry.instrumentation.psycopg`, and parent context is missing/invalid.
- Targets the Procrastinate worker's idle chatter — poll, heartbeat, LISTEN, abort-poll, plus the unnamed BEGIN/COMMIT statements that show up as `name=\"agent_on_demand_9liq\"` (the DB name) — all of which currently emit as single-span root traces because they run outside any user-defined span.
- Logs are unaffected; only the trace pipeline runs through the filter.

## Why

Honeycomb is receiving ~7,300 orphan SQL spans/hr from the worker with no debugging value. Real in-task SQL gets a parent via the companion PR (worker-task-spans), so anything still parentless after that lands is polling we want to discard.

## Test plan

- [x] `make test` — 1,198 passed (4 new tests in `tests/test_observability_filter.py`)
- [x] `make lint` — clean
- [ ] After merge: confirm in Honeycomb that orphan psycopg spans drop to ~0 while parented in-task SQL is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)