### PR TITLE
docs(errors): add missing 429, fix envelope claim, add two missing 409 cases

### DIFF
--- a/site/docs/api/errors.md
+++ b/site/docs/api/errors.md
@@ -2,13 +2,13 @@
 
 ## Error envelope
 
-All error responses use a single shape:
+Most error responses use this shape:
 
 ```json
 {"detail": "<string or list>"}
 ```
 
-- For every status code **except 422**, `detail` is a string.
+- For every status code **except 422 and 429**, `detail` is a string.
 - For **422**, `detail` is a list of Pydantic validation error objects:
 
 ```json
@@ -21,6 +21,16 @@ All error responses use a single shape:
       "input": {}
     }
   ]
+}
+```
+
+- For **429**, `detail` is a string and two extra fields are present:
+
+```json
+{
+  "detail": "Concurrent session limit reached (3/3). Terminate an active session before starting a new one.",
+  "limit": 3,
+  "active": 3
 }
 ```
 
@@ -39,6 +49,7 @@ Client rule: `isinstance(detail, list)` if and only if status is 422.
 | 405 | string | Method not allowed | `{"detail":"Method not allowed"}` |
 | 409 | string | Conflict — see table below | `{"detail":"Version mismatch: expected 3, got 2"}` |
 | 422 | **list** | Pydantic validation failure | `{"detail":[{"type":"missing",...}]}` |
+| 429 | string + extras | Concurrent session limit reached | `{"detail":"...","limit":3,"active":3}` |
 | 502 | string | Sprites upstream error during session create | `{"detail":"Failed to create Sprite: connection refused"}` |
 
 ## 409 conflict cases
@@ -59,6 +70,8 @@ All of these return `409`:
 | `POST /sessions/{id}/prompt` | Session is running | `"Session is already running"` |
 | `POST /sessions/{id}/prompt` | Session has failed | `"Session has failed and cannot be resumed. Start a new session."` |
 | `POST /sessions/{id}/prompt` | Session is terminated | `"Session has been terminated"` |
+| `POST /sessions/{id}/prompt` | Session already has a pending turn (concurrent send race) | `"Session already has a pending turn"` |
+| `POST /sessions/{id}/prompt` | Backend handle gone (Sprite cleaned up while session record exists) | `"Session backend is no longer available; start a new session."` |
 | `POST /sessions/{id}/terminate` | Session already terminated | `"Session is already terminated"` |
 | `DELETE /sessions/{id}/delete` | Session is active (pending or running) | `"Cannot delete an active session"` |
 


### PR DESCRIPTION
## What was wrong

Three gaps found by comparing `site/docs/api/errors.md` against the views:

### 1. 429 entirely absent from the status code table

`POST /sessions` returns `429` when a user hits their concurrent session limit (`create.py:145–155`):

```python
return JsonResponse(
    {
        "detail": f"Concurrent session limit reached ({locked_count}/{locked_max}). ...",
        "limit": locked_max,
        "active": locked_count,
    },
    status=429,
)
```

The 429 body also includes `"limit"` and `"active"` fields, which contradicted the page's claim that all non-422 errors use `{"detail":"..."}`. A client following the docs would have no idea this status code exists and no idea how to read the response.

### 2. Two undocumented 409 paths for `POST /sessions/{id}/prompt`

The docs listed three 409 cases for this endpoint. Two more exist in `lifecycle.py`:

- **`"Session already has a pending turn"`** — fired at line 92 when a second concurrent `send_prompt` wins the row lock while `status` is still `"pending"`. Guards against turn-number races.
- **`"Session backend is no longer available; start a new session."`** — fired at line 72 when `SessionHandleNotFound` is raised (Sprite handle cleaned up while the session record survives). Returns 409 rather than 404 to avoid ambiguity with "session not found."

## What changed

- `errors.md` envelope section: "All error responses" → "Most error responses"; added 429-specific example with `limit`/`active` fields; updated the client rule note.
- Status code table: added 429 row.
- 409 conflict table: added the two missing `POST /sessions/{id}/prompt` rows.

## How I verified

- 429 body: `create.py` lines 145–155 — `JsonResponse(..., status=429)` with `limit` and `active` keys.
- "Session already has a pending turn": `lifecycle.py` line 92.
- "Session backend is no longer available": `lifecycle.py` lines 72–75 (`SessionHandleNotFound` handler).
- All three `detail` strings for the existing 409 rows confirmed against `session_state.py`.
- No open PRs touch `site/docs/api/errors.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)