### PR TITLE
observability: parse runtime stream-json into child spans

### DIFF
--- a/src/agent_on_demand/session_service/log_sink.py
+++ b/src/agent_on_demand/session_service/log_sink.py
@@ -26,6 +26,8 @@ from agent_on_demand.models import AgentSession, AgentSessionLog, SessionTurn
 if TYPE_CHECKING:
     from opentelemetry.trace import Span
 
+    from .runtime_trace import RuntimeTraceEmitter
+
 logger = logging.getLogger(__name__)
 
 _SENTINEL = object()
@@ -90,10 +92,12 @@ class LogChunkSink:
         session: AgentSession,
         turn: SessionTurn,
         span: Span | None = None,
+        trace_emitter: RuntimeTraceEmitter | None = None,
     ):
         self._session = session
         self._turn = turn
         self._span = span
+        self._trace_emitter = trace_emitter
         self._queue: queue.Queue = queue.Queue(maxsize=QUEUE_MAXSIZE)
         self._buffer: list[AgentSessionLog] = []
         self.stdout_writer = TaggingQueueWriter(self._queue, "stdout")
@@ -126,6 +130,8 @@ class LogChunkSink:
                 )
             )
             self._record_chunk_event(chunk)
+            if self._trace_emitter is not None:
+                self._trace_emitter.feed(chunk.stream, chunk.data)
             if len(self._buffer) >= FLUSH_SIZE:
                 self._flush_buffer()
         self._flush_buffer()

--- a/src/agent_on_demand/session_service/runtime_trace.py
+++ b/src/agent_on_demand/session_service/runtime_trace.py
@@ -1,0 +1,218 @@
+"""Per-runtime stream-json → OpenTelemetry bridge.
+
+The runtime CLIs we shell out to (`claude --output-format stream-json`,
+`gemini --output-format stream-json`, `codex exec --json`) emit one JSON
+event per line on stdout. PR #284 already records a `runtime.output`
+span event per chunk so the trace timeline shows when output arrived;
+this module goes one step further: it line-buffers stdout, parses each
+event, and turns the structured shape into trace data:
+
+  - One **child span** per `tool_use` block, started when the assistant
+    message announces it and ended when the matching `user` message
+    carries the `tool_result`. The duration is the wall-clock the tool
+    took to execute, which is exactly the "dead time" the operator was
+    seeing on the original trace.
+  - **Span events** for non-durational signals (assistant text/thinking,
+    system init, the final `result` envelope) so they show up as
+    annotations on the parent span timeline.
+
+Adapters live in this same module — only `claude` is wired in for now;
+adding `codex`/`gemini` is just another entry in `_ADAPTERS`. The line
+buffering, span lifecycle, and orphan-close logic are runtime-agnostic
+and live entirely in `RuntimeTraceEmitter`.
+
+The reference for the Claude event taxonomy is the CLI pretty-printer
+in `clients/python/src/aod/pretty/claude.py` — keep the two in sync if
+the upstream stream-json shape changes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from opentelemetry.trace import Span, Tracer
+
+logger = logging.getLogger(__name__)
+
+# A trace action is a tuple the emitter knows how to apply:
+#   ("event", name: str, attrs: dict)
+#   ("tool_start", tool_id: str, span_name: str, attrs: dict)
+#   ("tool_end",   tool_id: str, attrs: dict)
+TraceAction = tuple[Any, ...]
+Adapter = Callable[[dict], Iterable[TraceAction]]
+
+
+class RuntimeTraceEmitter:
+    """Stateful per-turn bridge between runtime stdout and OTel spans.
+
+    Construction is cheap and IO-free. `feed(stream, data)` is called once
+    per chunk by `LogChunkSink.drain()`; only stdout is parsed (stream-json
+    is stdout-only on every runtime we support). `finish()` runs after the
+    drain loop and closes any tool spans the runtime never matched up
+    (turn timed out mid-call, runtime crashed, etc.).
+    """
+
+    def __init__(self, parent_span: Span, runtime: str, tracer: Tracer):
+        self._parent = parent_span
+        self._tracer = tracer
+        self._adapter = _ADAPTERS.get(runtime)
+        self._line_buf = bytearray()
+        self._open_tool_spans: dict[str, Span] = {}
+
+    def feed(self, stream: str, data: bytes) -> None:
+        if self._adapter is None or stream != "stdout":
+            return
+        self._line_buf.extend(data)
+        while True:
+            idx = self._line_buf.find(b"\n")
+            if idx < 0:
+                break
+            line = bytes(self._line_buf[:idx])
+            del self._line_buf[: idx + 1]
+            self._handle_line(line)
+
+    def finish(self) -> None:
+        """Close any tool spans that never saw a matching tool_result.
+
+        Without this, an aborted turn leaves spans that never end and
+        never export, which Honeycomb shows as "incomplete" traces.
+        """
+        for span in self._open_tool_spans.values():
+            span.set_attribute("aod.tool_status", "abandoned")
+            span.end()
+        self._open_tool_spans.clear()
+
+    def _handle_line(self, line: bytes) -> None:
+        if not line.strip():
+            return
+        try:
+            obj = json.loads(line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return
+        if not isinstance(obj, dict):
+            return
+        try:
+            actions = list(self._adapter(obj)) if self._adapter else []
+        except Exception:
+            # An adapter bug must not crash the drain loop — that would
+            # abort the turn. Log and move on.
+            logger.exception("runtime trace adapter raised on event")
+            return
+        for action in actions:
+            self._apply(action)
+
+    def _apply(self, action: TraceAction) -> None:
+        kind = action[0]
+        if kind == "event":
+            _, name, attrs = action
+            self._parent.add_event(name, attributes=_clean_attrs(attrs))
+        elif kind == "tool_start":
+            _, tool_id, span_name, attrs = action
+            if not tool_id or tool_id in self._open_tool_spans:
+                return
+            span = self._tracer.start_span(span_name, attributes=_clean_attrs(attrs))
+            self._open_tool_spans[tool_id] = span
+        elif kind == "tool_end":
+            _, tool_id, attrs = action
+            if tool_id not in self._open_tool_spans:
+                return
+            span = self._open_tool_spans.pop(tool_id)
+            for k, v in _clean_attrs(attrs).items():
+                span.set_attribute(k, v)
+            span.end()
+
+
+def _clean_attrs(attrs: dict | None) -> dict:
+    """Drop None values — OTel attribute setters reject them."""
+    if not attrs:
+        return {}
+    return {k: v for k, v in attrs.items() if v is not None}
+
+
+# ---------------------------------------------------------------------------
+# Adapters
+# ---------------------------------------------------------------------------
+
+
+def _claude_adapter(obj: dict) -> Iterable[TraceAction]:
+    """Map one Claude stream-json event to zero or more trace actions.
+
+    Mirrors the event taxonomy in `clients/python/src/aod/pretty/claude.py`:
+      - `system` (init / task_started / …) → span event
+      - `assistant.message.content[]`:
+          - `text` → assistant_text event (length only)
+          - `thinking` → thinking event (length only)
+          - `tool_use` → start a child span keyed by tool_use_id
+      - `user.message.content[]` `tool_result` → end the matching child span
+      - `result` (terminal) → span event with usage + cost attrs
+    """
+    kind = obj.get("type")
+    if kind == "system":
+        subtype = str(obj.get("subtype") or "unknown")
+        attrs: dict[str, Any] = {"aod.subtype": subtype}
+        if subtype == "init":
+            attrs["aod.model"] = obj.get("model")
+            tools = obj.get("tools") or []
+            attrs["aod.tools_count"] = len(tools)
+        yield ("event", f"claude.system.{subtype}", attrs)
+        return
+
+    if kind == "assistant":
+        message = obj.get("message") or {}
+        for block in message.get("content") or []:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "text":
+                text = block.get("text") or ""
+                yield ("event", "claude.assistant_text", {"aod.length": len(text)})
+            elif btype == "thinking":
+                text = block.get("thinking") or ""
+                yield ("event", "claude.thinking", {"aod.length": len(text)})
+            elif btype == "tool_use":
+                tool_id = str(block.get("id") or "")
+                if not tool_id:
+                    continue
+                tool_name = str(block.get("name") or "?")
+                yield (
+                    "tool_start",
+                    tool_id,
+                    "runtime.tool_use",
+                    {"aod.tool_name": tool_name, "aod.tool_id": tool_id},
+                )
+        return
+
+    if kind == "user":
+        message = obj.get("message") or {}
+        for block in message.get("content") or []:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "tool_result":
+                continue
+            tool_id = str(block.get("tool_use_id") or "")
+            if not tool_id:
+                continue
+            yield (
+                "tool_end",
+                tool_id,
+                {"aod.is_error": bool(block.get("is_error", False))},
+            )
+        return
+
+    if kind == "result":
+        attrs = {"aod.subtype": str(obj.get("subtype") or "")}
+        for key in ("duration_ms", "num_turns", "total_cost_usd"):
+            value = obj.get(key)
+            if value is not None:
+                attrs[f"aod.{key}"] = value
+        yield ("event", "claude.result", attrs)
+        return
+
+
+_ADAPTERS: dict[str, Adapter] = {
+    "claude": _claude_adapter,
+}

--- a/src/agent_on_demand/session_service/turn_executor.py
+++ b/src/agent_on_demand/session_service/turn_executor.py
@@ -18,9 +18,11 @@ from django.utils import timezone
 
 from agent_on_demand.analytics import capture as posthog_capture
 from agent_on_demand.models import AgentSession, AgentSessionLog
+from agent_on_demand.observability import get_tracer
 
 from .log_sink import LogChunkSink
 from .provisioning import STAGE_RUNTIME_START, emit_stage_event
+from .runtime_trace import RuntimeTraceEmitter
 from .turn.argv import build_turn_argv
 from .turn.outcome import compute_final_status
 
@@ -66,7 +68,8 @@ class TurnExecutor:
         self._mode = mode
         self._timeout = timeout
         self._span = span
-        self._sink = LogChunkSink(session, turn, span=span)
+        self._trace_emitter = RuntimeTraceEmitter(span, spec.runtime, get_tracer())
+        self._sink = LogChunkSink(session, turn, span=span, trace_emitter=self._trace_emitter)
         self._result_holder: list = []
 
     def run(self) -> None:
@@ -89,6 +92,7 @@ class TurnExecutor:
 
         self._sink.drain()
         self._sink.report_drops()
+        self._trace_emitter.finish()
 
         cmd_thread.join(timeout=CMD_THREAD_JOIN_TIMEOUT)
         if cmd_thread.is_alive():

--- a/tests/test_runtime_trace.py
+++ b/tests/test_runtime_trace.py
@@ -160,9 +160,7 @@ def test_claude_adapter_user_tool_result_error_flag():
             {
                 "type": "user",
                 "message": {
-                    "content": [
-                        {"type": "tool_result", "tool_use_id": "x", "is_error": True}
-                    ]
+                    "content": [{"type": "tool_result", "tool_use_id": "x", "is_error": True}]
                 },
             }
         )
@@ -252,9 +250,7 @@ def test_emitter_starts_and_ends_tool_use_span(memory_tracer):
         _line(
             {
                 "type": "user",
-                "message": {
-                    "content": [{"type": "tool_result", "tool_use_id": "t1"}]
-                },
+                "message": {"content": [{"type": "tool_result", "tool_use_id": "t1"}]},
             }
         ),
     )
@@ -278,9 +274,7 @@ def test_emitter_finish_closes_orphan_tool_spans(memory_tracer):
         _line(
             {
                 "type": "assistant",
-                "message": {
-                    "content": [{"type": "tool_use", "id": "orphan", "name": "Read"}]
-                },
+                "message": {"content": [{"type": "tool_use", "id": "orphan", "name": "Read"}]},
             }
         ),
     )
@@ -312,12 +306,8 @@ def test_emitter_buffers_partial_lines(memory_tracer):
 def test_emitter_handles_multiple_lines_in_one_chunk(memory_tracer):
     parent = FakeSpan()
     emitter = _emitter(parent)
-    a = _line(
-        {"type": "assistant", "message": {"content": [{"type": "text", "text": "a"}]}}
-    )
-    b = _line(
-        {"type": "assistant", "message": {"content": [{"type": "text", "text": "bb"}]}}
-    )
+    a = _line({"type": "assistant", "message": {"content": [{"type": "text", "text": "a"}]}})
+    b = _line({"type": "assistant", "message": {"content": [{"type": "text", "text": "bb"}]}})
     emitter.feed("stdout", a + b)
     assert parent.events == [
         ("claude.assistant_text", {"aod.length": 1}),
@@ -369,9 +359,7 @@ def test_emitter_duplicate_tool_start_ignored(memory_tracer):
     block = _line(
         {
             "type": "assistant",
-            "message": {
-                "content": [{"type": "tool_use", "id": "dup", "name": "Bash"}]
-            },
+            "message": {"content": [{"type": "tool_use", "id": "dup", "name": "Bash"}]},
         }
     )
     emitter.feed("stdout", block)
@@ -381,9 +369,7 @@ def test_emitter_duplicate_tool_start_ignored(memory_tracer):
         _line(
             {
                 "type": "user",
-                "message": {
-                    "content": [{"type": "tool_result", "tool_use_id": "dup"}]
-                },
+                "message": {"content": [{"type": "tool_result", "tool_use_id": "dup"}]},
             }
         ),
     )
@@ -399,9 +385,7 @@ def test_emitter_unknown_tool_result_silently_ignored(memory_tracer):
         _line(
             {
                 "type": "user",
-                "message": {
-                    "content": [{"type": "tool_result", "tool_use_id": "ghost"}]
-                },
+                "message": {"content": [{"type": "tool_result", "tool_use_id": "ghost"}]},
             }
         ),
     )
@@ -412,9 +396,7 @@ def test_emitter_adapter_exception_does_not_propagate(memory_tracer, mocker):
     """A bug in an adapter must not abort the drain loop and fail the turn."""
     parent = FakeSpan()
     emitter = _emitter(parent)
-    mocker.patch.object(
-        emitter, "_adapter", side_effect=RuntimeError("adapter exploded")
-    )
+    mocker.patch.object(emitter, "_adapter", side_effect=RuntimeError("adapter exploded"))
     emitter.feed(
         "stdout",
         _line({"type": "assistant", "message": {"content": []}}),

--- a/tests/test_runtime_trace.py
+++ b/tests/test_runtime_trace.py
@@ -1,0 +1,429 @@
+"""Tests for `runtime_trace.RuntimeTraceEmitter` and the Claude adapter.
+
+Stand up an in-memory OTel tracer provider per test (matching the pattern
+in `test_otel_task_tracing.py`) so we can introspect the spans the emitter
+creates: name, attributes, parent linkage, lifecycle.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from agent_on_demand.session_service.runtime_trace import (
+    RuntimeTraceEmitter,
+    _claude_adapter,
+)
+
+
+@pytest.fixture
+def memory_tracer():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(resource=Resource.create({"service.name": "aod-test"}))
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    previous = trace.get_tracer_provider()
+    trace._TRACER_PROVIDER_SET_ONCE._done = False
+    trace._TRACER_PROVIDER = None
+    trace.set_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        provider.shutdown()
+        trace._TRACER_PROVIDER_SET_ONCE._done = False
+        trace._TRACER_PROVIDER = None
+        trace.set_tracer_provider(previous)
+
+
+class FakeSpan:
+    """Captures span events; ignores attribute writes after start."""
+
+    def __init__(self):
+        self.events: list[tuple[str, dict]] = []
+
+    def add_event(self, name, attributes=None):
+        self.events.append((name, dict(attributes or {})))
+
+    def set_attribute(self, key, value):
+        pass
+
+
+def _emitter(parent, runtime="claude", tracer=None):
+    if tracer is None:
+        tracer = trace.get_tracer("test")
+    return RuntimeTraceEmitter(parent, runtime, tracer)
+
+
+def _line(obj: dict) -> bytes:
+    return (json.dumps(obj) + "\n").encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Adapter unit tests — pure mapping, no tracer needed
+# ---------------------------------------------------------------------------
+
+
+def test_claude_adapter_assistant_text_event():
+    actions = list(
+        _claude_adapter(
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "hello world"}]},
+            }
+        )
+    )
+    assert actions == [("event", "claude.assistant_text", {"aod.length": 11})]
+
+
+def test_claude_adapter_thinking_event():
+    actions = list(
+        _claude_adapter(
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "thinking", "thinking": "ponder"}]},
+            }
+        )
+    )
+    assert actions == [("event", "claude.thinking", {"aod.length": 6})]
+
+
+def test_claude_adapter_tool_use_starts_span():
+    actions = list(
+        _claude_adapter(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_abc",
+                            "name": "Bash",
+                            "input": {"command": "ls"},
+                        }
+                    ]
+                },
+            }
+        )
+    )
+    assert actions == [
+        (
+            "tool_start",
+            "toolu_abc",
+            "runtime.tool_use",
+            {"aod.tool_name": "Bash", "aod.tool_id": "toolu_abc"},
+        )
+    ]
+
+
+def test_claude_adapter_tool_use_without_id_is_skipped():
+    """Without a tool_use_id we can't pair start↔end, so don't open a span."""
+    actions = list(
+        _claude_adapter(
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "tool_use", "name": "Bash"}]},
+            }
+        )
+    )
+    assert actions == []
+
+
+def test_claude_adapter_user_tool_result_ends_span():
+    actions = list(
+        _claude_adapter(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_abc",
+                            "is_error": False,
+                        }
+                    ]
+                },
+            }
+        )
+    )
+    assert actions == [("tool_end", "toolu_abc", {"aod.is_error": False})]
+
+
+def test_claude_adapter_user_tool_result_error_flag():
+    actions = list(
+        _claude_adapter(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "x", "is_error": True}
+                    ]
+                },
+            }
+        )
+    )
+    assert actions[0][2]["aod.is_error"] is True
+
+
+def test_claude_adapter_system_init_event():
+    actions = list(
+        _claude_adapter(
+            {
+                "type": "system",
+                "subtype": "init",
+                "model": "claude-sonnet-4-6",
+                "tools": list(range(27)),
+            }
+        )
+    )
+    assert actions == [
+        (
+            "event",
+            "claude.system.init",
+            {
+                "aod.subtype": "init",
+                "aod.model": "claude-sonnet-4-6",
+                "aod.tools_count": 27,
+            },
+        )
+    ]
+
+
+def test_claude_adapter_result_event_with_usage():
+    actions = list(
+        _claude_adapter(
+            {
+                "type": "result",
+                "subtype": "success",
+                "duration_ms": 12300,
+                "num_turns": 15,
+                "total_cost_usd": 0.0234,
+            }
+        )
+    )
+    assert actions == [
+        (
+            "event",
+            "claude.result",
+            {
+                "aod.subtype": "success",
+                "aod.duration_ms": 12300,
+                "aod.num_turns": 15,
+                "aod.total_cost_usd": 0.0234,
+            },
+        )
+    ]
+
+
+def test_claude_adapter_unknown_type_yields_nothing():
+    assert list(_claude_adapter({"type": "task_progress"})) == []
+
+
+# ---------------------------------------------------------------------------
+# Emitter — end-to-end with real tracer
+# ---------------------------------------------------------------------------
+
+
+def test_emitter_starts_and_ends_tool_use_span(memory_tracer):
+    parent = FakeSpan()
+    emitter = _emitter(parent)
+    emitter.feed(
+        "stdout",
+        _line(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {"type": "tool_use", "id": "t1", "name": "Bash"},
+                    ]
+                },
+            }
+        ),
+    )
+    # Span has not ended yet — tool_result hasn't arrived.
+    assert memory_tracer.get_finished_spans() == ()
+    emitter.feed(
+        "stdout",
+        _line(
+            {
+                "type": "user",
+                "message": {
+                    "content": [{"type": "tool_result", "tool_use_id": "t1"}]
+                },
+            }
+        ),
+    )
+    spans = memory_tracer.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "runtime.tool_use"
+    assert span.attributes["aod.tool_name"] == "Bash"
+    assert span.attributes["aod.tool_id"] == "t1"
+    assert span.attributes["aod.is_error"] is False
+
+
+def test_emitter_finish_closes_orphan_tool_spans(memory_tracer):
+    """A turn that aborts mid-tool (timeout, runtime crash) leaves a tool_use
+    with no matching tool_result. finish() must end those spans so they
+    actually export."""
+    parent = FakeSpan()
+    emitter = _emitter(parent)
+    emitter.feed(
+        "stdout",
+        _line(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [{"type": "tool_use", "id": "orphan", "name": "Read"}]
+                },
+            }
+        ),
+    )
+    emitter.finish()
+    spans = memory_tracer.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "runtime.tool_use"
+    assert spans[0].attributes["aod.tool_status"] == "abandoned"
+
+
+def test_emitter_buffers_partial_lines(memory_tracer):
+    """A JSON object split across two feed() calls only fires after the
+    newline arrives — otherwise the parser sees malformed JSON and drops."""
+    parent = FakeSpan()
+    emitter = _emitter(parent)
+    payload = _line(
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "split"}]},
+        }
+    )
+    mid = len(payload) // 2
+    emitter.feed("stdout", payload[:mid])
+    assert parent.events == []
+    emitter.feed("stdout", payload[mid:])
+    assert parent.events == [("claude.assistant_text", {"aod.length": 5})]
+
+
+def test_emitter_handles_multiple_lines_in_one_chunk(memory_tracer):
+    parent = FakeSpan()
+    emitter = _emitter(parent)
+    a = _line(
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "a"}]}}
+    )
+    b = _line(
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "bb"}]}}
+    )
+    emitter.feed("stdout", a + b)
+    assert parent.events == [
+        ("claude.assistant_text", {"aod.length": 1}),
+        ("claude.assistant_text", {"aod.length": 2}),
+    ]
+
+
+def test_emitter_drops_malformed_json_silently(memory_tracer):
+    parent = FakeSpan()
+    emitter = _emitter(parent)
+    emitter.feed("stdout", b"not-json\n")
+    emitter.feed("stdout", b"{also not valid}\n")
+    assert parent.events == []
+    assert memory_tracer.get_finished_spans() == ()
+
+
+def test_emitter_ignores_stderr(memory_tracer):
+    """stream-json is stdout-only on every supported runtime."""
+    parent = FakeSpan()
+    emitter = _emitter(parent)
+    emitter.feed(
+        "stderr",
+        _line(
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "x"}]},
+            }
+        ),
+    )
+    assert parent.events == []
+
+
+def test_emitter_unknown_runtime_is_a_noop(memory_tracer):
+    parent = FakeSpan()
+    emitter = _emitter(parent, runtime="opencode")  # no adapter wired yet
+    emitter.feed(
+        "stdout",
+        _line({"type": "assistant", "message": {"content": []}}),
+    )
+    assert parent.events == []
+    assert memory_tracer.get_finished_spans() == ()
+
+
+def test_emitter_duplicate_tool_start_ignored(memory_tracer):
+    """A second tool_use with the same id must not replace the first
+    (would orphan the original span and lose its duration)."""
+    parent = FakeSpan()
+    emitter = _emitter(parent)
+    block = _line(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "tool_use", "id": "dup", "name": "Bash"}]
+            },
+        }
+    )
+    emitter.feed("stdout", block)
+    emitter.feed("stdout", block)  # duplicate — ignored
+    emitter.feed(
+        "stdout",
+        _line(
+            {
+                "type": "user",
+                "message": {
+                    "content": [{"type": "tool_result", "tool_use_id": "dup"}]
+                },
+            }
+        ),
+    )
+    spans = memory_tracer.get_finished_spans()
+    assert len(spans) == 1
+
+
+def test_emitter_unknown_tool_result_silently_ignored(memory_tracer):
+    parent = FakeSpan()
+    emitter = _emitter(parent)
+    emitter.feed(
+        "stdout",
+        _line(
+            {
+                "type": "user",
+                "message": {
+                    "content": [{"type": "tool_result", "tool_use_id": "ghost"}]
+                },
+            }
+        ),
+    )
+    assert memory_tracer.get_finished_spans() == ()
+
+
+def test_emitter_adapter_exception_does_not_propagate(memory_tracer, mocker):
+    """A bug in an adapter must not abort the drain loop and fail the turn."""
+    parent = FakeSpan()
+    emitter = _emitter(parent)
+    mocker.patch.object(
+        emitter, "_adapter", side_effect=RuntimeError("adapter exploded")
+    )
+    emitter.feed(
+        "stdout",
+        _line({"type": "assistant", "message": {"content": []}}),
+    )
+    assert parent.events == []
+
+
+def test_emitter_skips_blank_lines(memory_tracer):
+    parent = FakeSpan()
+    emitter = _emitter(parent)
+    emitter.feed("stdout", b"\n\n\n")
+    assert parent.events == []

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -695,6 +695,26 @@ def test_drain_emits_runtime_output_span_event_per_chunk(user):
 
 
 @pytest.mark.django_db
+def test_drain_feeds_chunks_to_trace_emitter(user):
+    """The drain loop should hand each chunk to the trace emitter so it
+    can line-buffer + parse stream-json into structured spans."""
+    session, turn = _make_session_and_turn(user)
+    fed: list[tuple[str, bytes]] = []
+
+    class FakeEmitter:
+        def feed(self, stream, data):
+            fed.append((stream, bytes(data)))
+
+    sink = LogChunkSink(session, turn, span=None, trace_emitter=FakeEmitter())
+    sink.stdout_writer.write(b"out chunk")
+    sink.stderr_writer.write(b"err chunk")
+    sink.put_sentinel()
+    sink.drain()
+
+    assert fed == [("stdout", b"out chunk"), ("stderr", b"err chunk")]
+
+
+@pytest.mark.django_db
 def test_drain_buffers_chunk_before_emitting_span_event(user):
     """If span.add_event raises (custom exporter, ended span on a buggy SDK,
     etc.) the chunk must already be in the buffer — otherwise it's silently


### PR DESCRIPTION
## Summary
Builds on #284. The cadence event filled the dead time visually but didn't name what was happening. This adds `RuntimeTraceEmitter`, which line-buffers the runtime's stdout, parses each JSON event, and turns the structured shape into trace data:

- **Child span per `tool_use` block** — started when the assistant message announces it, ended when the matching `user` message carries the `tool_result`. The span duration is the wall-clock the tool took to execute, which is exactly the dead time the operator was seeing on the original trace.
- **Span events for non-durational signals** — assistant text/thinking, system init, the final `result` envelope (with usage + cost).

Only the `claude` adapter is wired in for now; codex / gemini / opencode follow as additional `_ADAPTERS` entries. The Claude event taxonomy mirrors `clients/python/src/aod/pretty/claude.py` — keep them in sync if the upstream stream-json shape changes.

`finish()` runs after the drain loop and closes any tool spans the runtime never matched up (turn timed out mid-call, runtime crashed), so Honeycomb doesn't show incomplete traces.

## Architecture
- `session_service/runtime_trace.py` (new) — `RuntimeTraceEmitter` + `_claude_adapter`. Adapter dispatch is a tuple-action protocol (`event` / `tool_start` / `tool_end`) so adding a runtime is a pure-data change.
- `session_service/log_sink.py` — `LogChunkSink` gains an optional `trace_emitter` parameter; the drain loop hands each chunk to it after buffering. Additive, doesn't disturb PR #284's `span` cadence path.
- `session_service/turn_executor.py` — constructs the emitter once per turn, threads it into the sink, calls `emitter.finish()` after drain.

## Safety
- Adapter exceptions are caught and logged inside `_handle_line` so a parser bug can't abort the drain loop and fail the turn.
- `finish()` always runs (between `sink.drain()` and `cmd_thread.join`) so orphaned tool spans always get exported.
- Duplicate `tool_use_id` is ignored (preserves the first span's wall clock).
- `tool_result` for an unknown id is silently dropped.
- Malformed JSON lines are silently dropped.

## Test plan
- [x] `make lint` (clean)
- [x] `make typecheck` (mypy clean)
- [x] `make test` (1231 passed, +22 over main)
- [x] 20 new emitter/adapter unit tests in `tests/test_runtime_trace.py` covering: span lifecycle, partial-line buffering, multi-line chunks, malformed JSON, stderr ignore, unknown runtime, duplicate tool_use_id, unknown tool_result_id, adapter exception, blank lines, orphan span close in `finish()`.
- [x] 1 new sink integration test in `tests/test_tasks.py` confirming `LogChunkSink` actually feeds chunks to the emitter.
- [ ] Post-deploy: confirm a real session trace in Honeycomb shows `runtime.tool_use` child spans naming the long Bash / Read / Edit calls inside `session.execute_turn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)