### PR TITLE
docs: fix session state machine — pending rejects POST /sessions/{id}/prompt

### DIFF
--- a/site/docs/api/concepts.md
+++ b/site/docs/api/concepts.md
@@ -58,13 +58,13 @@ A **session** is one execution of an agent inside a Sprite. Sessions are:
         POST /sessions/{id}/prompt (allowed from completed)
 ```
 
-- `pending` → accepted, not yet executing. Prompts are accepted but state stays `pending`.
-- `running` → agent CLI is executing inside the Sprite. Prompts return `409`.
+- `pending` → accepted, not yet executing. Cannot accept a new prompt; a turn is already queued. `POST /prompt` returns `409`.
+- `running` → agent CLI is executing inside the Sprite. `POST /prompt` returns `409`.
 - `completed` → runtime exited with code 0. Prompts accepted; session resets to `pending`.
 - `failed` → runtime exited non-zero, or an unhandled exception. Cannot be continued; `POST /prompt` returns `409`.
 - `terminated` → stopped by `POST /sessions/{id}/terminate`. Cannot be continued.
 
-Only `pending` and `completed` sessions accept `POST /sessions/{id}/prompt`. `running`, `failed`, and `terminated` all return `409`.
+Only `completed` sessions accept `POST /sessions/{id}/prompt`. All other states (`pending`, `running`, `failed`, `terminated`) return `409`.
 
 ## Optimistic concurrency (agents and environments)
 

--- a/site/docs/api/errors.md
+++ b/site/docs/api/errors.md
@@ -70,7 +70,7 @@ All of these return `409`:
 | `POST /sessions/{id}/prompt` | Session is running | `"Session is already running"` |
 | `POST /sessions/{id}/prompt` | Session has failed | `"Session has failed and cannot be resumed. Start a new session."` |
 | `POST /sessions/{id}/prompt` | Session is terminated | `"Session has been terminated"` |
-| `POST /sessions/{id}/prompt` | Session already has a pending turn (concurrent send race) | `"Session already has a pending turn"` |
+| `POST /sessions/{id}/prompt` | Session is in `pending` state (turn already queued) | `"Session already has a pending turn"` |
 | `POST /sessions/{id}/prompt` | Backend handle gone (Sprite cleaned up while session record exists) | `"Session backend is no longer available; start a new session."` |
 | `POST /sessions/{id}/terminate` | Session already terminated | `"Session is already terminated"` |
 | `DELETE /sessions/{id}/delete` | Session is active (pending or running) | `"Cannot delete an active session"` |


### PR DESCRIPTION
## What was wrong

`site/docs/api/concepts.md` contradicted itself. The state machine **diagram** correctly shows `POST /sessions/{id}/prompt` flowing only from `completed` → `pending`. But the prose on the same page said the opposite:

> Only `pending` and `completed` sessions accept `POST /sessions/{id}/prompt`.

And the `pending` state description said:

> Prompts are accepted but state stays `pending`.

Both are false. The code confirms it:

- `session_state.py::check_can_accept_prompt` does not reject `pending` (it is used as a fast-fail for obviously invalid states), but
- `lifecycle.py::send_prompt` always returns 409 for pending inside the transaction:
  ```python
  if locked.status == "pending":
      return JsonResponse({"detail": "Session already has a pending turn"}, status=409)
  ```

So **only `completed` sessions accept follow-up prompts**. Every other status returns 409.

The `errors.md` 409 table also labelled the condition as "(concurrent send race)", implying this only fires in a race. It fires on any prompt sent to a pending session.

## What changed

- `site/docs/api/concepts.md`: fixed the state bullet for `pending`, fixed the summary line.
- `site/docs/api/errors.md`: fixed the 409 condition description for `"Session already has a pending turn"`.

## How I verified

- Read `src/agent_on_demand/session_state.py` and `src/agent_on_demand/views/sessions/lifecycle.py` to confirm `pending` always returns 409.
- Ran `cd site && mkdocs build` — built in 0.74 s, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)