### PR TITLE
observability: run `claude update` on provision

### DIFF
--- a/src/agent_on_demand/runtimes/claude.py
+++ b/src/agent_on_demand/runtimes/claude.py
@@ -15,12 +15,28 @@ if TYPE_CHECKING:
     from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
 
 
+# Minimum version that emits `claude_code.interaction` spans and honors
+# inbound `TRACEPARENT` in `-p`/`--print` non-interactive mode (the
+# Traces (beta) feature documented at
+# https://code.claude.com/docs/en/monitoring-usage#traces-beta). The
+# Sprite base image ships an older 2.1.92 that drops both, breaking the
+# parent linkage we propagate from `session.execute_turn`.
+CLAUDE_CODE_VERSION = "2.1.123"
+
+
 class ClaudeRuntime:
     """Runtime for Anthropic's Claude Code CLI.
 
     Auth comes from the env file written during provisioning
     (ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN); the CLI picks it up on
     its own, so the command shape is the same for both.
+
+    The Sprite base image ships claude pre-installed but pinned to 2.1.92,
+    which predates the Traces (beta) `TRACEPARENT` propagation. `install`
+    upgrades it to `CLAUDE_CODE_VERSION` per provision so child spans
+    parent under our `session.execute_turn` span. If the Environment has
+    `networking_type="limited"`, the allowed-hosts list must include
+    `registry.npmjs.org`.
     """
 
     name = "claude"
@@ -29,7 +45,9 @@ class ClaudeRuntime:
     skills_sh_agent: str | None = "claude-code"
 
     def install(self, handle: "SessionHandle") -> None:
-        return None
+        handle.make_command(
+            "bash", "-lc", f"npm install -g @anthropic-ai/claude-code@{CLAUDE_CODE_VERSION}"
+        ).run()
 
     def build_command(self, spec: "SessionSpec", mode: Literal["run", "continue"]) -> list[str]:
         return build_claude_command(spec, mode)

--- a/src/agent_on_demand/runtimes/claude.py
+++ b/src/agent_on_demand/runtimes/claude.py
@@ -15,15 +15,6 @@ if TYPE_CHECKING:
     from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
 
 
-# Minimum version that emits `claude_code.interaction` spans and honors
-# inbound `TRACEPARENT` in `-p`/`--print` non-interactive mode (the
-# Traces (beta) feature documented at
-# https://code.claude.com/docs/en/monitoring-usage#traces-beta). The
-# Sprite base image ships an older 2.1.92 that drops both, breaking the
-# parent linkage we propagate from `session.execute_turn`.
-CLAUDE_CODE_VERSION = "2.1.123"
-
-
 class ClaudeRuntime:
     """Runtime for Anthropic's Claude Code CLI.
 
@@ -32,11 +23,14 @@ class ClaudeRuntime:
     its own, so the command shape is the same for both.
 
     The Sprite base image ships claude pre-installed but pinned to 2.1.92,
-    which predates the Traces (beta) `TRACEPARENT` propagation. `install`
-    upgrades it to `CLAUDE_CODE_VERSION` per provision so child spans
-    parent under our `session.execute_turn` span. If the Environment has
-    `networking_type="limited"`, the allowed-hosts list must include
-    `registry.npmjs.org`.
+    which predates the Traces (beta) `TRACEPARENT` propagation documented
+    at https://code.claude.com/docs/en/monitoring-usage#traces-beta. On
+    that version, child spans land in Honeycomb as orphan roots instead
+    of parenting under our `session.execute_turn` span. `install` runs
+    `claude update` per provision to pull the latest CLI before the
+    network policy locks down. If the Environment has
+    `networking_type="limited"`, the allowed-hosts list must reach
+    whatever update channel claude uses (npm registry today).
     """
 
     name = "claude"
@@ -45,9 +39,7 @@ class ClaudeRuntime:
     skills_sh_agent: str | None = "claude-code"
 
     def install(self, handle: "SessionHandle") -> None:
-        handle.make_command(
-            "bash", "-lc", f"npm install -g @anthropic-ai/claude-code@{CLAUDE_CODE_VERSION}"
-        ).run()
+        handle.make_command("bash", "-lc", "claude update").run()
 
     def build_command(self, spec: "SessionSpec", mode: Literal["run", "continue"]) -> list[str]:
         return build_claude_command(spec, mode)

--- a/src/agent_on_demand/session_service/provisioning/stages.py
+++ b/src/agent_on_demand/session_service/provisioning/stages.py
@@ -60,8 +60,9 @@ __all__ = [
 
 def install_runtime(handle: SessionHandle, spec: SessionSpec, session_id: str | None) -> None:
     """Run per-runtime `install` hook before the network policy locks things
-    down. For pre-baked runtimes (claude/codex/gemini) this is a no-op; for
-    meta-runtimes that fetch binaries, internet access is required here."""
+    down. For pre-baked runtimes (codex/gemini) this is a no-op; for
+    runtimes that fetch binaries (claude upgrades past the base-image pin,
+    opencode pulls from npm), internet access is required here."""
     with stage_timer(session_id, STAGE_INSTALL_RUNTIME):
         try:
             spec.runtime.install(handle)

--- a/tests/runtimes/test_claude.py
+++ b/tests/runtimes/test_claude.py
@@ -8,7 +8,7 @@ import json
 import pytest
 from django.contrib.auth.models import User
 
-from agent_on_demand.runtimes.claude import CLAUDE_CODE_VERSION, ClaudeRuntime
+from agent_on_demand.runtimes.claude import ClaudeRuntime
 from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
 from tests.fakes.sprite import RecordingSprite
 
@@ -43,10 +43,12 @@ def test_providers():
     assert ClaudeRuntime().providers == {"anthropic"}
 
 
-def test_install_runs_npm_global():
+def test_install_runs_claude_update():
     """Sprite base image pins claude to 2.1.92, which predates the
-    Traces (beta) `TRACEPARENT` propagation. install() must upgrade
-    via npm so `claude_code.interaction` parents under our worker span.
+    Traces (beta) `TRACEPARENT` propagation. install() must run
+    `claude update` so `claude_code.interaction` parents under our
+    worker span. Delegating the version choice to `claude update` keeps
+    the upgrade channel consistent with what claude itself ships.
     """
     sprite = RecordingSprite("s")
     ClaudeRuntime().install(sprite)
@@ -54,8 +56,7 @@ def test_install_runs_npm_global():
     argv = sprite.commands[0].argv
     assert argv[0] == "bash"
     assert argv[1] == "-lc"
-    assert f"@anthropic-ai/claude-code@{CLAUDE_CODE_VERSION}" in argv[2]
-    assert "npm install -g" in argv[2]
+    assert argv[2] == "claude update"
 
 
 @pytest.mark.django_db

--- a/tests/runtimes/test_claude.py
+++ b/tests/runtimes/test_claude.py
@@ -8,7 +8,7 @@ import json
 import pytest
 from django.contrib.auth.models import User
 
-from agent_on_demand.runtimes.claude import ClaudeRuntime
+from agent_on_demand.runtimes.claude import CLAUDE_CODE_VERSION, ClaudeRuntime
 from agent_on_demand.session_service.specs import McpServerSpec, SessionSpec
 from tests.fakes.sprite import RecordingSprite
 
@@ -41,6 +41,21 @@ def test_skills_root():
 
 def test_providers():
     assert ClaudeRuntime().providers == {"anthropic"}
+
+
+def test_install_runs_npm_global():
+    """Sprite base image pins claude to 2.1.92, which predates the
+    Traces (beta) `TRACEPARENT` propagation. install() must upgrade
+    via npm so `claude_code.interaction` parents under our worker span.
+    """
+    sprite = RecordingSprite("s")
+    ClaudeRuntime().install(sprite)
+    assert len(sprite.commands) == 1
+    argv = sprite.commands[0].argv
+    assert argv[0] == "bash"
+    assert argv[1] == "-lc"
+    assert f"@anthropic-ai/claude-code@{CLAUDE_CODE_VERSION}" in argv[2]
+    assert "npm install -g" in argv[2]
 
 
 @pytest.mark.django_db

--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -97,12 +97,18 @@ class TestProvisionSessionOrder:
         script = fake_sprites.last_sprite().write_map()["/tmp/aod-provision.sh"]
         assert "/home/sprite/.codex" not in script
 
-    def test_single_bash_command_invokes_provision_script(self, user, fake_sprites):
+    def test_provisioning_issues_install_then_provision_script(self, user, fake_sprites):
         provision_session(user, _spec(user))
         sprite = fake_sprites.last_sprite()
-        # The whole provisioning phase uses exactly one sprite.command —
-        # invoking the provision script. No per-stage chmod / clone commands.
-        assert sprite.command_strings() == ["bash -l /tmp/aod-provision.sh"]
+        # Two sprite.command invocations during provisioning, in order:
+        # ClaudeRuntime.install runs `claude update` to upgrade past the
+        # base-image 2.1.92 (predates Traces (beta) TRACEPARENT support);
+        # the provision script bundles the rest. No per-stage chmod /
+        # clone commands.
+        assert sprite.command_strings() == [
+            "bash -lc claude update",
+            "bash -l /tmp/aod-provision.sh",
+        ]
 
     def test_env_file_contains_credential_and_session_id(self, user, fake_sprites):
         provision_session(user, _spec(user))


### PR DESCRIPTION
## Summary

- Replaces `ClaudeRuntime.install`'s no-op with `claude update` per provision, so each Sprite runs a Claude CLI new enough to honor inbound `TRACEPARENT` and emit `claude_code.interaction` spans.
- Updates the stale `install_runtime` docstring that listed claude as pre-baked.

## Why

After #285 propagated trace context into Claude on the Sprite, parent linkage still didn't appear in the `claude-code` Honeycomb dataset. Diagnosis from production data over the last 24h (env `aod-prod`):

- Every Sprite turn runs `service.version=2.1.92`, `terminal.type=non-interactive` (so `--print` mode is detected). Across 5 distinct sessions on 2.1.92: **0** `claude_code.interaction` spans, plus 15 `claude_code.llm_request` and 9 `claude_code.tool` spans, each as its own root trace_id with no parent.
- The one working `claude_code.interaction` (correctly parented, with a child `claude_code.llm_request` nested under it) came from a `2.1.123` instance running on a developer's local terminal — proof the propagation path works once the CLI version supports it.

The Traces (beta) feature documented at https://code.claude.com/docs/en/monitoring-usage#traces-beta is newer than the 2.1.92 baked into the Sprite base image; running `claude update` in provisioning sidesteps the base-image lag and tracks whatever channel claude itself ships from.

## Trade-offs

- Adds latency to every provision (`claude update` is a network fetch). Acceptable as an interim fix; long-term we should ask Sprites to bump the base image and drop this `install` hook.
- `limited`-networking environments will need whatever update channel claude uses (npm registry today) on their allowed-hosts list. Audit before merging if any prod environment uses `limited` networking.
- We don't pin a specific version — `claude update` decides. That's a deliberate choice: the upstream upgrade channel is the source of truth we want to track, and the 2.1.123 minimum is preserved by `latest > 2.1.123`.

## Test plan

- [x] `tests/runtimes/test_claude.py::test_install_runs_claude_update` — asserts `bash -lc "claude update"` is the command issued.
- [x] `ruff check` clean.
- [ ] Run one `make test-e2e-fast` against a deploy that picks this up to confirm provision still completes.
- [ ] After deploy, verify a fresh Sprite turn produces a `claude_code.interaction` span in the `claude-code` dataset whose `trace.parent_id` matches the originating `session.execute_turn` `trace.span_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)