### PR TITLE
fix(ts-sdk): allow environment_id=null on agent update to detach env

### DIFF
--- a/clients/typescript/src/resources/agents.ts
+++ b/clients/typescript/src/resources/agents.ts
@@ -20,7 +20,8 @@ export interface AgentUpdateParams {
   runtime?: string;
   system?: string;
   description?: string;
-  environment_id?: string;
+  // Pass `null` to detach the current environment from the agent.
+  environment_id?: string | null;
   skills?: Record<string, unknown>[];
   mcp_servers?: McpServer[];
   metadata?: Record<string, unknown>;

--- a/clients/typescript/tests/agents.test.ts
+++ b/clients/typescript/tests/agents.test.ts
@@ -49,6 +49,22 @@ describe("agents", () => {
     expect(server.requests[0]?.body).toEqual({ version: 1, name: "renamed" });
   });
 
+  it("forwards environment_id=null to detach an env", async () => {
+    const server = new MockServer();
+    const agentId = "a1";
+    server.json(
+      "PUT",
+      `/agents/${agentId}`,
+      200,
+      makeAgent({ id: agentId, version: 2, environment_id: null }),
+    );
+    await newClient(server).agents.update(agentId, {
+      version: 1,
+      environment_id: null,
+    });
+    expect(server.requests[0]?.body).toEqual({ version: 1, environment_id: null });
+  });
+
   it("surfaces 409 as ConflictError on stale version", async () => {
     const server = new MockServer();
     server.json("PUT", "/agents/a1", 409, { detail: "stale version" });


### PR DESCRIPTION
## Summary
- The API supports `PUT /agents/{id}` with `environment_id: null` to detach an agent's environment (pinned by `tests/test_agents.py::test_update_agent_environment_id_null_detaches`).
- TS SDK typed `AgentUpdateParams.environment_id?: string`, so a typed caller couldn't request a detach without `as any`.
- Runtime already passes `null` through (`stripUndefined` only filters `undefined`), so this is a types-only fix plus a regression test.

## Test plan
- [x] `npm test` (29 tests pass; new test asserts `environment_id: null` reaches the wire)
- [x] `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)