### PR TITLE
observability: emit runtime.output span event per log chunk

### DIFF
--- a/src/agent_on_demand/session_service/log_sink.py
+++ b/src/agent_on_demand/session_service/log_sink.py
@@ -81,9 +81,10 @@ class LogChunkSink:
          emit the posthog event for any dropped chunks.
     """
 
-    def __init__(self, session: AgentSession, turn: SessionTurn):
+    def __init__(self, session: AgentSession, turn: SessionTurn, span=None):
         self._session = session
         self._turn = turn
+        self._span = span
         self._queue: queue.Queue = queue.Queue(maxsize=QUEUE_MAXSIZE)
         self._buffer: list[AgentSessionLog] = []
         self.stdout_writer = TaggingQueueWriter(self._queue, "stdout")
@@ -107,6 +108,7 @@ class LogChunkSink:
                 continue
             if chunk is _SENTINEL:
                 break
+            self._record_chunk_event(chunk)
             self._buffer.append(
                 AgentSessionLog(
                     session=self._session,
@@ -143,6 +145,23 @@ class LogChunkSink:
                     raise
                 close_old_connections()
                 time.sleep(delay)
+
+    def _record_chunk_event(self, chunk: TaggedChunk) -> None:
+        """Mark each chunk as a span event so the trace timeline shows when
+        the runtime produced output during the long sprite.command().run().
+        Without this, only the periodic INSERT statements appear in the
+        worker span and the gaps between them (model thinking + tool use)
+        are invisible. PR 2 will parse stream-json lines into richer child
+        spans; this is the cheap, runtime-agnostic baseline."""
+        if self._span is None:
+            return
+        self._span.add_event(
+            "runtime.output",
+            attributes={
+                "aod.stream": chunk.stream,
+                "aod.bytes": len(chunk.data),
+            },
+        )
 
     @property
     def total_drop_count(self) -> int:

--- a/src/agent_on_demand/session_service/log_sink.py
+++ b/src/agent_on_demand/session_service/log_sink.py
@@ -16,11 +16,15 @@ import io
 import logging
 import queue
 import time
+from typing import TYPE_CHECKING
 
 from django.db import close_old_connections
 
 from agent_on_demand.analytics import capture as posthog_capture
 from agent_on_demand.models import AgentSession, AgentSessionLog, SessionTurn
+
+if TYPE_CHECKING:
+    from opentelemetry.trace import Span
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +85,12 @@ class LogChunkSink:
          emit the posthog event for any dropped chunks.
     """
 
-    def __init__(self, session: AgentSession, turn: SessionTurn, span=None):
+    def __init__(
+        self,
+        session: AgentSession,
+        turn: SessionTurn,
+        span: Span | None = None,
+    ):
         self._session = session
         self._turn = turn
         self._span = span
@@ -108,7 +117,6 @@ class LogChunkSink:
                 continue
             if chunk is _SENTINEL:
                 break
-            self._record_chunk_event(chunk)
             self._buffer.append(
                 AgentSessionLog(
                     session=self._session,
@@ -117,6 +125,7 @@ class LogChunkSink:
                     data=chunk.data.decode("utf-8", errors="replace"),
                 )
             )
+            self._record_chunk_event(chunk)
             if len(self._buffer) >= FLUSH_SIZE:
                 self._flush_buffer()
         self._flush_buffer()
@@ -148,11 +157,9 @@ class LogChunkSink:
 
     def _record_chunk_event(self, chunk: TaggedChunk) -> None:
         """Mark each chunk as a span event so the trace timeline shows when
-        the runtime produced output during the long sprite.command().run().
-        Without this, only the periodic INSERT statements appear in the
-        worker span and the gaps between them (model thinking + tool use)
-        are invisible. PR 2 will parse stream-json lines into richer child
-        spans; this is the cheap, runtime-agnostic baseline."""
+        the runtime produced output. Without this, only the periodic INSERT
+        statements appear inside the turn span and the gaps between them
+        (model thinking + tool use) are invisible."""
         if self._span is None:
             return
         self._span.add_event(

--- a/src/agent_on_demand/session_service/turn_executor.py
+++ b/src/agent_on_demand/session_service/turn_executor.py
@@ -66,7 +66,7 @@ class TurnExecutor:
         self._mode = mode
         self._timeout = timeout
         self._span = span
-        self._sink = LogChunkSink(session, turn)
+        self._sink = LogChunkSink(session, turn, span=span)
         self._result_holder: list = []
 
     def run(self) -> None:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -25,7 +25,7 @@ from agent_on_demand.models import (
     UserBackendCredential,
     UserCredential,
 )
-from agent_on_demand.session_service.log_sink import TaggingQueueWriter
+from agent_on_demand.session_service.log_sink import LogChunkSink, TaggingQueueWriter
 from agent_on_demand.session_service.tasks import (
     destroy_session_task,
     execute_turn,
@@ -668,6 +668,42 @@ def test_bulk_create_exhausts_retries_and_raises(user, mocker):
     assert len(exhaustion_calls) == 1
     props = exhaustion_calls[0].kwargs.get("properties", {})
     assert props.get("dropped_chunks", 0) > 0
+
+
+@pytest.mark.django_db
+def test_drain_emits_runtime_output_span_event_per_chunk(user):
+    """Each chunk consumed by the drain loop should fan out as a `runtime.output`
+    span event on the parent span. The trace would otherwise only show INSERT
+    spans at flush time, hiding the cadence of model output between flushes."""
+    session, turn = _make_session_and_turn(user)
+    span_events: list[tuple[str, dict]] = []
+
+    class FakeSpan:
+        def add_event(self, name, attributes=None):
+            span_events.append((name, dict(attributes or {})))
+
+    sink = LogChunkSink(session, turn, span=FakeSpan())
+    sink.stdout_writer.write(b"hello")
+    sink.stderr_writer.write(b"warn\n")
+    sink.put_sentinel()
+    sink.drain()
+
+    assert [(name, attrs["aod.stream"], attrs["aod.bytes"]) for name, attrs in span_events] == [
+        ("runtime.output", "stdout", 5),
+        ("runtime.output", "stderr", 5),
+    ]
+
+
+@pytest.mark.django_db
+def test_drain_without_span_does_not_raise(user):
+    """LogChunkSink must tolerate a missing span — span is None when callers
+    construct the sink outside a traced task (none today, but the constructor
+    keeps the parameter optional)."""
+    session, turn = _make_session_and_turn(user)
+    sink = LogChunkSink(session, turn, span=None)
+    sink.stdout_writer.write(b"x")
+    sink.put_sentinel()
+    sink.drain()
 
 
 @pytest.mark.django_db

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -695,6 +695,29 @@ def test_drain_emits_runtime_output_span_event_per_chunk(user):
 
 
 @pytest.mark.django_db
+def test_drain_buffers_chunk_before_emitting_span_event(user):
+    """If span.add_event raises (custom exporter, ended span on a buggy SDK,
+    etc.) the chunk must already be in the buffer — otherwise it's silently
+    lost with no drop counter or posthog event. The drain loop intentionally
+    buffers first, then emits."""
+    session, turn = _make_session_and_turn(user)
+
+    class RaisingSpan:
+        def add_event(self, name, attributes=None):
+            raise RuntimeError("exporter blew up")
+
+    sink = LogChunkSink(session, turn, span=RaisingSpan())
+    sink.stdout_writer.write(b"persisted")
+    sink.put_sentinel()
+
+    with pytest.raises(RuntimeError, match="exporter blew up"):
+        sink.drain()
+
+    assert len(sink._buffer) == 1
+    assert sink._buffer[0].data == "persisted"
+
+
+@pytest.mark.django_db
 def test_drain_without_span_does_not_raise(user):
     """LogChunkSink must tolerate a missing span — span is None when callers
     construct the sink outside a traced task (none today, but the constructor


### PR DESCRIPTION
## Summary
- Pass the active `session.execute_turn` span from `TurnExecutor` into `LogChunkSink` and emit a `runtime.output` span event (with `aod.stream` + `aod.bytes`) for each chunk consumed by the drain loop.
- Without it, the only inner spans on a turn are the periodic `INSERT` statements at flush time — so the gaps between flushes (model thinking + tool use) look like dead time on the Honeycomb trace. With it, the timeline shows the cadence of model output throughout the turn.
- Cheap, runtime-agnostic baseline. Per-runtime stream-json parsing into named child spans (e.g. `runtime.tool_use { tool: "Bash" }`) follows in a separate PR.

## Test plan
- [x] `make lint`
- [x] `make test` (1209 passed)
- [x] New unit tests:
  - `test_drain_emits_runtime_output_span_event_per_chunk` — verifies one event per chunk with the expected attrs.
  - `test_drain_without_span_does_not_raise` — sink tolerates `span=None`.
- [ ] Post-deploy: confirm a real session trace in Honeycomb shows `runtime.output` events filling the previously dead time inside `session.execute_turn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)