### PR TITLE
docs(runtimes): fix API key supply section — UserCredential is primary

### DIFF
--- a/site/docs/api/runtimes.md
+++ b/site/docs/api/runtimes.md
@@ -52,8 +52,8 @@ matching user credential — useful for pinning a specific key to one environmen
 testing. `env_vars` are encrypted at rest and never echoed back in API responses.
 See [Core Concepts → Environments](concepts.md#environments) for the full shape.
 
-If the user has no credential configured for the runtime's provider, and the attached
-environment doesn't supply the expected env var either, the CLI will fail on startup and
+If the user has no credential configured for the runtime's provider, and no attached
+environment supplies the expected env var either, the CLI will fail on startup and
 the session will transition to `failed`.
 
 ## Per-runtime notes

--- a/site/docs/api/runtimes.md
+++ b/site/docs/api/runtimes.md
@@ -41,27 +41,20 @@ model's provider — mismatched pairs (e.g. an OpenAI model with the `claude` ru
 
 ## Supplying API keys
 
-Each runtime reads its API key from a specific env var at session start. On the hosted API
-(`aod.ravi.id`) you register credentials once via the dashboard; they are stored encrypted
-and injected into every session you own.
+Each runtime reads its API key from a specific env var at session start. Credentials are
+stored per-user, encrypted at rest, and injected automatically into every session. On the
+hosted API (`aod.ravi.id`) you register them once via the dashboard. When self-hosting,
+set them via the Django shell — see
+[Deploy → Sprites credentials](../operators/deploy.md#sprites-credentials).
 
-When self-hosting, set the env var on the session's **environment**:
-
-```bash
-curl -X POST https://aod.ravi.id/environments \
-  -H "Authorization: Bearer $AOD_API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "with-anthropic-key",
-    "env_vars": {"ANTHROPIC_API_KEY": "sk-ant-..."}
-  }'
-```
-
-`env_vars` are encrypted at rest and never echoed back in API responses.
+`env_vars` on an environment are also sourced into the session and **override** any
+matching user credential — useful for pinning a specific key to one environment or for
+testing. `env_vars` are encrypted at rest and never echoed back in API responses.
 See [Core Concepts → Environments](concepts.md#environments) for the full shape.
 
-If no environment is attached to a session, or the environment doesn't set the runtime's
-expected env var, the CLI will fail on startup and the session will transition to `failed`.
+If the user has no credential configured for the runtime's provider, and the attached
+environment doesn't supply the expected env var either, the CLI will fail on startup and
+the session will transition to `failed`.
 
 ## Per-runtime notes
 


### PR DESCRIPTION
## Summary

- The "Supplying API keys" section in `site/docs/api/runtimes.md` told self-hosters to inject API keys via environment `env_vars`, as if that were the only mechanism — it ignored `UserCredential` rows entirely
- In practice, credentials are stored per-user as `UserCredential` rows (via the dashboard on the hosted API, or via the Django shell when self-hosting) and are injected automatically at session start by `write_env_file` in `session_service/provisioning/stages.py`
- `env_vars` on an environment do work as an override (they're sourced last and win over user credentials per the code comment), but presenting them as the self-hosting mechanism is backwards
- The failure condition sentence was also wrong: it said the session fails if "the environment doesn't set the runtime's expected env var", which ignores the `UserCredential` path

## What changed

- Replaced the "when self-hosting, create an environment with env_vars" paragraph with the accurate primary mechanism: `UserCredential` rows, linking to `deploy.md#sprites-credentials`
- Kept `env_vars` documented as an **override** mechanism (which it is), not as the only mechanism
- Fixed the failure condition to require both sources to be absent before the CLI fails

## Verified against

- `src/agent_on_demand/session_service/provisioning/stages.py` lines 90-114 — `write_env_file` reads `UserCredential.objects.filter(user=spec.user)` first, then `env.env_vars` last (overrides win)
- `site/docs/operators/deploy.md` — the canonical self-hosting credential setup steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)