### PR TITLE
docs(patterns): filter chat-bot stream by turn; correct dashboard delete-blocked statuses

### DIFF
--- a/examples/chat-bot/bot.py
+++ b/examples/chat-bot/bot.py
@@ -38,12 +38,21 @@ client = Client()  # reads AOD_API_URL + AOD_API_TOKEN
 thread_sessions: dict[str, str] = {}
 
 
-def _drain_stdout(session_id: str) -> str:
-    """Block until the session reaches a terminal event, returning stdout joined."""
+def _drain_stdout(session_id: str, turn: int) -> str:
+    """Block until the session reaches a terminal event, returning this turn's stdout joined.
+
+    Filters by ``turn`` because ``client.sessions.stream`` replays from the
+    start of the session; without the filter, every reply after the first
+    would include all prior turns concatenated.
+    """
     parts: list[str] = []
     with client.sessions.stream(session_id) as events:
         for event in events:
-            if event.type == "output" and event.extra.get("stream") == "stdout":
+            if (
+                event.type == "output"
+                and event.extra.get("stream") == "stdout"
+                and event.extra.get("turn") == turn
+            ):
                 parts.append(event.extra.get("data", ""))
             elif event.type in ("exit", "error", "terminated", "stale"):
                 break
@@ -65,7 +74,7 @@ def on_mention(event: dict, say) -> None:
         else:
             session_id = thread_sessions[thread_ts]
             try:
-                client.sessions.prompt(session_id, prompt=prompt)
+                ack = client.sessions.prompt(session_id, prompt=prompt)
                 log.info("resumed session %s for thread %s", session_id, thread_ts)
             except ConflictError:
                 # 409: session is running (user typed during a reply).
@@ -73,7 +82,7 @@ def on_mention(event: dict, say) -> None:
                 say(text="Still working on the previous message…", thread_ts=thread_ts)
                 return
 
-        reply = _drain_stdout(thread_sessions[thread_ts])
+        reply = _drain_stdout(thread_sessions[thread_ts], ack.current_turn)
     except AodError as e:
         log.exception("aod error")
         say(text=f":warning: agent error: {e}", thread_ts=thread_ts)

--- a/site/docs/patterns/chat-bot.md
+++ b/site/docs/patterns/chat-bot.md
@@ -19,6 +19,14 @@ Stream the agent's response back to the thread via
 
 ## Example (Slack)
 
+!!! warning "Filter the stream by turn"
+    `client.sessions.stream(session_id)` replays every `output` event from the
+    start of the session, and the `exit`/`error`/`terminated` events are
+    *session*-terminal, not per-turn. If you don't filter, every reply after
+    the first will include all prior turns concatenated. Capture
+    `ack.current_turn` from the create/prompt response and only emit
+    `output` events whose `event.extra["turn"]` matches.
+
 ```python
 import os
 from aod import Client, ConflictError
@@ -31,12 +39,16 @@ client = Client()  # reads AOD_API_URL + AOD_API_TOKEN
 # Simple in-memory store; use Redis/DB in production
 thread_sessions: dict[str, str] = {}
 
-def run_turn(session_id: str) -> str:
-    """Collect all output for one turn into a single reply string."""
+def run_turn(session_id: str, turn: int) -> str:
+    """Collect this turn's stdout into a single reply string."""
     parts: list[str] = []
     with client.sessions.stream(session_id) as events:
         for event in events:
-            if event.type == "output" and event.extra.get("stream") == "stdout":
+            if (
+                event.type == "output"
+                and event.extra.get("stream") == "stdout"
+                and event.extra.get("turn") == turn
+            ):
                 parts.append(event.extra.get("data", ""))
             elif event.type in ("exit", "error", "terminated", "stale"):
                 break
@@ -53,14 +65,14 @@ def handle_mention(event, say):
     else:
         session_id = thread_sessions[thread_ts]
         try:
-            client.sessions.prompt(session_id, prompt=prompt)
+            ack = client.sessions.prompt(session_id, prompt=prompt)
         except ConflictError:
             # 409: session is already running (user typed quickly).
             # Queue this message or tell the user to wait.
             say(text="Still working on the previous message…", thread_ts=thread_ts)
             return
 
-    output = run_turn(thread_sessions[thread_ts])
+    output = run_turn(thread_sessions[thread_ts], ack.current_turn)
     say(text=output, thread_ts=thread_ts)
 ```
 

--- a/site/docs/patterns/dashboard.md
+++ b/site/docs/patterns/dashboard.md
@@ -70,8 +70,8 @@ Use this when your infrastructure doesn't support long-lived HTTP responses
   `ConflictError` (HTTP 409) — handle it gracefully.
 - **Cleanup:** Implement a retention policy: call
   `client.sessions.delete(session_id)` on sessions older than your threshold.
-  Sessions cannot be deleted while `status == "running"` — attempting to
-  raises `ConflictError`.
+  Active sessions (`status` of `pending` or `running`) cannot be deleted —
+  attempting to raises `ConflictError`. Terminate first, then delete.
 
 A complete runnable implementation — FastAPI backend, browser-side
 `EventSource`, single-token SSE proxy — lives at


### PR DESCRIPTION
Closes #282.

## Summary
- **chat-bot pattern + bundled example** now capture `ack.current_turn` from the create/prompt response and filter `output` events on `event.extra["turn"]`. Without this filter the SSE replay returns turns 1..N concatenated on every reply, because `exit`/`error`/`terminated` events are session-terminal, not per-turn.
- Added a callout above the Slack snippet explaining the gotcha so future copy-pasters don't reintroduce the bug.
- **dashboard.md** delete-blocked statuses corrected: the server blocks `delete` on `pending` and `running`, not just `running` (matches `errors.md`'s "Cannot delete an active session").

## Test plan
- [ ] Render docs (`mkdocs serve`) and check both patterns pages format cleanly
- [ ] Skim `examples/chat-bot/bot.py` — first message creates a session, second message in the same thread should now post only the new turn's output instead of the cumulative conversation
- [ ] Confirm `SessionAck.current_turn` is populated on both create and prompt responses (it is — `views/sessions/create.py:219`, `views/sessions/lifecycle.py:129`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)