### PR TITLE
fix(observability): pass spec.runtime.name to RuntimeTraceEmitter

### DIFF
--- a/src/agent_on_demand/session_service/runtime_trace.py
+++ b/src/agent_on_demand/session_service/runtime_trace.py
@@ -57,6 +57,16 @@ class RuntimeTraceEmitter:
     """
 
     def __init__(self, parent_span: Span, runtime: str, tracer: Tracer):
+        # `runtime` must be the string name (e.g. "claude"), not a `Runtime`
+        # object. The original wiring passed `spec.runtime` directly, which
+        # is the Runtime instance, so `_ADAPTERS.get(...)` silently returned
+        # None and the emitter became a no-op in prod. Catching it here
+        # keeps the next refactor from regressing the same way.
+        if not isinstance(runtime, str):
+            raise TypeError(
+                f"runtime must be the runtime name string, got "
+                f"{type(runtime).__name__}; pass spec.runtime.name."
+            )
         self._parent = parent_span
         self._tracer = tracer
         self._adapter = _ADAPTERS.get(runtime)

--- a/src/agent_on_demand/session_service/turn_executor.py
+++ b/src/agent_on_demand/session_service/turn_executor.py
@@ -69,7 +69,7 @@ class TurnExecutor:
         self._mode = mode
         self._timeout = timeout
         self._span = span
-        self._trace_emitter = RuntimeTraceEmitter(span, spec.runtime, get_tracer())
+        self._trace_emitter = RuntimeTraceEmitter(span, spec.runtime.name, get_tracer())
         self._sink = LogChunkSink(session, turn, span=span, trace_emitter=self._trace_emitter)
         self._result_holder: list = []
 

--- a/tests/test_runtime_trace.py
+++ b/tests/test_runtime_trace.py
@@ -340,6 +340,20 @@ def test_emitter_ignores_stderr(memory_tracer):
     assert parent.events == []
 
 
+def test_emitter_rejects_non_string_runtime(memory_tracer):
+    """Pinning the constructor's type guard. PR #286's wiring originally
+    passed `spec.runtime` (a Runtime object) instead of `spec.runtime.name`,
+    silently producing a no-op adapter. The TypeError makes that regression
+    fail at construction instead of in production."""
+
+    class FakeRuntime:
+        name = "claude"
+
+    parent = FakeSpan()
+    with pytest.raises(TypeError, match="spec.runtime.name"):
+        RuntimeTraceEmitter(parent, FakeRuntime(), trace.get_tracer("test"))
+
+
 def test_emitter_unknown_runtime_is_a_noop(memory_tracer):
     parent = FakeSpan()
     emitter = _emitter(parent, runtime="opencode")  # no adapter wired yet

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -327,6 +327,63 @@ def test_execute_turn_writes_log_chunks_via_tagging_writer(user, mocker):
     assert all(log.turn_id == turn.id for log in logs)
 
 
+@pytest.mark.django_db
+def test_execute_turn_wires_runtime_trace_emitter_with_runtime_name(user, mocker):
+    """Regression: `spec.runtime` is a Runtime *object* after the PR #285
+    refactor; passing the object to RuntimeTraceEmitter silently produced a
+    no-op adapter in prod (PR #286 + #285 integration bug). The emitter
+    expects the runtime *name* string. This test would have caught it: it
+    drives a Claude stream-json chunk through the full execute_turn path
+    and asserts the emitter was constructed with the right shape."""
+    import json as _json
+
+    from agent_on_demand.session_service import turn_executor as turn_executor_mod
+
+    session, turn = _make_session_and_turn(user)
+    _, mock_cmd = _patch_sprite(mocker, "success")
+
+    captured: list = []
+    real_emitter_cls = turn_executor_mod.RuntimeTraceEmitter
+
+    def capture_emitter(span, runtime, tracer):
+        captured.append(runtime)
+        return real_emitter_cls(span, runtime, tracer)
+
+    mocker.patch.object(turn_executor_mod, "RuntimeTraceEmitter", capture_emitter)
+
+    def drive_output(*_, **__):
+        writer = mock_cmd.stdout
+        writer.write(
+            (
+                _json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [{"type": "text", "text": "ok"}],
+                        },
+                    }
+                )
+                + "\n"
+            ).encode()
+        )
+
+    mock_cmd.run.side_effect = drive_output
+
+    execute_turn(
+        session_id=str(session.id),
+        turn_id=turn.id,
+        prompt="t",
+        mode="run",
+        timeout=10.0,
+    )
+
+    assert captured, "RuntimeTraceEmitter was never constructed"
+    assert captured[0] == "claude", (
+        f"emitter received {captured[0]!r}; expected the runtime name string 'claude'. "
+        "Passing the Runtime object instead silently disables the adapter."
+    )
+
+
 # --------------------------------------------------------------------------
 # provision_session_task tests
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR #286 (stream-json parser) and PR #285 (in-Sprite Claude OTel) merged back-to-back. **#286 was written against the pre-#285 API where `spec.runtime` was a string; #285 changed it to a `Runtime` object.** The combined merge wired up `RuntimeTraceEmitter(span, spec.runtime, ...)` — so `_ADAPTERS.get(<Runtime object>)` silently returned `None`, the adapter was never invoked, and PR #286 produced **zero** `claude.*` events / **zero** `runtime.tool_use` child spans in production.

PR #284's cadence path (`runtime.output` per chunk) was unaffected, which is why traces still showed circles for the cadence — but the gaps between them were never named.

## Evidence

Honeycomb query against `aod-prod / aod-worker` for the last 2h, library = `agent_on_demand`:

| event name | count |
| --- | --- |
| `runtime.output` | 42 |
| `claude.assistant_text`, `claude.thinking`, `claude.system.init`, `claude.result` | **0** |
| `runtime.tool_use` (child span) | **0** |

## Fix

- Pass `spec.runtime.name` (the string runtime key) at the call site in `TurnExecutor.__init__`.
- Add a `TypeError` in `RuntimeTraceEmitter.__init__` so the next refactor that breaks this trips loudly in CI instead of silently in prod.

## Test plan

- [x] `make lint` (clean), `make typecheck` (mypy clean), `make test` (51 affected pass)
- [x] New unit test `test_emitter_rejects_non_string_runtime` pins the TypeError.
- [x] New integration test `test_execute_turn_wires_runtime_trace_emitter_with_runtime_name` drives a real Claude stream-json line through the full `execute_turn` path and asserts the emitter receives `"claude"`, not the Runtime object.
- [x] Verified both new tests **fail without the source fix** by stashing `runtime_trace.py` and `turn_executor.py` and re-running.
- [ ] Post-deploy: confirm a Claude session trace shows `claude.assistant_text` events on the parent and `runtime.tool_use` child spans for any tool calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)