### PR TITLE
sdk(python): send Last-Event-ID header on stream resume

### DIFF
--- a/clients/python/src/aod/resources/sessions.py
+++ b/clients/python/src/aod/resources/sessions.py
@@ -67,6 +67,20 @@ def _stream_params(since: int | None) -> dict[str, Any]:
     return {"since": since} if since is not None else {}
 
 
+def _stream_headers(since: int | None) -> dict[str, str]:
+    """Build the request headers for `GET /sessions/{id}/stream`.
+
+    `Last-Event-ID` is the standard SSE resume header. The server reads
+    either it or the `?since=` query parameter; sending the header too
+    makes resume work transparently when an intermediary strips query
+    params (some SSE-aware proxies do).
+    """
+    headers = {"Accept": "text/event-stream"}
+    if since is not None:
+        headers["Last-Event-ID"] = str(since)
+    return headers
+
+
 class Sessions:
     def __init__(self, client: httpx.Client) -> None:
         self._client = client
@@ -131,7 +145,7 @@ class Sessions:
             "GET",
             f"/sessions/{session_id}/stream",
             params=_stream_params(since),
-            headers={"Accept": "text/event-stream"},
+            headers=_stream_headers(since),
         ) as response:
             yield iter_sse(response)
 
@@ -267,7 +281,7 @@ class AsyncSessions:
             "GET",
             f"/sessions/{session_id}/stream",
             params=_stream_params(since),
-            headers={"Accept": "text/event-stream"},
+            headers=_stream_headers(since),
         ) as response:
             yield aiter_sse(response)
 

--- a/clients/python/tests/test_sessions.py
+++ b/clients/python/tests/test_sessions.py
@@ -156,6 +156,64 @@ def test_stream_passes_since_param(client, server):
 
     assert collected[0].type == "start"
     assert server.requests[-1].params.get("since") == ["42"]
+    # Standard SSE resume header — sent alongside ?since= so resume works
+    # even if an intermediary strips query params.
+    assert server.requests[-1].headers.get("last-event-id") == "42"
+
+
+def test_stream_no_since_omits_last_event_id(client, server):
+    sid = str(uuid4())
+
+    def responder(request):
+        import httpx
+
+        body = b'data: {"type":"start"}\n\n'
+        return httpx.Response(200, content=body, headers={"content-type": "text/event-stream"})
+
+    server.register("GET", f"/sessions/{sid}/stream", responder)
+
+    with client.sessions.stream(sid) as events:
+        list(events)
+
+    assert "last-event-id" not in {k.lower() for k in server.requests[-1].headers}
+
+
+@pytest.mark.asyncio
+async def test_async_stream_sends_last_event_id(async_client, server):
+    sid = str(uuid4())
+
+    def responder(request):
+        import httpx
+
+        body = b'data: {"type":"start"}\n\n'
+        return httpx.Response(200, content=body, headers={"content-type": "text/event-stream"})
+
+    server.register("GET", f"/sessions/{sid}/stream", responder)
+
+    async with async_client.sessions.stream(sid, since=7) as events:
+        async for _ in events:
+            break
+
+    assert server.requests[-1].headers.get("last-event-id") == "7"
+
+
+@pytest.mark.asyncio
+async def test_async_stream_no_since_omits_last_event_id(async_client, server):
+    sid = str(uuid4())
+
+    def responder(request):
+        import httpx
+
+        body = b'data: {"type":"start"}\n\n'
+        return httpx.Response(200, content=body, headers={"content-type": "text/event-stream"})
+
+    server.register("GET", f"/sessions/{sid}/stream", responder)
+
+    async with async_client.sessions.stream(sid) as events:
+        async for _ in events:
+            break
+
+    assert "last-event-id" not in {k.lower() for k in server.requests[-1].headers}
 
 
 def test_create_with_typed_github_resource(client, server):


### PR DESCRIPTION
## Summary

The server reads either \`Last-Event-ID\` or \`?since=\` and prefers the header (per the openapi spec). The SDK was sending only the query param; some SSE-aware proxies strip query params on long-lived streams, so sending both makes resume work transparently end-to-end.

When \`since\` is \`None\` the header is omitted — same behavior as before.

Part of the [SDK improvement backlog](https://github.com/ravi-hq/agent-on-demand/pull/291) — item 7 of 14.

## Test plan

- [x] \`pytest\` — 61 pass (was 59; two new tests cover header-set-when-since and header-omitted-when-no-since, plus async)
- [x] \`ruff check\` clean