### PR TITLE
fix(ts-sdk): timeoutMs must cover body read, not just connect

### DIFF
--- a/clients/typescript/src/http.ts
+++ b/clients/typescript/src/http.ts
@@ -74,16 +74,16 @@ export class HttpClient {
     const signal = linkSignal(controller, opts.signal);
     init.signal = signal;
 
-    let response: Response;
+    // Keep the timer covering parseBody too — fetch resolves once headers
+    // arrive, so a slow body would otherwise read forever.
     try {
-      response = await this.fetchFn(url, init);
+      const response = await this.fetchFn(url, init);
+      const body = await parseBody(response);
+      raiseForStatus(response.status, body, method, url);
+      return body as T;
     } finally {
       clearTimeout(timeoutId);
     }
-
-    const body = await parseBody(response);
-    raiseForStatus(response.status, body, method, url);
-    return body as T;
   }
 
   async rawStream(

--- a/clients/typescript/tests/client.test.ts
+++ b/clients/typescript/tests/client.test.ts
@@ -69,6 +69,36 @@ describe("Client", () => {
     expect(server.requests[0]?.headers["user-agent"]).toBe(`aod-sdk-ts/${VERSION}`);
   });
 
+  it("aborts when reading the body exceeds timeoutMs", async () => {
+    // Pre-fix, fetch resolved on headers and the body read had no timer,
+    // so a slow body would hang the caller for as long as the server held
+    // the connection open. Pin: timeoutMs covers parseBody too.
+    const fetchFn: typeof fetch = (_input, init) => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          init?.signal?.addEventListener("abort", () => {
+            controller.error(new DOMException("aborted", "AbortError"));
+          });
+        },
+      });
+      return Promise.resolve(
+        new Response(stream, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    };
+    const client = new Client({
+      baseUrl: "http://mock",
+      token: "aod_test",
+      fetch: fetchFn,
+      timeoutMs: 50,
+    });
+    const start = Date.now();
+    await expect(client.agents.list()).rejects.toBeDefined();
+    expect(Date.now() - start).toBeLessThan(2000);
+  });
+
   it("strips trailing slash from baseUrl", async () => {
     const server = new MockServer();
     server.json("GET", "/health", 200, { status: "ok" });

--- a/clients/typescript/tests/client.test.ts
+++ b/clients/typescript/tests/client.test.ts
@@ -95,7 +95,7 @@ describe("Client", () => {
       timeoutMs: 50,
     });
     const start = Date.now();
-    await expect(client.agents.list()).rejects.toBeDefined();
+    await expect(client.agents.list()).rejects.toMatchObject({ name: "AbortError" });
     expect(Date.now() - start).toBeLessThan(2000);
   });
 


### PR DESCRIPTION
## Summary
- `fetch()` resolves on the response headers — the body is still streaming. The current `try { fetchFn() } finally { clearTimeout }` cleared the timer **before** `parseBody()` reads the body, so a server that sends headers fast but the body slowly hangs the caller for the full connection lifetime.
- Move `clearTimeout` to wrap both the fetch call **and** `parseBody`. `init.signal` already abort-links to the timer, so a timer fire during body read aborts the read.
- Regression test uses a custom `fetch` whose body stream errors on signal abort + a 50ms timeout. Pre-fix the test's `expect(...).rejects.toBeDefined()` would have timed out vitest's default 5s.

## Test plan
- [x] `npm test` (29 tests; new test added)
- [x] `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)