### PR TITLE
sdk(python): omnibus — rolling SDK improvements

### DIFF
--- a/clients/python/src/aod/models.py
+++ b/clients/python/src/aod/models.py
@@ -191,6 +191,9 @@ class Networking(_Model):
 NetworkingInput = Networking | dict[str, Any]
 
 
+NetworkingInput = Networking | dict[str, Any]
+
+
 class SessionResource(_Model):
     """A GitHub repo cloned into the Sprite for a session.
 

--- a/clients/python/src/aod/models.py
+++ b/clients/python/src/aod/models.py
@@ -116,6 +116,55 @@ class GithubSkill(_Model):
 SkillInput = InlineSkill | GithubSkill | dict[str, Any]
 
 
+# Mirrors `skill_validation.py` on the server. Validating client-side
+# means callers see a typed exception immediately rather than a 422
+# from the wire.
+SKILL_NAME_RE = r"^[a-z0-9][a-z0-9-]{0,63}$"
+GITHUB_SOURCE_RE = r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$"
+MAX_SKILL_CONTENT_BYTES = 64 * 1024
+MAX_SKILL_DESCRIPTION_LEN = 1024
+SKILL_HEREDOC_DELIMITER = "SKILL_EOF"
+
+
+class InlineSkill(_Model):
+    """A skill whose content is shipped in-band.
+
+    The server materializes `content` to `<skills_root>/<name>/SKILL.md`
+    via a bash heredoc at provision time; `content` must therefore not
+    contain the heredoc delimiter `SKILL_EOF`. Same regex and size cap
+    as `skill_validation.py` on the server.
+    """
+
+    name: str = Field(pattern=SKILL_NAME_RE, max_length=64)
+    description: str = Field(max_length=MAX_SKILL_DESCRIPTION_LEN)
+    content: str
+
+    @field_validator("content")
+    @classmethod
+    def _validate_content(cls, v: str) -> str:
+        if len(v.encode("utf-8")) > MAX_SKILL_CONTENT_BYTES:
+            raise ValueError(f"content exceeds {MAX_SKILL_CONTENT_BYTES} bytes")
+        if SKILL_HEREDOC_DELIMITER in v:
+            raise ValueError(f"content must not contain {SKILL_HEREDOC_DELIMITER!r}")
+        return v
+
+
+class GithubSkill(_Model):
+    """A skill installed from a GitHub repo at provision time.
+
+    Omit `name` to install every `SKILL.md` the repo exposes; provide
+    `name` to install just one.
+    """
+
+    type: Literal["github"] = "github"
+    description: str = Field(max_length=MAX_SKILL_DESCRIPTION_LEN)
+    source: str = Field(pattern=GITHUB_SOURCE_RE)
+    name: str | None = Field(default=None, pattern=SKILL_NAME_RE, max_length=64)
+
+
+SkillInput = InlineSkill | GithubSkill | dict[str, Any]
+
+
 class Networking(_Model):
     """Networking config on an environment.
 

--- a/clients/python/src/aod/resources/environments.py
+++ b/clients/python/src/aod/resources/environments.py
@@ -4,6 +4,7 @@ from typing import Any
 from uuid import UUID
 
 import httpx
+from pydantic import BaseModel
 
 from .._http import check_response
 from ..models import Environment, EnvironmentVersion, Networking, NetworkingInput

--- a/clients/python/src/aod/resources/sessions.py
+++ b/clients/python/src/aod/resources/sessions.py
@@ -9,6 +9,7 @@ from typing import Any
 from uuid import UUID
 
 import httpx
+from pydantic import BaseModel
 
 from .._http import check_response
 from ..models import (


### PR DESCRIPTION
## Summary

Rolling omnibus PR for the Python SDK improvement series. Force-pushed each iteration as `main + (all open feature branches merged in)`.

Read this PR's diff for the cumulative picture; click through to each component PR for focused review.

## Component PRs

- [x] #291 — thoughts: aod-sdk improvement backlog
- [x] #294 — sdk(python): typed McpServer request models
- [x] #297 — sdk(python): typed Skill request models
- [x] #298 — sdk(python): typed GithubRepoResource for session create
- [x] #299 — sdk(python): typed Networking input for environments
- [x] #300 — sdk(python): sessions.run helper — create + stream + collect
- [x] #302 — docs(openapi): sync stale fields with live API
- [x] #303 — sdk(python): sessions.wait_for_completion for existing sessions
- [x] #304 — sdk(python): send Last-Event-ID header on stream resume
- [x] #308 — sdk(python): sessions.stream_resumable — auto-reconnect on drop
- [x] #312 — sdk(python): aod.pretty.formatter_for + GenericFormatter fallback

## Test plan

- [x] \`pytest\` — 106 pass after merging all components (was 59 on main)
- [x] \`ruff check\` clean
- [ ] Each component PR is independently mergeable; this branch goes away once all components land