### PR TITLE
docs(landing): add missing turn_start event to SSE demo

### DIFF
--- a/src/agent_on_demand/templates/ui/landing.html
+++ b/src/agent_on_demand/templates/ui/landing.html
@@ -51,6 +51,8 @@
 <span class="c-mute">id: 1</span>
 <span class="c-evt">data:</span> <span class="c-str">{"type":"stage","id":1,"stage":"create_sprite","state":"done","duration_ms":3820}</span>
 
+<span class="c-evt">data:</span> <span class="c-str">{"type":"turn_start","id":2,"turn":1}</span>
+
 <span class="c-mute">id: 2</span>
 <span class="c-evt">data:</span> <span class="c-str">{"type":"output","id":2,"stream":"stdout","data":"Reading src/payments.py…","turn":1}</span>
 


### PR DESCRIPTION
## Summary

- The marketing page terminal demo was missing the `turn_start` event between the last `stage` event and the first `output` event
- Per the [Streaming reference](https://ravi-hq.github.io/agent-on-demand/api/streaming/), `turn_start` is always emitted before the first `output` event of each turn, shares the same `id` as the following `output` event, and deliberately carries no SSE `id:` line (to avoid advancing `Last-Event-ID` prematurely)
- Developers using the demo as a reference to build clients would not expect `turn_start` and could break on reconnect

## Before / after

**Before** (skips `turn_start`):
```
id: 1
data: {"type":"stage","id":1,"stage":"create_sprite","state":"done","duration_ms":3820}

id: 2
data: {"type":"output","id":2,"stream":"stdout","data":"Reading src/payments.py…","turn":1}
```

**After** (matches spec):
```
id: 1
data: {"type":"stage","id":1,"stage":"create_sprite","state":"done","duration_ms":3820}

data: {"type":"turn_start","id":2,"turn":1}

id: 2
data: {"type":"output","id":2,"stream":"stdout","data":"Reading src/payments.py…","turn":1}
```

## Test plan

- [ ] Verify the landing page terminal demo renders correctly
- [ ] Confirm `turn_start` has no `id:` SSE prefix (per spec) and shares `id:2` with the following output event

🤖 Generated with [Claude Code](https://claude.com/claude-code)