### PR TITLE
omnibus: TypeScript SDK improvements (rolling)

### DIFF
--- a/clients/typescript/src/stream.ts
+++ b/clients/typescript/src/stream.ts
@@ -36,6 +36,7 @@ export function createStreamHandle(
       } catch {
         // iterator already finished or errored — nothing to do
       }
+      cleanupOnce();
     },
   };
 }

--- a/clients/typescript/tests/client.test.ts
+++ b/clients/typescript/tests/client.test.ts
@@ -144,6 +144,16 @@ describe("Client", () => {
     await client.health();
     expect(server.requests[0]?.path).toBe("/health");
   });
+
+  // Catches the easy mistake of bumping `package.json` without bumping the
+  // exported `VERSION` constant (the README's release checklist requires both,
+  // and the publish workflow only checks the tag against `package.json`).
+  it("exports a VERSION matching package.json", () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+    ) as { version: string };
+    expect(VERSION).toBe(pkg.version);
+  });
 });
 
 describe("module exports", () => {


### PR DESCRIPTION
## Summary
Rolling omnibus PR that bundles the focused TS-SDK PRs into a single review/merge unit. Each individual change is reviewed separately first; this PR is the "merge them all at once" alternative.

## Included changes
- #292 fix: rename resource `token` → `authorization_token` (was silently dropping private-repo PATs)
- #296 fix: allow `environment_id: null` on agent update to detach an env
- #301 feat: send `User-Agent: aod-sdk-ts/<version>` (parity with Python SDK)
- #305 fix: `timeoutMs` must cover body read, not just connect
- #310 fix: remove abort listener from external signal after each request (leak)
- #314 test: pin exported `VERSION` to `package.json` on every PR
- #315 fix: per-condition exports so CJS consumers get `.d.cts`
- #317 fix: cancel the underlying fetch when stream iteration ends
- #320 chore: align test fixtures with canonical runtime/model values

## Test plan
- [x] `npm test`
- [x] `npx tsc --noEmit`
- [x] `@arethetypeswrong/cli` 🟢 across all resolution modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)