### PR TITLE
docs: fix 422 detail type — can be string, not always a list

### DIFF
--- a/site/docs/api/errors.md
+++ b/site/docs/api/errors.md
@@ -9,20 +9,28 @@ Most error responses use this shape:
 ```
 
 - For every status code **except 422 and 429**, `detail` is a string.
-- For **422**, `detail` is a list of Pydantic validation error objects:
+- For **422**, `detail` is **either** a list (request-body field error) or a string (server-side validation, e.g. an incompatible model/runtime pair):
 
-```json
-{
-  "detail": [
-    {
-      "type": "missing",
-      "loc": ["prompt"],
-      "msg": "Field required",
-      "input": {}
-    }
-  ]
-}
-```
+  List shape — missing or wrong-type field in the request body:
+
+  ```json
+  {
+    "detail": [
+      {
+        "type": "missing",
+        "loc": ["prompt"],
+        "msg": "Field required",
+        "input": {}
+      }
+    ]
+  }
+  ```
+
+  String shape — server-side validation (e.g. `POST /agents` with an OpenAI model on the `claude` runtime):
+
+  ```json
+  {"detail": "Runtime claude cannot serve model openai/gpt-4.1: provider openai not in ['anthropic']"}
+  ```
 
 - For **429**, `detail` is a string and two extra fields are present:
 
@@ -34,7 +42,7 @@ Most error responses use this shape:
 }
 ```
 
-Client rule: `isinstance(detail, list)` if and only if status is 422.
+Client rule: when status is 422, use `isinstance(detail, list)` to distinguish request-body field errors (list) from server-side validation errors (string). Do not assume 422 always carries a list.
 
 ## Status code reference
 
@@ -48,7 +56,7 @@ Client rule: `isinstance(detail, list)` if and only if status is 422.
 | 404 | string | Resource not found, or not owned by this token's user | `{"detail":"Agent not found"}` |
 | 405 | string | Method not allowed | `{"detail":"Method not allowed"}` |
 | 409 | string | Conflict — see table below | `{"detail":"Version mismatch: expected 3, got 2"}` |
-| 422 | **list** | Pydantic validation failure | `{"detail":[{"type":"missing",...}]}` |
+| 422 | list or string | Server-side validation failure (list for body field errors; string for model/runtime incompatibility) | `{"detail":[{"type":"missing",...}]}` |
 | 429 | string + extras | Concurrent session limit reached | `{"detail":"...","limit":3,"active":3}` |
 | 502 | string | Sprites upstream error during session create | `{"detail":"Failed to create Sprite: connection refused"}` |
 

--- a/site/docs/sdks/python.md
+++ b/site/docs/sdks/python.md
@@ -65,7 +65,7 @@ Mapping matches the [Errors reference](../api/errors.md):
 | 401 | `AuthError` | Missing or invalid token |
 | 404 | `NotFoundError` | Resource missing (or not owned by caller) |
 | 409 | `ConflictError` | Archived row, terminal session, or stale `version` |
-| 422 | `ValidationError` | Server-side pydantic validation failure |
+| 422 | `ValidationError` | Server-side validation failure (see [Errors reference](../api/errors.md) for list vs string detail) |
 | 429 | `RateLimitError` | Per-user concurrent session limit (`.limit`, `.active`) |
 | 5xx | `ServerError` | |
 


### PR DESCRIPTION
## What was wrong

`site/docs/api/errors.md` stated:

> For **422**, `detail` is a list of Pydantic validation error objects

and included this definitive rule:

> Client rule: `isinstance(detail, list)` if and only if status is 422.

Both are false. `agents.py` calls `check_runtime_model_compat` **after** Pydantic validation passes, and returns 422 with **string** `detail` when the runtime/model pair is incompatible:

```python
# views/agents.py
compat_err = check_runtime_model_compat(RUNTIMES[req.runtime], MODELS[req.model])
if compat_err is not None:
    return JsonResponse({"detail": compat_err}, status=422)
```

Example: `POST /agents` with `{"runtime":"claude","model":"openai/gpt-4.1",...}` returns:

```json
{"detail": "Runtime claude cannot serve model openai/gpt-4.1: provider openai not in ['anthropic']"}
```

That's a string, not a list. A client following the documented rule and doing `detail[0]["msg"]` would get a `TypeError`. This check also runs on `PUT /agents/{id}`, so the same mismatch on update hits the same shape.

## What changed

- **`site/docs/api/errors.md`**: rewrite the 422 bullet to show both shapes with concrete examples; reword the client rule to say `isinstance(detail, list)` *distinguishes* the two shapes, not that it's a biconditional invariant. Update the status-code table row from `**list**` to `list or string`.
- **`site/docs/sdks/python.md`**: drop "pydantic validation failure" in favour of a link to the errors reference where both shapes are now explained.

## How I verified

- Read `src/agent_on_demand/views/agents.py` and `src/agent_on_demand/validation/runtime_model_compat.py` to confirm the 422 string path.
- `cd site && mkdocs build` — 0.75 s, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)