### PR TITLE
sdk(python): sessions.wait_for_completion for existing sessions

### DIFF
--- a/clients/python/src/aod/resources/sessions.py
+++ b/clients/python/src/aod/resources/sessions.py
@@ -308,8 +308,6 @@ class AsyncSessions:
         """See `Sessions.wait_for_completion` — async variant. `on_event`
         may be sync or async.
         """
-        import inspect
-
         events: list[StreamEvent] = []
         async with self.stream(session_id, since=since) as stream:
             async for event in stream:

--- a/clients/python/src/aod/resources/sessions.py
+++ b/clients/python/src/aod/resources/sessions.py
@@ -166,8 +166,28 @@ class Sessions:
             timeout=timeout,
             resources=resources,
         )
+        return self.wait_for_completion(
+            ack.id, on_event=on_event, collect_events=collect_events
+        )
+
+    def wait_for_completion(
+        self,
+        session_id: str | UUID,
+        *,
+        since: int | None = None,
+        on_event: Callable[[StreamEvent], None] | None = None,
+        collect_events: bool = True,
+    ) -> RunResult:
+        """Stream an existing session until the first terminal event
+        (`exit`, `error`, `terminated`), then return its final record.
+
+        Useful when sessions are kicked off elsewhere (different process,
+        another caller, prior `create()` you didn't await) and you want
+        to block on completion. Pass `since=<event id>` to resume from
+        a known cursor instead of replaying the full log.
+        """
         events: list[StreamEvent] = []
-        with self.stream(ack.id) as stream:
+        with self.stream(session_id, since=since) as stream:
             for event in stream:
                 if on_event is not None:
                     on_event(event)
@@ -175,7 +195,7 @@ class Sessions:
                     events.append(event)
                 if event.type in TERMINAL_EVENT_TYPES:
                     break
-        session = self.get(ack.id)
+        session = self.get(session_id)
         return RunResult(session=session, events=events)
 
 
@@ -273,8 +293,25 @@ class AsyncSessions:
             timeout=timeout,
             resources=resources,
         )
+        return await self.wait_for_completion(
+            ack.id, on_event=on_event, collect_events=collect_events
+        )
+
+    async def wait_for_completion(
+        self,
+        session_id: str | UUID,
+        *,
+        since: int | None = None,
+        on_event: Callable[[StreamEvent], Awaitable[None] | None] | None = None,
+        collect_events: bool = True,
+    ) -> RunResult:
+        """See `Sessions.wait_for_completion` — async variant. `on_event`
+        may be sync or async.
+        """
+        import inspect
+
         events: list[StreamEvent] = []
-        async with self.stream(ack.id) as stream:
+        async with self.stream(session_id, since=since) as stream:
             async for event in stream:
                 if on_event is not None:
                     result = on_event(event)
@@ -284,5 +321,5 @@ class AsyncSessions:
                     events.append(event)
                 if event.type in TERMINAL_EVENT_TYPES:
                     break
-        session = await self.get(ack.id)
+        session = await self.get(session_id)
         return RunResult(session=session, events=events)

--- a/clients/python/tests/test_sessions.py
+++ b/clients/python/tests/test_sessions.py
@@ -470,3 +470,44 @@ async def test_async_wait_for_completion(async_client, server, make_session):
 
     assert result.session.status == "terminated"
     assert [e.type for e in result.events] == ["start", "terminated"]
+
+
+async def test_async_wait_for_completion_supports_async_on_event(
+    async_client, server, make_session
+):
+    sid = str(uuid4())
+    server.register(
+        "GET",
+        f"/sessions/{sid}/stream",
+        _stream_responder([b'{"type":"start"}', b'{"type":"exit","id":1,"exit_code":0}']),
+    )
+    server.json("GET", f"/sessions/{sid}", 200, make_session(id=sid))
+
+    seen = []
+
+    async def on_event(e):
+        seen.append(e.type)
+
+    async with async_client as c:
+        result = await c.sessions.wait_for_completion(sid, on_event=on_event)
+
+    assert seen == ["start", "exit"]
+    assert [e.type for e in result.events] == ["start", "exit"]
+
+
+async def test_async_wait_for_completion_collect_events_false(
+    async_client, server, make_session
+):
+    sid = str(uuid4())
+    server.register(
+        "GET",
+        f"/sessions/{sid}/stream",
+        _stream_responder([b'{"type":"start"}', b'{"type":"exit","id":1,"exit_code":0}']),
+    )
+    server.json("GET", f"/sessions/{sid}", 200, make_session(id=sid))
+
+    async with async_client as c:
+        result = await c.sessions.wait_for_completion(sid, collect_events=False)
+
+    assert result.events == []
+    assert result.session.id is not None

--- a/clients/python/tests/test_sessions.py
+++ b/clients/python/tests/test_sessions.py
@@ -400,3 +400,73 @@ async def test_async_run_supports_async_on_event(async_client, server, make_sess
         await c.sessions.run(agent_id=uuid4(), prompt="x", on_event=on_event)
 
     assert seen == ["start", "exit"]
+
+
+def test_wait_for_completion_streams_existing_session(client, server, make_session):
+    """Caller has a session id from elsewhere — block until terminal."""
+    sid = str(uuid4())
+    server.register(
+        "GET",
+        f"/sessions/{sid}/stream",
+        _stream_responder(
+            [
+                b'{"type":"start"}',
+                b'{"type":"output","id":1,"data":"hi"}',
+                b'{"type":"exit","id":2,"exit_code":0}',
+            ]
+        ),
+    )
+    server.json(
+        "GET", f"/sessions/{sid}", 200, make_session(id=sid, status="completed", exit_code=0)
+    )
+
+    result = client.sessions.wait_for_completion(sid)
+
+    assert result.session.status == "completed"
+    assert [e.type for e in result.events] == ["start", "output", "exit"]
+
+
+def test_wait_for_completion_passes_since(client, server, make_session):
+    sid = str(uuid4())
+    server.register(
+        "GET",
+        f"/sessions/{sid}/stream",
+        _stream_responder([b'{"type":"exit","id":11,"exit_code":0}']),
+    )
+    server.json("GET", f"/sessions/{sid}", 200, make_session(id=sid))
+
+    client.sessions.wait_for_completion(sid, since=10)
+
+    stream_request = next(r for r in server.requests if "/stream" in r.path)
+    assert stream_request.params.get("since") == ["10"]
+
+
+def test_wait_for_completion_calls_on_event(client, server, make_session):
+    sid = str(uuid4())
+    server.register(
+        "GET",
+        f"/sessions/{sid}/stream",
+        _stream_responder([b'{"type":"start"}', b'{"type":"exit","id":1,"exit_code":0}']),
+    )
+    server.json("GET", f"/sessions/{sid}", 200, make_session(id=sid))
+
+    seen = []
+    client.sessions.wait_for_completion(sid, on_event=lambda e: seen.append(e.type))
+
+    assert seen == ["start", "exit"]
+
+
+async def test_async_wait_for_completion(async_client, server, make_session):
+    sid = str(uuid4())
+    server.register(
+        "GET",
+        f"/sessions/{sid}/stream",
+        _stream_responder([b'{"type":"start"}', b'{"type":"terminated","id":1}']),
+    )
+    server.json("GET", f"/sessions/{sid}", 200, make_session(id=sid, status="terminated"))
+
+    async with async_client as c:
+        result = await c.sessions.wait_for_completion(sid)
+
+    assert result.session.status == "terminated"
+    assert [e.type for e in result.events] == ["start", "terminated"]


### PR DESCRIPTION
## Summary

Companion to #300. The streaming-loop core of \`sessions.run\` is also useful for sessions kicked off elsewhere — fan out a batch via \`create()\`, then block on each via \`wait_for_completion(session_id)\`.

\`\`\`python
ack = client.sessions.create(...)
# ... do other work ...
result = client.sessions.wait_for_completion(ack.id)
\`\`\`

- Refactor \`run\` to delegate to \`wait_for_completion\` (no duplicated stream loop)
- \`since=<event id>\` for resume-from-cursor instead of replaying
- Sync + async; \`on_event\` may be sync or async on the async client

**Stacked on #300** — review/merge that one first. Once it's in I can rebase this onto main.

Part of the [SDK improvement backlog](https://github.com/ravi-hq/agent-on-demand/pull/291) — item 6 of 14.

## Test plan

- [x] \`pytest\` — 69 pass (was 65 on #300; four new tests cover the new helper sync + async, since param, on_event)
- [x] \`ruff check\` clean