### PR TITLE
docs(deploy): fix stale model names in FIELD_ENCRYPTION_KEY description

### DIFF
--- a/site/docs/operators/deploy.md
+++ b/site/docs/operators/deploy.md
@@ -26,7 +26,7 @@ sourced from `src/config/settings.py`:
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `DJANGO_SECRET_KEY` | Yes (prod) | `dev-insecure-key-change-in-prod` | Django secret key for session signing — safe to rotate |
-| `FIELD_ENCRYPTION_KEY` | Yes (prod) | Falls back to `DJANGO_SECRET_KEY` | KEK for encrypted `UserSpritesKey` / `UserRuntimeKey` rows — **durable; rotating requires a re-encrypt migration** |
+| `FIELD_ENCRYPTION_KEY` | Yes (prod) | Falls back to `DJANGO_SECRET_KEY` | KEK for encrypted `UserBackendCredential` / `UserCredential` rows — **durable; rotating requires a re-encrypt migration** |
 | `DJANGO_DEBUG` | No | `true` | Set to `false` in production |
 | `DJANGO_ALLOWED_HOSTS` | No | `*` | Comma-separated list of allowed host headers |
 | `DATABASE_URL` | Yes | `postgres://agent_on_demand:agent_on_demand@localhost:5460/agent_on_demand` (matches `make db-up`) | Postgres DSN parsed by `dj-database-url`. Postgres is required — SQLite is only used by the test suite. |


### PR DESCRIPTION
## What was wrong

The `FIELD_ENCRYPTION_KEY` row in the deploy guide's env-vars table said:

> KEK for encrypted `UserSpritesKey` / `UserRuntimeKey` rows

Both model names are stale. `UserRuntimeKey` was deleted by migration `0016_runtime_redesign` and replaced by `UserCredential`. `UserSpritesKey` was deleted by migration `0021_drop_user_sprites_key` and replaced by `UserBackendCredential`.

An operator reading this description and then searching the codebase would find neither model.

`settings.py` already has the correct names in its own inline comment:

```python
# Dedicated KEK for encrypted model fields (UserBackendCredential, UserCredential). Split
# from SECRET_KEY so session-signing keys can be rotated independently …
FIELD_ENCRYPTION_KEY = os.environ.get("FIELD_ENCRYPTION_KEY")
```

## What changed

One word substitution in `site/docs/operators/deploy.md`: `UserSpritesKey` / `UserRuntimeKey` → `UserBackendCredential` / `UserCredential`.

## How I verified

- Checked migrations `0016` and `0021` confirm both old models were deleted.
- `settings.py` line 11 already uses the correct names.
- `cd site && mkdocs build` — 0.75 s, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)