### PR TITLE
fix(ts-sdk): remove abort listener from external signal after each request

### DIFF
--- a/clients/typescript/src/http.ts
+++ b/clients/typescript/src/http.ts
@@ -71,7 +71,7 @@ export class HttpClient {
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
-    const signal = linkSignal(controller, opts.signal);
+    const { signal, cleanup } = linkSignal(controller, opts.signal);
     init.signal = signal;
 
     // Keep the timer covering parseBody too — fetch resolves once headers
@@ -83,6 +83,7 @@ export class HttpClient {
       return body as T;
     } finally {
       clearTimeout(timeoutId);
+      cleanup();
     }
   }
 
@@ -134,19 +135,24 @@ function buildQueryString(query?: Record<string, unknown>): string {
   return count === 0 ? "" : `?${params.toString()}`;
 }
 
-function linkSignal(
+// Without explicit removal, the listener (closing over `controller`) leaks
+// for as long as `external` lives — a real issue when callers reuse one
+// AbortController across many requests. The returned `cleanup` removes the
+// listener on every exit path.
+export function linkSignal(
   controller: AbortController,
   external?: AbortSignal,
-): AbortSignal {
-  if (!external) return controller.signal;
+): { signal: AbortSignal; cleanup: () => void } {
+  const noop = () => {};
+  if (!external) return { signal: controller.signal, cleanup: noop };
   if (external.aborted) {
     controller.abort(external.reason);
-    return controller.signal;
+    return { signal: controller.signal, cleanup: noop };
   }
-  external.addEventListener(
-    "abort",
-    () => controller.abort(external.reason),
-    { once: true },
-  );
-  return controller.signal;
+  const onAbort = () => controller.abort(external.reason);
+  external.addEventListener("abort", onAbort);
+  return {
+    signal: controller.signal,
+    cleanup: () => external.removeEventListener("abort", onAbort),
+  };
 }

--- a/clients/typescript/src/resources/sessions.ts
+++ b/clients/typescript/src/resources/sessions.ts
@@ -1,4 +1,4 @@
-import type { HttpClient } from "../http.js";
+import { linkSignal, type HttpClient } from "../http.js";
 import { createStreamHandle, type StreamHandle } from "../stream.js";
 import type {
   Session,
@@ -101,13 +101,13 @@ export class Sessions {
     opts: SessionStreamOptions = {},
   ): Promise<StreamHandle> {
     const controller = new AbortController();
-    const signal = linkSignal(controller, opts.signal);
+    const { signal, cleanup } = linkSignal(controller, opts.signal);
     const query = opts.since !== undefined ? { since: opts.since } : undefined;
     const { response, url } = await this.http.rawStream(
       `/sessions/${sessionId}/stream`,
       { query, signal },
     );
-    return createStreamHandle(response, url, controller);
+    return createStreamHandle(response, url, controller, cleanup);
   }
 }
 
@@ -117,21 +117,4 @@ function stripUndefined<T extends object>(obj: T): Partial<T> {
     if (v !== undefined) out[k] = v;
   }
   return out as Partial<T>;
-}
-
-function linkSignal(
-  controller: AbortController,
-  external?: AbortSignal,
-): AbortSignal {
-  if (!external) return controller.signal;
-  if (external.aborted) {
-    controller.abort(external.reason);
-    return controller.signal;
-  }
-  external.addEventListener(
-    "abort",
-    () => controller.abort(external.reason),
-    { once: true },
-  );
-  return controller.signal;
 }

--- a/clients/typescript/src/stream.ts
+++ b/clients/typescript/src/stream.ts
@@ -9,24 +9,28 @@ export function createStreamHandle(
   response: Response,
   url: string,
   controller: AbortController,
+  onClose: () => void = () => {},
 ): StreamHandle {
   // Releasing the reader's lock leaves the response body unconsumed; the
   // socket can outlive the for-await loop unless we abort the fetch. Run
   // abort on every iteration-end path (natural completion, break, throw,
-  // or explicit close) and guard it with an idempotency flag.
-  let aborted = false;
-  const abortOnce = () => {
-    if (aborted) return;
-    aborted = true;
+  // or explicit close) and guard it with an idempotency flag. `onClose`
+  // is the caller-supplied cleanup (e.g. removing the abort listener
+  // from an external signal) that must also fire exactly once.
+  let closed = false;
+  const closeOnce = () => {
+    if (closed) return;
+    closed = true;
     controller.abort();
+    onClose();
   };
-  const iterator = iterateSSE(response, url, abortOnce);
+  const iterator = iterateSSE(response, url, closeOnce);
   return {
     [Symbol.asyncIterator]() {
       return iterator;
     },
     async close() {
-      abortOnce();
+      closeOnce();
       try {
         await iterator.return?.(undefined);
       } catch {

--- a/clients/typescript/tests/client.test.ts
+++ b/clients/typescript/tests/client.test.ts
@@ -46,6 +46,40 @@ describe("Client", () => {
     expect(server.requests[0]?.headers["authorization"]).toBe("Bearer aod_test");
   });
 
+  it("removes its abort listener from the external signal after each request", async () => {
+    // Pre-fix, every completed request left a closure-capturing `abort`
+    // listener on the external signal. Long-lived signals (e.g. a global
+    // cancel-all controller) accumulated listeners — and the per-request
+    // AbortControllers they pinned — across the lifetime of the signal.
+    const server = new MockServer();
+    server.json("GET", "/agents", 200, { data: [] });
+    const real = new AbortController();
+    let added = 0;
+    let removed = 0;
+    const fakeSignal = {
+      aborted: false,
+      reason: undefined,
+      addEventListener: (type: string, listener: EventListener, opts?: AddEventListenerOptions) => {
+        added++;
+        real.signal.addEventListener(type, listener, opts);
+      },
+      removeEventListener: (type: string, listener: EventListener) => {
+        removed++;
+        real.signal.removeEventListener(type, listener);
+      },
+    } as unknown as AbortSignal;
+    const client = new Client({
+      baseUrl: "http://mock",
+      token: "aod_test",
+      fetch: server.fetch,
+    });
+    await client.agents.list({ signal: fakeSignal });
+    await client.agents.list({ signal: fakeSignal });
+    await client.agents.list({ signal: fakeSignal });
+    expect(added).toBe(3);
+    expect(removed).toBe(3);
+  });
+
   it("returns health payload", async () => {
     const server = new MockServer();
     server.json("GET", "/health", 200, { status: "ok" });

--- a/clients/typescript/tests/stream.test.ts
+++ b/clients/typescript/tests/stream.test.ts
@@ -107,6 +107,49 @@ describe("stream", () => {
     await stream.close();
   });
 
+  it("removes its abort listener from the external signal after the stream closes", async () => {
+    // Mirrors the non-streaming listener-leak guarantee in client.test.ts.
+    // sessions.stream goes through linkSignal too, so a long-lived external
+    // signal must not accumulate one listener per opened stream.
+    const server = new MockServer();
+    const sid = uuid();
+    server.register("GET", `/sessions/${sid}/stream`, () => {
+      const body = 'data: {"type":"start"}\n\n';
+      return new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    });
+    const real = new AbortController();
+    let added = 0;
+    let removed = 0;
+    const fakeSignal = {
+      aborted: false,
+      reason: undefined,
+      addEventListener: (
+        type: string,
+        listener: EventListener,
+        opts?: AddEventListenerOptions,
+      ) => {
+        added++;
+        real.signal.addEventListener(type, listener, opts);
+      },
+      removeEventListener: (type: string, listener: EventListener) => {
+        removed++;
+        real.signal.removeEventListener(type, listener);
+      },
+    } as unknown as AbortSignal;
+
+    const stream = await newClient(server).sessions.stream(sid, { signal: fakeSignal });
+    for await (const _ of stream) {
+      break;
+    }
+    await stream.close();
+
+    expect(added).toBe(1);
+    expect(removed).toBe(1);
+  });
+
   it("aborts the underlying fetch when the iteration ends without close()", async () => {
     // Pre-fix, breaking out of `for await` only released the reader's lock —
     // the fetch's underlying connection stayed open until socket idle-out.


### PR DESCRIPTION
## Summary
- `linkSignal` registered an `abort` listener on the caller's signal with `{ once: true }`. That option auto-removes the listener **only after it fires** — if the external signal never aborts (the common case), each completed request leaves the closure pinning the per-request `AbortController`.
- For a long-lived signal — e.g. a global cancel-all controller, or one passed to many sequential calls — listeners (and the per-request controllers they captured) accumulate across the signal's lifetime.
- Refactor `linkSignal` to return `{ signal, cleanup }`. Both the unary HTTP path and the streaming path call cleanup on completion (success, thrown error, or `stream.close()`).
- Also dedupes the second copy of `linkSignal` that lived in `resources/sessions.ts`.

## Test plan
- [x] `npm test` — added a regression that runs 3 sequential requests against a fake signal that counts add/remove pairs, asserts 3 adds and 3 removes.
- [x] `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)