### PR TITLE
observability: propagate trace context into Claude Code on Sprite

### DIFF
--- a/src/agent_on_demand/runtimes/base.py
+++ b/src/agent_on_demand/runtimes/base.py
@@ -24,3 +24,16 @@ class Runtime(Protocol):
     ) -> None:
         """Write any per-runtime config files on the session. Always called at provision time,
         even when mcp_servers is empty."""
+
+    def otel_env(
+        self,
+        spec: SessionSpec,
+        traceparent: str | None,
+        tracestate: str | None,
+    ) -> dict[str, str]:
+        """Env vars to inject into the per-turn process for OpenTelemetry export.
+
+        Return ``{}`` to disable. Implementations that support OTel should
+        honor ``traceparent`` / ``tracestate`` so the runtime CLI's spans
+        parent under the worker span that launched the turn.
+        """

--- a/src/agent_on_demand/runtimes/base.py
+++ b/src/agent_on_demand/runtimes/base.py
@@ -31,9 +31,32 @@ class Runtime(Protocol):
         traceparent: str | None,
         tracestate: str | None,
     ) -> dict[str, str]:
-        """Env vars to inject into the per-turn process for OpenTelemetry export.
+        """Non-secret env vars to inject into the per-turn process for
+        OpenTelemetry export.
 
         Return ``{}`` to disable. Implementations that support OTel should
         honor ``traceparent`` / ``tracestate`` so the runtime CLI's spans
         parent under the worker span that launched the turn.
+
+        Secret-bearing values (API keys, auth headers) belong in
+        ``static_env`` instead, since this dict is rendered into the
+        ``argv`` handed to the backend and could leak via logs.
+
+        Default returns ``{}`` rather than ``None`` so a runtime that
+        forgets to override still composes safely with ``build_turn_argv``.
         """
+        return {}
+
+    def static_env(self, spec: SessionSpec) -> list[tuple[str, str]]:
+        """Runtime-specific env-var pairs to write into ``/tmp/aod-env`` at
+        provision time.
+
+        Use for secrets (the file is mode 0600 on the per-session Sprite,
+        same threat model as the credentials already written there) or
+        for config that doesn't change per turn. Per-turn dynamic context
+        (W3C trace headers, etc.) belongs in ``otel_env``.
+
+        Default returns ``[]`` so a runtime that forgets to override is a
+        silent no-op rather than a `TypeError` in the env-file builder.
+        """
+        return []

--- a/src/agent_on_demand/runtimes/claude.py
+++ b/src/agent_on_demand/runtimes/claude.py
@@ -5,7 +5,10 @@ from typing import TYPE_CHECKING, Literal
 
 from agent_on_demand.runtimes.claude_command import build_claude_command
 from agent_on_demand.runtimes.claude_config import render_claude_mcp_config
-from agent_on_demand.runtimes.claude_otel import build_claude_otel_env
+from agent_on_demand.runtimes.claude_otel import (
+    build_claude_otel_env,
+    build_claude_otel_static_env,
+)
 
 if TYPE_CHECKING:
     from agent_on_demand.session_service.backends import SessionHandle
@@ -52,3 +55,6 @@ class ClaudeRuntime:
         tracestate: str | None,
     ) -> dict[str, str]:
         return build_claude_otel_env(spec, traceparent, tracestate)
+
+    def static_env(self, spec: "SessionSpec") -> list[tuple[str, str]]:
+        return build_claude_otel_static_env()

--- a/src/agent_on_demand/runtimes/claude.py
+++ b/src/agent_on_demand/runtimes/claude.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Literal
 
 from agent_on_demand.runtimes.claude_command import build_claude_command
 from agent_on_demand.runtimes.claude_config import render_claude_mcp_config
+from agent_on_demand.runtimes.claude_otel import build_claude_otel_env
 
 if TYPE_CHECKING:
     from agent_on_demand.session_service.backends import SessionHandle
@@ -43,3 +44,11 @@ class ClaudeRuntime:
             "/home/sprite/.claude.json",
             json.dumps({"mcpServers": config}, indent=2),
         )
+
+    def otel_env(
+        self,
+        spec: "SessionSpec",
+        traceparent: str | None,
+        tracestate: str | None,
+    ) -> dict[str, str]:
+        return build_claude_otel_env(spec, traceparent, tracestate)

--- a/src/agent_on_demand/runtimes/claude_otel.py
+++ b/src/agent_on_demand/runtimes/claude_otel.py
@@ -1,0 +1,102 @@
+"""Build the OpenTelemetry env-var dict for a per-turn Claude Code invocation.
+
+Claude Code reads `TRACEPARENT` / `TRACESTATE` from its own environment in
+`-p` (non-interactive) mode and parents its `claude_code.interaction` span
+under that context. By passing the worker's `session.execute_turn` span as
+the parent, every API request, tool call, and hook execution Claude makes
+on the Sprite shows up under the same trace as the rows we wrote on the
+worker side — one waterfall per turn in Honeycomb.
+
+Gated on `HONEYCOMB_API_KEY`: when unset, returns `{}` so unit tests and
+local dev (and any deploy without telemetry) behave identically. Same
+gating shape as `agent_on_demand.observability.init_otel`.
+
+Pure module — no I/O, no Django imports — so it can be direct-tested under
+mutmut's hammett runner.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent_on_demand.session_service.specs import SessionSpec
+
+HONEYCOMB_OTLP_ENDPOINT = "https://api.honeycomb.io"
+
+# Resource-attribute values must not contain spaces, commas, semicolons,
+# backslashes, or double quotes (Claude Code monitoring docs). Everything
+# we emit (UUIDs, ints, slug-shaped runtime/model strings) already satisfies
+# that, but the filter keeps a future surprise from poisoning the whole
+# attribute string and silently dropping every span.
+_FORBIDDEN_RESOURCE_VALUE_CHARS = frozenset(' ,;"\\')
+
+
+def build_claude_otel_env(
+    spec: "SessionSpec",
+    traceparent: str | None,
+    tracestate: str | None = None,
+    honeycomb_api_key: str | None = None,
+) -> dict[str, str]:
+    """Return env vars to inject into the Claude Code subprocess.
+
+    `honeycomb_api_key` defaults to `os.environ["HONEYCOMB_API_KEY"]`; pass
+    explicitly from tests. When unset, returns `{}` — the only safe no-op
+    when the receiving collector is unconfigured.
+
+    `traceparent` should be the W3C traceparent header of the worker span
+    that's about to launch the turn. When falsy, telemetry still flows but
+    the `claude_code.interaction` span starts a new root, which means the
+    server-side worker span and the in-Sprite Claude span won't link.
+    """
+    api_key = (
+        honeycomb_api_key if honeycomb_api_key is not None else os.environ.get("HONEYCOMB_API_KEY")
+    )
+    if not api_key:
+        return {}
+
+    env: dict[str, str] = {
+        "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+        "CLAUDE_CODE_ENHANCED_TELEMETRY_BETA": "1",
+        "OTEL_METRICS_EXPORTER": "otlp",
+        "OTEL_LOGS_EXPORTER": "otlp",
+        "OTEL_TRACES_EXPORTER": "otlp",
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": HONEYCOMB_OTLP_ENDPOINT,
+        "OTEL_EXPORTER_OTLP_HEADERS": f"x-honeycomb-team={api_key}",
+        "OTEL_RESOURCE_ATTRIBUTES": _build_resource_attributes(spec),
+    }
+    if traceparent:
+        env["TRACEPARENT"] = traceparent
+    if tracestate:
+        env["TRACESTATE"] = tracestate
+    return env
+
+
+def _build_resource_attributes(spec: "SessionSpec") -> str:
+    """Render `OTEL_RESOURCE_ATTRIBUTES` value (comma-separated key=value).
+
+    Each value is filtered against `_FORBIDDEN_RESOURCE_VALUE_CHARS` and
+    skipped if any character would corrupt the attribute string. Empty
+    values are also skipped — the doc says `key=` is technically valid but
+    it's noise.
+    """
+    candidates: list[tuple[str, str]] = [
+        ("aod.runtime", spec.runtime.name),
+        ("aod.model", spec.model),
+    ]
+    if spec.runtime_session_id:
+        candidates.append(("aod.session_id", spec.runtime_session_id))
+    if spec.user is not None and spec.user.id is not None:
+        candidates.append(("aod.user_id", str(spec.user.id)))
+    if spec.environment is not None and spec.environment.id is not None:
+        candidates.append(("aod.environment_id", str(spec.environment.id)))
+    pairs = [(k, v) for k, v in candidates if _is_safe_attribute_value(v)]
+    return ",".join(f"{k}={v}" for k, v in pairs)
+
+
+def _is_safe_attribute_value(value: str) -> bool:
+    if not value:
+        return False
+    return not any(c in _FORBIDDEN_RESOURCE_VALUE_CHARS for c in value)

--- a/src/agent_on_demand/runtimes/claude_otel.py
+++ b/src/agent_on_demand/runtimes/claude_otel.py
@@ -26,11 +26,14 @@ if TYPE_CHECKING:
 HONEYCOMB_OTLP_ENDPOINT = "https://api.honeycomb.io"
 
 # Resource-attribute values must not contain spaces, commas, semicolons,
-# backslashes, or double quotes (Claude Code monitoring docs). Everything
-# we emit (UUIDs, ints, slug-shaped runtime/model strings) already satisfies
-# that, but the filter keeps a future surprise from poisoning the whole
-# attribute string and silently dropping every span.
-_FORBIDDEN_RESOURCE_VALUE_CHARS = frozenset(' ,;"\\')
+# backslashes, or double quotes (Claude Code monitoring docs). `=` is the
+# key/value separator in the rendered string, so a value containing `=`
+# would corrupt parsing (`aod.model=foo=bar` is ambiguous). Everything we
+# emit today (UUIDs, ints, slug-shaped runtime/model strings) already
+# satisfies that, but the filter keeps a future surprise — say a model
+# name that includes `=` — from poisoning the whole attribute string and
+# silently dropping every span.
+_FORBIDDEN_RESOURCE_VALUE_CHARS = frozenset(' ,;"\\=')
 
 
 def build_claude_otel_env(
@@ -39,7 +42,15 @@ def build_claude_otel_env(
     tracestate: str | None = None,
     honeycomb_api_key: str | None = None,
 ) -> dict[str, str]:
-    """Return env vars to inject into the Claude Code subprocess.
+    """Return non-secret env vars to inject into the Claude Code subprocess
+    via the per-turn bash shim.
+
+    The Honeycomb API key is *not* in this dict — the secret-bearing
+    `OTEL_EXPORTER_OTLP_HEADERS` line lives in `/tmp/aod-env` (written at
+    provision time via `build_claude_otel_static_env`), not the shim
+    string. Argv may be persisted by Procrastinate or logged by the
+    Sprite SDK; the file is mode 0600 inside the per-session Sprite and
+    matches the threat model already accepted for `ANTHROPIC_API_KEY`.
 
     `honeycomb_api_key` defaults to `os.environ["HONEYCOMB_API_KEY"]`; pass
     explicitly from tests. When unset, returns `{}` — the only safe no-op
@@ -49,6 +60,13 @@ def build_claude_otel_env(
     that's about to launch the turn. When falsy, telemetry still flows but
     the `claude_code.interaction` span starts a new root, which means the
     server-side worker span and the in-Sprite Claude span won't link.
+
+    `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA` is currently undocumented in
+    public Claude Code docs (only the standard `CLAUDE_CODE_ENABLE_TELEMETRY`
+    is). Confirmed working with Claude Code as of the docs revision at
+    https://code.claude.com/docs/en/monitoring-usage (April 2026). If a
+    future Claude Code version stops emitting traces, check whether this
+    flag has been renamed or promoted to GA.
     """
     api_key = (
         honeycomb_api_key if honeycomb_api_key is not None else os.environ.get("HONEYCOMB_API_KEY")
@@ -64,7 +82,6 @@ def build_claude_otel_env(
         "OTEL_TRACES_EXPORTER": "otlp",
         "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
         "OTEL_EXPORTER_OTLP_ENDPOINT": HONEYCOMB_OTLP_ENDPOINT,
-        "OTEL_EXPORTER_OTLP_HEADERS": f"x-honeycomb-team={api_key}",
         "OTEL_RESOURCE_ATTRIBUTES": _build_resource_attributes(spec),
     }
     if traceparent:
@@ -72,6 +89,29 @@ def build_claude_otel_env(
     if tracestate:
         env["TRACESTATE"] = tracestate
     return env
+
+
+def build_claude_otel_static_env(
+    honeycomb_api_key: str | None = None,
+) -> list[tuple[str, str]]:
+    """Return secret-bearing env-var pairs to write into `/tmp/aod-env` at
+    provision time.
+
+    Today this is only `OTEL_EXPORTER_OTLP_HEADERS`, which carries the
+    Honeycomb API key. Splitting it from `build_claude_otel_env` keeps the
+    secret out of the per-turn bash shim string (and therefore out of any
+    log that records the argv handed to `sprite.command(...)`).
+
+    Returns `[]` when `HONEYCOMB_API_KEY` is unset — same gating shape as
+    `build_claude_otel_env`. The list-of-pairs return matches the
+    `credentials` shape `build_env_file_body` already consumes.
+    """
+    api_key = (
+        honeycomb_api_key if honeycomb_api_key is not None else os.environ.get("HONEYCOMB_API_KEY")
+    )
+    if not api_key:
+        return []
+    return [("OTEL_EXPORTER_OTLP_HEADERS", f"x-honeycomb-team={api_key}")]
 
 
 def _build_resource_attributes(spec: "SessionSpec") -> str:

--- a/src/agent_on_demand/runtimes/codex.py
+++ b/src/agent_on_demand/runtimes/codex.py
@@ -39,3 +39,11 @@ class CodexRuntime:
             return
         body = render_codex_mcp_config(mcp_servers)
         handle.workspace().write_text("/home/sprite/.codex/config.toml", body)
+
+    def otel_env(
+        self,
+        spec: "SessionSpec",
+        traceparent: str | None,
+        tracestate: str | None,
+    ) -> dict[str, str]:
+        return {}

--- a/src/agent_on_demand/runtimes/codex.py
+++ b/src/agent_on_demand/runtimes/codex.py
@@ -47,3 +47,6 @@ class CodexRuntime:
         tracestate: str | None,
     ) -> dict[str, str]:
         return {}
+
+    def static_env(self, spec: "SessionSpec") -> list[tuple[str, str]]:
+        return []

--- a/src/agent_on_demand/runtimes/gemini.py
+++ b/src/agent_on_demand/runtimes/gemini.py
@@ -46,3 +46,6 @@ class GeminiRuntime:
         tracestate: str | None,
     ) -> dict[str, str]:
         return {}
+
+    def static_env(self, spec: "SessionSpec") -> list[tuple[str, str]]:
+        return []

--- a/src/agent_on_demand/runtimes/gemini.py
+++ b/src/agent_on_demand/runtimes/gemini.py
@@ -38,3 +38,11 @@ class GeminiRuntime:
             "/home/sprite/.gemini/settings.json",
             json.dumps({"mcpServers": config}, indent=2),
         )
+
+    def otel_env(
+        self,
+        spec: "SessionSpec",
+        traceparent: str | None,
+        tracestate: str | None,
+    ) -> dict[str, str]:
+        return {}

--- a/src/agent_on_demand/runtimes/opencode.py
+++ b/src/agent_on_demand/runtimes/opencode.py
@@ -53,3 +53,11 @@ class OpencodeRuntime:
             "/home/sprite/.config/opencode/opencode.json",
             json.dumps({"mcp": config}, indent=2),
         )
+
+    def otel_env(
+        self,
+        spec: "SessionSpec",
+        traceparent: str | None,
+        tracestate: str | None,
+    ) -> dict[str, str]:
+        return {}

--- a/src/agent_on_demand/runtimes/opencode.py
+++ b/src/agent_on_demand/runtimes/opencode.py
@@ -61,3 +61,6 @@ class OpencodeRuntime:
         tracestate: str | None,
     ) -> dict[str, str]:
         return {}
+
+    def static_env(self, spec: "SessionSpec") -> list[tuple[str, str]]:
+        return []

--- a/src/agent_on_demand/session_service/provisioning/env_file.py
+++ b/src/agent_on_demand/session_service/provisioning/env_file.py
@@ -17,17 +17,30 @@ if TYPE_CHECKING:
     from agent_on_demand.session_service.specs import SessionSpec
 
 
-def build_env_file_body(spec: "SessionSpec", credentials: list[tuple[str, str]]) -> str:
+def build_env_file_body(
+    spec: "SessionSpec",
+    credentials: list[tuple[str, str]],
+    runtime_static_env: list[tuple[str, str]] | tuple[tuple[str, str], ...] = (),
+) -> str:
     """Render the body of /tmp/aod-env.
 
     `credentials` is a list of ``(env_var_name, value)`` pairs already
-    resolved from the ORM by the caller. Each value is ``shlex.quote``-d
-    before emission. Precedence: credentials → AOD_SESSION_ID → AOD_MODEL
-    → sorted ``spec.environment.env_vars`` (per-environment overrides
-    win). Body always ends with exactly one trailing newline.
+    resolved from the ORM by the caller. `runtime_static_env` is a list of
+    ``(env_var_name, value)`` pairs contributed by the runtime
+    (``Runtime.static_env``) — used for runtime-specific secrets that
+    must not appear in the per-turn argv shim string. Each value is
+    ``shlex.quote``-d before emission.
+
+    Precedence: credentials → runtime_static_env → AOD_SESSION_ID →
+    AOD_MODEL → sorted ``spec.environment.env_vars`` (per-environment
+    overrides win, so a user can opt out of a runtime-contributed var by
+    re-setting it in their environment). Body always ends with exactly
+    one trailing newline.
     """
     lines: list[str] = []
     for env_name, value in credentials:
+        lines.append(f"{env_name}={shlex.quote(value)}")
+    for env_name, value in runtime_static_env:
         lines.append(f"{env_name}={shlex.quote(value)}")
     # Falsy session_id / model mean "not set yet" and skip the line; a falsy
     # env_vars value is a deliberate user-supplied empty override and is

--- a/src/agent_on_demand/session_service/provisioning/stages.py
+++ b/src/agent_on_demand/session_service/provisioning/stages.py
@@ -92,8 +92,11 @@ def write_env_file(handle: SessionHandle, spec: SessionSpec, session_id: str | N
     so every line must be a valid KEY=value shell assignment.
 
     Precedence: user credentials first (so their env-var names are mapped
-    from `CREDENTIAL_ENV_VAR`), then the session metadata, then any
-    Environment.env_vars last — per-environment overrides win."""
+    from `CREDENTIAL_ENV_VAR`), then any runtime-contributed static env
+    (e.g. Claude's Honeycomb header — kept here rather than in the per-turn
+    argv shim so the API key never appears in command logs), then the
+    session metadata, then any Environment.env_vars last — per-environment
+    overrides win."""
     from agent_on_demand.models.auth import CREDENTIAL_ENV_VAR, UserCredential
 
     credentials: list[tuple[str, str]] = []
@@ -101,7 +104,8 @@ def write_env_file(handle: SessionHandle, spec: SessionSpec, session_id: str | N
         env_name = CREDENTIAL_ENV_VAR.get(cred.kind)
         if env_name:
             credentials.append((env_name, cred.get_value()))
-    body = build_env_file_body(spec, credentials)
+    runtime_static_env = spec.runtime.static_env(spec)
+    body = build_env_file_body(spec, credentials, runtime_static_env)
     with stage_timer(session_id, STAGE_ENV_FILE):
         try:
             handle.workspace().write_text(ENV_FILE_PATH, body)

--- a/src/agent_on_demand/session_service/turn/argv.py
+++ b/src/agent_on_demand/session_service/turn/argv.py
@@ -8,6 +8,7 @@ Procrastinate task decorators in tasks.py).
 
 from __future__ import annotations
 
+import shlex
 from typing import TYPE_CHECKING
 
 from agent_on_demand.runtimes import Runtime
@@ -15,10 +16,13 @@ from agent_on_demand.runtimes import Runtime
 if TYPE_CHECKING:
     from agent_on_demand.session_service.specs import SessionSpec
 
-_ENV_SOURCE_SHIM = 'set -a; source /tmp/aod-env; set +a; exec "$@"'
 
-
-def build_turn_argv(runtime: Runtime, spec: SessionSpec, mode: str) -> list[str]:
+def build_turn_argv(
+    runtime: Runtime,
+    spec: SessionSpec,
+    mode: str,
+    extra_env: dict[str, str] | None = None,
+) -> list[str]:
     """Return the full argv for the per-turn `sprite.command`.
 
     The first three elements are a thin `bash -lc` shim that sources
@@ -30,6 +34,22 @@ def build_turn_argv(runtime: Runtime, spec: SessionSpec, mode: str) -> list[str]
     Prompt delivery is out of band: callers attach `cmd.stdin` with the
     prompt bytes so it flows through the bash shim into the runtime CLI.
 
+    ``extra_env`` is a per-turn map of additional env vars to export into
+    the runtime CLI's process. Used for telemetry context that changes per
+    turn (e.g. W3C ``TRACEPARENT``) and so does not belong in the shared
+    ``/tmp/aod-env`` file. Values are ``shlex.quote``-d. Keys are emitted
+    in sorted order — a deterministic shim string is what mutation tests
+    can pin against. Assignments happen *after* ``source /tmp/aod-env``,
+    so they win against any duplicate set there. Keys are emitted
+    verbatim and must already be valid shell identifiers; the caller (a
+    ``Runtime.otel_env`` impl) is the trust boundary.
+
+    The `env=` parameter on `sprite.command()` is deliberately not used:
+    it replaces PATH/HOME on the Sprite (see sprites skill gotcha #1) and
+    leaks values into the WebSocket URL (#2). Argv flows through the
+    message body, so values inlined into the shim string stay out of URL
+    logs.
+
     Raises ``ValueError`` if ``mode`` is not exactly ``"run"`` or
     ``"continue"``, with the message ``"mode must be 'run' or 'continue',
     got <repr>"``. Catches typos at the boundary instead of forwarding
@@ -40,4 +60,24 @@ def build_turn_argv(runtime: Runtime, spec: SessionSpec, mode: str) -> list[str]
     if mode not in ("run", "continue"):
         raise ValueError(f"mode must be 'run' or 'continue', got {mode!r}")
     argv = runtime.build_command(spec, mode)  # type: ignore[arg-type]
-    return ["bash", "-lc", _ENV_SOURCE_SHIM, "--", *argv]
+    return ["bash", "-lc", build_env_source_shim(extra_env), "--", *argv]
+
+
+def build_env_source_shim(extra_env: dict[str, str] | None) -> str:
+    """Render the bash shim that sources `/tmp/aod-env` and re-execs the
+    runtime argv. ``extra_env`` keys are emitted in sorted order between
+    the source and the ``exec``."""
+    parts = ["set -a", "source /tmp/aod-env"]
+    if extra_env:
+        for key in sorted(extra_env):
+            parts.append(f"{key}={shlex.quote(extra_env[key])}")
+    parts.append("set +a")
+    parts.append('exec "$@"')
+    return "; ".join(parts)
+
+
+# The shim emitted when no `extra_env` is supplied. Pinned as a module
+# constant so existing tests (and any future caller that wants to assert
+# on the baseline shape) have a stable reference. Computed once via the
+# same builder so the two can never drift.
+_ENV_SOURCE_SHIM = build_env_source_shim(None)

--- a/src/agent_on_demand/session_service/turn_executor.py
+++ b/src/agent_on_demand/session_service/turn_executor.py
@@ -21,6 +21,7 @@ from agent_on_demand.models import AgentSession, AgentSessionLog
 
 from .log_sink import LogChunkSink
 from .provisioning import STAGE_RUNTIME_START, emit_stage_event
+from .tracing import inject_carrier
 from .turn.argv import build_turn_argv
 from .turn.outcome import compute_final_status
 
@@ -82,7 +83,19 @@ class TurnExecutor:
         # Built before thread spawn so any raise surfaces as a task-level
         # failure (procrastinate logging + alerting) rather than getting
         # swallowed into result_holder as a session-level error.
-        argv = build_turn_argv(self._spec.runtime, self._spec, self._mode)
+        #
+        # `extra_env` carries the W3C trace context plus any OTel exporter
+        # config the runtime wants Claude (or any other CLI) to see for the
+        # turn. The carrier is captured here, while we are still inside the
+        # `session.execute_turn` span, so the in-Sprite `claude_code.interaction`
+        # span parents under it.
+        carrier = inject_carrier()
+        extra_env = self._spec.runtime.otel_env(
+            self._spec,
+            carrier.get("traceparent"),
+            carrier.get("tracestate"),
+        )
+        argv = build_turn_argv(self._spec.runtime, self._spec, self._mode, extra_env=extra_env)
 
         cmd_thread = threading.Thread(target=self._run_command, args=(argv,), daemon=True)
         cmd_thread.start()

--- a/tests/test_claude_otel.py
+++ b/tests/test_claude_otel.py
@@ -13,6 +13,7 @@ import pytest
 from agent_on_demand.runtimes.claude_otel import (
     HONEYCOMB_OTLP_ENDPOINT,
     build_claude_otel_env,
+    build_claude_otel_static_env,
 )
 
 
@@ -50,15 +51,32 @@ def test_returns_empty_when_api_key_empty_string():
 
 
 def test_uses_env_var_when_no_explicit_key(monkeypatch):
+    """The dict is non-empty when HONEYCOMB_API_KEY is set — gating fires
+    on the env var, not the explicit kwarg."""
     monkeypatch.setenv("HONEYCOMB_API_KEY", "key-from-env")
     env = build_claude_otel_env(_spec(), traceparent=None)
-    assert env["OTEL_EXPORTER_OTLP_HEADERS"] == "x-honeycomb-team=key-from-env"
+    assert env != {}
+    assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
 
 
-def test_explicit_key_overrides_env(monkeypatch):
+def test_explicit_key_takes_precedence_over_env(monkeypatch):
+    """An explicit ``honeycomb_api_key`` argument is what gates the
+    return — even if it differs from the env var."""
     monkeypatch.setenv("HONEYCOMB_API_KEY", "from-env")
     env = build_claude_otel_env(_spec(), traceparent=None, honeycomb_api_key="from-arg")
-    assert env["OTEL_EXPORTER_OTLP_HEADERS"] == "x-honeycomb-team=from-arg"
+    assert env != {}
+
+
+def test_dynamic_env_does_not_contain_api_key():
+    """Security pin: the per-turn dynamic env (which is rendered into
+    the bash shim string and persisted in argv) must not contain the
+    Honeycomb API key. The secret-bearing OTEL_EXPORTER_OTLP_HEADERS
+    line lives in /tmp/aod-env via build_claude_otel_static_env instead.
+    """
+    env = build_claude_otel_env(_spec(), traceparent=None, honeycomb_api_key="my-secret-key")
+    assert "OTEL_EXPORTER_OTLP_HEADERS" not in env
+    # The raw key must not appear in any value either.
+    assert all("my-secret-key" not in v for v in env.values())
 
 
 # ---------- exporter / endpoint ----------
@@ -166,7 +184,7 @@ def test_resource_attributes_skip_when_environment_missing():
     assert "aod.environment_id" not in env["OTEL_RESOURCE_ATTRIBUTES"]
 
 
-@pytest.mark.parametrize("forbidden", [" ", ",", ";", "\\", '"'])
+@pytest.mark.parametrize("forbidden", [" ", ",", ";", "\\", '"', "="])
 def test_resource_attributes_skip_unsafe_values(forbidden):
     """Per Claude Code monitoring docs, OTEL_RESOURCE_ATTRIBUTES values may
     not contain spaces, commas, semicolons, double quotes, or backslashes.
@@ -187,3 +205,34 @@ def test_resource_attributes_value_format_has_no_spaces():
     Spaces would break the OTEL parser silently (per the doc)."""
     env = build_claude_otel_env(_spec(), traceparent=None, honeycomb_api_key="k")
     assert " " not in env["OTEL_RESOURCE_ATTRIBUTES"]
+
+
+# ---------- static env (the secret slot) ----------
+
+
+def test_static_env_returns_empty_when_api_key_unset(monkeypatch):
+    monkeypatch.delenv("HONEYCOMB_API_KEY", raising=False)
+    assert build_claude_otel_static_env() == []
+
+
+def test_static_env_returns_empty_when_api_key_empty():
+    assert build_claude_otel_static_env(honeycomb_api_key="") == []
+
+
+def test_static_env_carries_honeycomb_header():
+    """The OTEL header line is what goes into /tmp/aod-env so the API
+    key never reaches the per-turn bash shim string."""
+    pairs = build_claude_otel_static_env(honeycomb_api_key="my-key")
+    assert pairs == [("OTEL_EXPORTER_OTLP_HEADERS", "x-honeycomb-team=my-key")]
+
+
+def test_static_env_uses_env_var_when_no_explicit_key(monkeypatch):
+    monkeypatch.setenv("HONEYCOMB_API_KEY", "from-env")
+    pairs = build_claude_otel_static_env()
+    assert pairs == [("OTEL_EXPORTER_OTLP_HEADERS", "x-honeycomb-team=from-env")]
+
+
+def test_static_env_explicit_key_takes_precedence_over_env(monkeypatch):
+    monkeypatch.setenv("HONEYCOMB_API_KEY", "from-env")
+    pairs = build_claude_otel_static_env(honeycomb_api_key="from-arg")
+    assert pairs == [("OTEL_EXPORTER_OTLP_HEADERS", "x-honeycomb-team=from-arg")]

--- a/tests/test_claude_otel.py
+++ b/tests/test_claude_otel.py
@@ -1,0 +1,189 @@
+"""Direct unit tests for `build_claude_otel_env`.
+
+The module is pure (no Django, no I/O) so tests use ``SimpleNamespace``
+spec stubs and pass `honeycomb_api_key` explicitly. Each test pins one
+mutation-killable property of the env-var dict that gets injected into
+Claude Code's process.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent_on_demand.runtimes.claude_otel import (
+    HONEYCOMB_OTLP_ENDPOINT,
+    build_claude_otel_env,
+)
+
+
+def _spec(
+    *,
+    runtime_name: str = "claude",
+    model: str = "anthropic/claude-sonnet-4-6",
+    runtime_session_id: str | None = "sess-uuid-1234",
+    user_id: int | None = 42,
+    environment_id: int | None = 7,
+):
+    runtime = SimpleNamespace(name=runtime_name)
+    user = None if user_id is None else SimpleNamespace(id=user_id)
+    environment = None if environment_id is None else SimpleNamespace(id=environment_id)
+    return SimpleNamespace(
+        runtime=runtime,
+        model=model,
+        runtime_session_id=runtime_session_id,
+        user=user,
+        environment=environment,
+    )
+
+
+# ---------- gating ----------
+
+
+def test_returns_empty_when_api_key_unset(monkeypatch):
+    monkeypatch.delenv("HONEYCOMB_API_KEY", raising=False)
+    assert build_claude_otel_env(_spec(), traceparent="abc") == {}
+
+
+def test_returns_empty_when_api_key_empty_string():
+    """Empty string is treated as unset — same shape as observability.init_otel."""
+    assert build_claude_otel_env(_spec(), traceparent="abc", honeycomb_api_key="") == {}
+
+
+def test_uses_env_var_when_no_explicit_key(monkeypatch):
+    monkeypatch.setenv("HONEYCOMB_API_KEY", "key-from-env")
+    env = build_claude_otel_env(_spec(), traceparent=None)
+    assert env["OTEL_EXPORTER_OTLP_HEADERS"] == "x-honeycomb-team=key-from-env"
+
+
+def test_explicit_key_overrides_env(monkeypatch):
+    monkeypatch.setenv("HONEYCOMB_API_KEY", "from-env")
+    env = build_claude_otel_env(_spec(), traceparent=None, honeycomb_api_key="from-arg")
+    assert env["OTEL_EXPORTER_OTLP_HEADERS"] == "x-honeycomb-team=from-arg"
+
+
+# ---------- exporter / endpoint ----------
+
+
+def test_enables_telemetry_and_traces_beta():
+    env = build_claude_otel_env(_spec(), traceparent=None, honeycomb_api_key="k")
+    assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
+    assert env["CLAUDE_CODE_ENHANCED_TELEMETRY_BETA"] == "1"
+
+
+def test_selects_otlp_for_all_three_signals():
+    env = build_claude_otel_env(_spec(), traceparent=None, honeycomb_api_key="k")
+    assert env["OTEL_METRICS_EXPORTER"] == "otlp"
+    assert env["OTEL_LOGS_EXPORTER"] == "otlp"
+    assert env["OTEL_TRACES_EXPORTER"] == "otlp"
+
+
+def test_selects_http_protobuf_endpoint():
+    env = build_claude_otel_env(_spec(), traceparent=None, honeycomb_api_key="k")
+    assert env["OTEL_EXPORTER_OTLP_PROTOCOL"] == "http/protobuf"
+    assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == HONEYCOMB_OTLP_ENDPOINT
+    assert HONEYCOMB_OTLP_ENDPOINT == "https://api.honeycomb.io"
+
+
+# ---------- trace context ----------
+
+
+def test_traceparent_is_injected_when_provided():
+    env = build_claude_otel_env(_spec(), traceparent="00-abc-01", honeycomb_api_key="k")
+    assert env["TRACEPARENT"] == "00-abc-01"
+
+
+def test_traceparent_omitted_when_none():
+    env = build_claude_otel_env(_spec(), traceparent=None, honeycomb_api_key="k")
+    assert "TRACEPARENT" not in env
+
+
+def test_traceparent_omitted_when_empty():
+    env = build_claude_otel_env(_spec(), traceparent="", honeycomb_api_key="k")
+    assert "TRACEPARENT" not in env
+
+
+def test_tracestate_is_injected_when_provided():
+    env = build_claude_otel_env(
+        _spec(),
+        traceparent="00-abc-01",
+        tracestate="vendor=foo",
+        honeycomb_api_key="k",
+    )
+    assert env["TRACESTATE"] == "vendor=foo"
+
+
+def test_tracestate_omitted_when_none():
+    env = build_claude_otel_env(
+        _spec(), traceparent="00-abc-01", tracestate=None, honeycomb_api_key="k"
+    )
+    assert "TRACESTATE" not in env
+
+
+# ---------- resource attributes ----------
+
+
+def test_resource_attributes_include_runtime_and_model():
+    env = build_claude_otel_env(_spec(), traceparent=None, honeycomb_api_key="k")
+    attrs = env["OTEL_RESOURCE_ATTRIBUTES"]
+    assert "aod.runtime=claude" in attrs
+    assert "aod.model=anthropic/claude-sonnet-4-6" in attrs
+
+
+def test_resource_attributes_include_session_id_when_set():
+    env = build_claude_otel_env(
+        _spec(runtime_session_id="my-session-uuid"),
+        traceparent=None,
+        honeycomb_api_key="k",
+    )
+    assert "aod.session_id=my-session-uuid" in env["OTEL_RESOURCE_ATTRIBUTES"]
+
+
+def test_resource_attributes_skip_session_id_when_none():
+    env = build_claude_otel_env(
+        _spec(runtime_session_id=None), traceparent=None, honeycomb_api_key="k"
+    )
+    assert "aod.session_id" not in env["OTEL_RESOURCE_ATTRIBUTES"]
+
+
+def test_resource_attributes_include_user_and_environment_ids():
+    env = build_claude_otel_env(
+        _spec(user_id=99, environment_id=11),
+        traceparent=None,
+        honeycomb_api_key="k",
+    )
+    attrs = env["OTEL_RESOURCE_ATTRIBUTES"]
+    assert "aod.user_id=99" in attrs
+    assert "aod.environment_id=11" in attrs
+
+
+def test_resource_attributes_skip_when_user_missing():
+    env = build_claude_otel_env(_spec(user_id=None), traceparent=None, honeycomb_api_key="k")
+    assert "aod.user_id" not in env["OTEL_RESOURCE_ATTRIBUTES"]
+
+
+def test_resource_attributes_skip_when_environment_missing():
+    env = build_claude_otel_env(_spec(environment_id=None), traceparent=None, honeycomb_api_key="k")
+    assert "aod.environment_id" not in env["OTEL_RESOURCE_ATTRIBUTES"]
+
+
+@pytest.mark.parametrize("forbidden", [" ", ",", ";", "\\", '"'])
+def test_resource_attributes_skip_unsafe_values(forbidden):
+    """Per Claude Code monitoring docs, OTEL_RESOURCE_ATTRIBUTES values may
+    not contain spaces, commas, semicolons, double quotes, or backslashes.
+    A bad value silently corrupts every attribute downstream of it, so we
+    drop the offender rather than emit a poisoned string."""
+    env = build_claude_otel_env(
+        _spec(model=f"bad{forbidden}model"),
+        traceparent=None,
+        honeycomb_api_key="k",
+    )
+    assert "aod.model=" not in env["OTEL_RESOURCE_ATTRIBUTES"]
+    # Other safe attrs still present.
+    assert "aod.runtime=claude" in env["OTEL_RESOURCE_ATTRIBUTES"]
+
+
+def test_resource_attributes_value_format_has_no_spaces():
+    """Sanity: the rendered OTEL_RESOURCE_ATTRIBUTES string has no spaces.
+    Spaces would break the OTEL parser silently (per the doc)."""
+    env = build_claude_otel_env(_spec(), traceparent=None, honeycomb_api_key="k")
+    assert " " not in env["OTEL_RESOURCE_ATTRIBUTES"]

--- a/tests/test_env_file.py
+++ b/tests/test_env_file.py
@@ -222,3 +222,101 @@ def test_model_value_is_quoted_simple():
 def test_env_var_value_is_quoted_simple():
     body = build_env_file_body(_spec(environment=_env({"FOO": "bar"})), [])
     assert "FOO=bar\n" in body
+
+
+# ---------- runtime_static_env: precedence + quoting ----------
+#
+# `runtime_static_env` is the slot used by `Runtime.static_env(spec)` to
+# inject runtime-specific secrets (today: Claude's Honeycomb header) into
+# /tmp/aod-env without putting them in the per-turn argv shim string. It
+# sits between credentials and AOD_SESSION_ID so a user can opt out by
+# re-setting the same key in `Environment.env_vars` (which lands last and
+# wins under bash `set -a; source ...` semantics).
+
+
+def test_runtime_static_env_omitted_by_default():
+    """Default-empty: no runtime contribution → body is identical to
+    pre-extension behavior, so non-claude runtimes pay zero cost."""
+    body = build_env_file_body(_spec(), [])
+    assert body == "\n"
+
+
+def test_runtime_static_env_appended_after_credentials():
+    body = build_env_file_body(
+        _spec(),
+        [("CRED1", "v1")],
+        [("OTEL_EXPORTER_OTLP_HEADERS", "x-honeycomb-team=k")],
+    )
+    keys = [ln.split("=", 1)[0] for ln in body.rstrip("\n").splitlines()]
+    assert keys == ["CRED1", "OTEL_EXPORTER_OTLP_HEADERS"]
+
+
+def test_runtime_static_env_precedes_session_id():
+    body = build_env_file_body(
+        _spec(runtime_session_id="s1"),
+        [],
+        [("OTEL_EXPORTER_OTLP_HEADERS", "x-honeycomb-team=k")],
+    )
+    keys = [ln.split("=", 1)[0] for ln in body.rstrip("\n").splitlines()]
+    assert keys == ["OTEL_EXPORTER_OTLP_HEADERS", "AOD_SESSION_ID"]
+
+
+def test_runtime_static_env_precedes_env_vars():
+    """Per-environment env_vars override runtime contributions — pin so a
+    user can disable telemetry by setting OTEL_EXPORTER_OTLP_HEADERS=''
+    in their Environment without code changes."""
+    body = build_env_file_body(
+        _spec(environment=_env({"AKEY": "v"})),
+        [],
+        [("OTEL_EXPORTER_OTLP_HEADERS", "x-honeycomb-team=k")],
+    )
+    keys = [ln.split("=", 1)[0] for ln in body.rstrip("\n").splitlines()]
+    assert keys == ["OTEL_EXPORTER_OTLP_HEADERS", "AKEY"]
+
+
+def test_runtime_static_env_value_is_shell_quoted():
+    """The header value contains `=`, which would be a shell parsing
+    landmine without quoting. Pin so a refactor that drops the
+    `shlex.quote` is caught."""
+    body = build_env_file_body(
+        _spec(),
+        [],
+        [("OTEL_EXPORTER_OTLP_HEADERS", "x-honeycomb-team=hk_secret value")],
+    )
+    # shlex.quote wraps in single quotes when value contains spaces.
+    assert "OTEL_EXPORTER_OTLP_HEADERS='x-honeycomb-team=hk_secret value'\n" in body
+
+
+def test_runtime_static_env_full_body_order():
+    """Full ordering: credentials → runtime_static_env → AOD_SESSION_ID
+    → AOD_MODEL → env_vars (alphabetical)."""
+    body = build_env_file_body(
+        _spec(
+            runtime_session_id="s",
+            model="m",
+            environment=_env({"ZZZ": "z", "AAA": "a"}),
+        ),
+        [("CRED", "c")],
+        [("RUNTIME_STATIC", "rs")],
+    )
+    keys = [ln.split("=", 1)[0] for ln in body.rstrip("\n").splitlines()]
+    assert keys == [
+        "CRED",
+        "RUNTIME_STATIC",
+        "AOD_SESSION_ID",
+        "AOD_MODEL",
+        "AAA",
+        "ZZZ",
+    ]
+
+
+def test_runtime_static_env_preserves_caller_order():
+    """Multiple runtime entries land in the order the caller supplied —
+    no reordering or sort. Mirrors how `credentials` behaves."""
+    body = build_env_file_body(
+        _spec(),
+        [],
+        [("FIRST", "1"), ("SECOND", "2"), ("THIRD", "3")],
+    )
+    keys = [ln.split("=", 1)[0] for ln in body.rstrip("\n").splitlines()]
+    assert keys == ["FIRST", "SECOND", "THIRD"]

--- a/tests/test_turn_argv.py
+++ b/tests/test_turn_argv.py
@@ -30,6 +30,7 @@ import pytest
 
 from agent_on_demand.session_service.turn.argv import (
     _ENV_SOURCE_SHIM,
+    build_env_source_shim,
     build_turn_argv,
 )
 
@@ -195,3 +196,89 @@ def test_uppercase_continue_mode_raises_value_error():
     with pytest.raises(ValueError) as exc_info:
         build_turn_argv(_runtime(argv=["x"]), _spec(), "CONTINUE")
     assert str(exc_info.value) == "mode must be 'run' or 'continue', got 'CONTINUE'"
+
+
+# ---------- extra_env (per-turn telemetry exports) ----------
+#
+# `extra_env` injects per-turn env vars (W3C TRACEPARENT, OTel exporter
+# config, etc.) into the bash shim between `source /tmp/aod-env` and
+# `exec`. Pinning the exact rendered shim shape keeps the surface clear
+# for mutmut: a quoting or ordering bug here breaks every claude turn's
+# trace context propagation silently.
+
+
+def test_extra_env_none_yields_baseline_shim():
+    """``extra_env=None`` is the default and renders the baseline
+    no-extras shim, identical to passing nothing."""
+    argv = build_turn_argv(_runtime(argv=["claude"]), _spec(), "run", extra_env=None)
+    assert argv[2] == _ENV_SOURCE_SHIM
+
+
+def test_extra_env_empty_yields_baseline_shim():
+    """An empty dict is the same as ``None`` — no assignments emitted."""
+    argv = build_turn_argv(_runtime(argv=["claude"]), _spec(), "run", extra_env={})
+    assert argv[2] == _ENV_SOURCE_SHIM
+
+
+def test_extra_env_appears_between_source_and_exec():
+    """Assignments land *after* ``source /tmp/aod-env`` (so they win
+    against any duplicate set there) and *before* ``set +a; exec``
+    (so ``set -a`` exports them into the runtime CLI's environment).
+    """
+    argv = build_turn_argv(
+        _runtime(argv=["claude"]),
+        _spec(),
+        "run",
+        extra_env={"TRACEPARENT": "00-abc-01"},
+    )
+    shim = argv[2]
+    src_idx = shim.index("source /tmp/aod-env")
+    set_off_idx = shim.index("set +a")
+    var_idx = shim.index("TRACEPARENT=")
+    assert src_idx < var_idx < set_off_idx
+
+
+def test_extra_env_keys_emitted_in_sorted_order():
+    """Keys are sorted so the rendered shim is deterministic across
+    runs. Pin so a future caller that relies on dict-insertion order
+    can't introduce flakiness."""
+    argv = build_turn_argv(
+        _runtime(argv=["claude"]),
+        _spec(),
+        "run",
+        extra_env={"ZULU": "z", "ALPHA": "a", "MIKE": "m"},
+    )
+    shim = argv[2]
+    a_idx = shim.index("ALPHA=")
+    m_idx = shim.index("MIKE=")
+    z_idx = shim.index("ZULU=")
+    assert a_idx < m_idx < z_idx
+
+
+def test_extra_env_values_are_shell_quoted():
+    """Values flow through ``shlex.quote`` so a value containing spaces,
+    quotes, or shell metacharacters can't break the shim or inject
+    arbitrary commands. Pin so a refactor that drops the quoting is
+    caught."""
+    argv = build_turn_argv(
+        _runtime(argv=["claude"]),
+        _spec(),
+        "run",
+        extra_env={"X": "a b'c;d"},
+    )
+    # shlex.quote wraps in single quotes and escapes embedded ones.
+    assert "X='a b'\"'\"'c;d'" in argv[2]
+
+
+def test_build_env_source_shim_baseline():
+    """Direct test on the shim builder. Empty/None input → exact
+    baseline string."""
+    assert build_env_source_shim(None) == _ENV_SOURCE_SHIM
+    assert build_env_source_shim({}) == _ENV_SOURCE_SHIM
+
+
+def test_build_env_source_shim_with_extras():
+    """Exact rendered shape with two exports — pins the order of the
+    parts joined with ``; ``."""
+    rendered = build_env_source_shim({"FOO": "bar", "BAZ": "qux"})
+    assert rendered == ('set -a; source /tmp/aod-env; BAZ=qux; FOO=bar; set +a; exec "$@"')


### PR DESCRIPTION
## Summary

- Per-turn `claude -p` on Sprites now exports OTel traces/metrics/events to Honeycomb.
- The worker's `session.execute_turn` span is the parent of Claude Code's `claude_code.interaction` span (and every API/tool span under it), so each turn is a single waterfall in Honeycomb instead of two disconnected traces.
- Gated on `HONEYCOMB_API_KEY` — same shape as `observability.init_otel`. Unset = unchanged behavior.

## How

- New pure module `runtimes/claude_otel.py` builds the OTel env-var dict (`CLAUDE_CODE_ENABLE_TELEMETRY`, `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA`, `OTEL_*` exporter config, `OTEL_RESOURCE_ATTRIBUTES`, `TRACEPARENT`/`TRACESTATE`). Filters resource-attr values that contain spaces/commas/etc. so a poisoned attr can't drop every span.
- `Runtime.otel_env(spec, traceparent, tracestate)` added to the Protocol. Only `ClaudeRuntime` returns the real dict; codex/gemini/opencode return `{}` until those CLIs grow OTel support.
- `build_turn_argv` now takes `extra_env`; the bash shim renders sorted, `shlex.quote`-d assignments between `source /tmp/aod-env` and `exec "$@"` so per-turn vars (TRACEPARENT changes every turn) reach the CLI without a Sprite filesystem round-trip.
- Why not `sprite.command(env=...)`: it replaces PATH/HOME on the Sprite (sprites skill gotcha #1) and leaks values into the WebSocket URL (#2). Argv flows through the message body, so values inlined into the shim string stay out of URL logs.
- `TurnExecutor.run` captures the carrier from the active worker span via the existing `inject_carrier()`, calls `runtime.otel_env(...)`, and threads the dict through to `build_turn_argv`.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 1238 passed (including 24 new in `test_claude_otel.py` and 7 new in `test_turn_argv.py`)
- [ ] Manual: deploy with `HONEYCOMB_API_KEY` set, run a session, verify one trace in Honeycomb spans both worker and in-Sprite Claude
- [ ] Manual: deploy without `HONEYCOMB_API_KEY` set, verify no behavior change (shim is byte-identical to baseline)
- [ ] Confirm Honeycomb's `claude_code.interaction` spans land under the dataset (`OTEL_EXPORTER_OTLP_HEADERS=x-honeycomb-team=...` routes by team key, dataset is decided by `service.name=claude-code` — separate dataset from the existing `aod-web` / `aod-worker` ones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)