### PR TITLE
docs(deploy): document DEFAULT_MAX_CONCURRENT_SESSIONS env var

### DIFF
--- a/site/docs/operators/deploy.md
+++ b/site/docs/operators/deploy.md
@@ -33,6 +33,7 @@ sourced from `src/config/settings.py`:
 | `SPRITES_BASE_URL` | No | `https://api.sprites.dev` | Override the Sprites API base URL |
 | `SPRITE_NAME_PREFIX` | No | `aod` | Prefix applied to all Sprite names created by this instance |
 | `DEFAULT_TIMEOUT` | No | `600` | Default session timeout in seconds |
+| `DEFAULT_MAX_CONCURRENT_SESSIONS` | No | `100` | Per-user cap on concurrent (`pending` + `running`) sessions. Raise or lower per user via `UserQuota.max_concurrent_sessions` in the Django shell. |
 
 A minimal production `.env`:
 

--- a/site/docs/operators/deploy.md
+++ b/site/docs/operators/deploy.md
@@ -44,6 +44,25 @@ DJANGO_DEBUG=false
 DJANGO_ALLOWED_HOSTS=aod.example.com
 ```
 
+### Per-user concurrent-session overrides
+
+`DEFAULT_MAX_CONCURRENT_SESSIONS` sets the cap for every user. To raise or lower
+the cap for a specific user, write a `UserQuota` row from the Django shell:
+
+```python
+from agent_on_demand.models import UserQuota
+from django.contrib.auth.models import User
+
+user = User.objects.get(username="alice")
+quota, _ = UserQuota.objects.get_or_create(user=user)
+quota.max_concurrent_sessions = 10  # set to None to fall back to DEFAULT_MAX_CONCURRENT_SESSIONS
+quota.save()
+```
+
+`UserQuota.max_concurrent_sessions = None` (the default for newly-created rows)
+falls back to `DEFAULT_MAX_CONCURRENT_SESSIONS`, so resetting an override is a
+field assignment — not a row delete.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds the missing `DEFAULT_MAX_CONCURRENT_SESSIONS` row to the environment variables table in `site/docs/operators/deploy.md`
- The variable has been enforced in `src/config/settings.py` (default `100`) since the quota system shipped, but was never documented for operators
- Description matches what the code actually does: per-user cap on `pending + running` sessions, adjustable per user via `UserQuota.max_concurrent_sessions` in the Django shell

## Test plan

- [ ] Verify the table row renders correctly in MkDocs
- [ ] Confirm the default (`100`) matches `settings.py`
- [ ] Confirm the `UserQuota` shell note is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)