### PR TITLE
fix(ts-sdk): rename resource token to authorization_token

### DIFF
--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -30,7 +30,7 @@ export interface SessionResource {
 }
 
 export interface SessionResourceInput extends SessionResource {
-  token?: string | null;
+  authorization_token?: string | null;
 }
 
 export interface Agent {

--- a/clients/typescript/tests/sessions.test.ts
+++ b/clients/typescript/tests/sessions.test.ts
@@ -32,6 +32,34 @@ describe("sessions", () => {
     });
   });
 
+  it("forwards authorization_token on a private-repo resource", async () => {
+    const server = new MockServer();
+    const sid = uuid();
+    server.json("POST", "/sessions", 201, { id: sid, status: "pending" });
+    await newClient(server).sessions.create({
+      agent_id: "a1",
+      prompt: "do a thing",
+      resources: [
+        {
+          type: "github_repository",
+          url: "https://github.com/me/private",
+          authorization_token: "ghp_secret",
+        },
+      ],
+    });
+    expect(server.requests[0]?.body).toEqual({
+      agent_id: "a1",
+      prompt: "do a thing",
+      resources: [
+        {
+          type: "github_repository",
+          url: "https://github.com/me/private",
+          authorization_token: "ghp_secret",
+        },
+      ],
+    });
+  });
+
   it("409 on prompt to a terminal session", async () => {
     const server = new MockServer();
     server.json("POST", "/sessions/s1/prompt", 409, { detail: "terminal" });


### PR DESCRIPTION
## Summary
- The TS SDK's `SessionResourceInput` exposed a `token` field for private GitHub repos, but the API expects `authorization_token` (`src/agent_on_demand/views/sessions/schemas.py`).
- Field name mismatch meant private-repo cloning silently failed when called from the TS SDK — the value was serialized as `token`, never read by the server.
- The field is undocumented in the TS README and not referenced by any existing test, so the rename is safe.

## Breaking change
`SessionResourceInput.token` is renamed to `SessionResourceInput.authorization_token`.

- TypeScript callers using `.token` will get a compile error after upgrading and must rename to `.authorization_token`.
- Plain-JS callers using `.token` will silently regress to the already-broken pre-fix behavior — the field is dropped on the wire — so they must also rename.
- Action for consumers: search for `.token` on `SessionResourceInput` (or `GithubRepoResource`) and rename to `.authorization_token` before upgrading.

This package does not yet ship a CHANGELOG; opening one is out of scope for this fix, but consumers should treat this as a breaking release.

## Test plan
- [x] `npm test` (29 tests pass; new test asserts the field reaches the wire under `authorization_token`)
- [x] `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)