### PR TITLE
sdk(python): aod.pretty.formatter_for + GenericFormatter fallback

### DIFF
--- a/clients/python/src/aod/pretty/__init__.py
+++ b/clients/python/src/aod/pretty/__init__.py
@@ -69,12 +69,15 @@ class GenericFormatter:
                 yield line
 
     def flush(self) -> Iterator[str]:
-        if self._buf.strip():
-            yield self._buf
+        # Match feed()'s \r-stripping so a trailing "dangling\r" (no \n)
+        # doesn't smuggle a stray carriage return into the last line.
+        tail = self._buf.rstrip("\r")
+        if tail.strip():
+            yield tail
         self._buf = ""
 
 
-def formatter_for(runtime: str) -> Formatter:
+def formatter_for(runtime: str | None = None) -> Formatter:
     """Return the formatter that knows how to read `runtime`'s stdout.
 
     Currently pattern-matches `runtime` against the registry of typed
@@ -84,7 +87,7 @@ def formatter_for(runtime: str) -> Formatter:
 
     Match rules (substring on the runtime name, lowercase):
       - "claude" → `ClaudeFormatter`
-      - everything else → `GenericFormatter`
+      - everything else (including `None`) → `GenericFormatter`
     """
     name = (runtime or "").lower()
     if "claude" in name:

--- a/clients/python/src/aod/pretty/__init__.py
+++ b/clients/python/src/aod/pretty/__init__.py
@@ -4,10 +4,92 @@ These helpers parse a specific runtime's stdout format into human-readable
 lines. They're intentionally not exported from the top-level `aod` namespace
 — the SDK core is runtime-agnostic; formatters are not.
 
-Currently shipped:
+The `Formatter` protocol pins the shape every formatter implements
+(`consume(event) -> Iterator[str]`, `feed(chunk) -> Iterator[str]`,
+`flush() -> Iterator[str]`); the `formatter_for(runtime)` factory picks
+the right one by runtime name and falls back to a passthrough for
+runtimes the SDK doesn't yet have a typed formatter for.
+
+Shipped today:
     - `aod.pretty.claude.ClaudeFormatter` — Claude `stream-json` output.
+    - `aod.pretty.GenericFormatter` — passthrough fallback that emits
+      stdout lines verbatim.
 """
 
+from collections.abc import Iterator
+from typing import Protocol, runtime_checkable
+
+from ..models import StreamEvent
 from .claude import ClaudeFormatter
 
-__all__ = ["ClaudeFormatter"]
+
+@runtime_checkable
+class Formatter(Protocol):
+    """Shape every runtime-specific pretty-printer implements.
+
+    `consume()` is the event-oriented entry point — pass a `StreamEvent`
+    from `client.sessions.stream(...)` and get zero or more display
+    lines back. `feed()` and `flush()` are the lower-level escape hatches
+    for callers that already extracted stdout bytes themselves.
+    """
+
+    def consume(self, event: StreamEvent) -> Iterator[str]: ...
+    def feed(self, chunk: str) -> Iterator[str]: ...
+    def flush(self) -> Iterator[str]: ...
+
+
+class GenericFormatter:
+    """Runtime-agnostic passthrough formatter.
+
+    Returned by `formatter_for(...)` when the runtime doesn't have a
+    typed formatter yet. Yields the raw stdout chunk verbatim, split on
+    newlines (so each line is one display line), with no JSON parsing.
+    Suitable for any runtime whose stdout format is human-readable text.
+    """
+
+    def __init__(self) -> None:
+        self._buf = ""
+
+    def consume(self, event: StreamEvent) -> Iterator[str]:
+        if event.type != "output":
+            return
+        if event.extra.get("stream") != "stdout":
+            return
+        data = event.extra.get("data")
+        if not isinstance(data, str):
+            return
+        yield from self.feed(data)
+
+    def feed(self, chunk: str) -> Iterator[str]:
+        self._buf += chunk
+        while "\n" in self._buf:
+            line, self._buf = self._buf.split("\n", 1)
+            line = line.rstrip("\r")
+            if line:
+                yield line
+
+    def flush(self) -> Iterator[str]:
+        if self._buf.strip():
+            yield self._buf
+        self._buf = ""
+
+
+def formatter_for(runtime: str) -> Formatter:
+    """Return the formatter that knows how to read `runtime`'s stdout.
+
+    Currently pattern-matches `runtime` against the registry of typed
+    formatters. Unknown runtimes fall back to `GenericFormatter`, which
+    emits stdout lines verbatim — useful for any runtime whose output
+    is human-readable text.
+
+    Match rules (substring on the runtime name, lowercase):
+      - "claude" → `ClaudeFormatter`
+      - everything else → `GenericFormatter`
+    """
+    name = (runtime or "").lower()
+    if "claude" in name:
+        return ClaudeFormatter()
+    return GenericFormatter()
+
+
+__all__ = ["ClaudeFormatter", "Formatter", "GenericFormatter", "formatter_for"]

--- a/clients/python/tests/test_pretty_factory.py
+++ b/clients/python/tests/test_pretty_factory.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from aod import StreamEvent
+from aod.pretty import ClaudeFormatter, Formatter, GenericFormatter, formatter_for
+
+
+def _output(data: str, *, stream: str = "stdout") -> StreamEvent:
+    return StreamEvent.from_payload({"type": "output", "id": 1, "stream": stream, "data": data})
+
+
+def test_formatter_for_claude_returns_claude_formatter():
+    assert isinstance(formatter_for("claude"), ClaudeFormatter)
+    assert isinstance(formatter_for("claude-code"), ClaudeFormatter)
+    assert isinstance(formatter_for("Claude-Code"), ClaudeFormatter)
+
+
+def test_formatter_for_unknown_returns_generic():
+    assert isinstance(formatter_for("codex"), GenericFormatter)
+    assert isinstance(formatter_for("gemini"), GenericFormatter)
+    assert isinstance(formatter_for("opencode"), GenericFormatter)
+    assert isinstance(formatter_for(""), GenericFormatter)
+
+
+def test_generic_formatter_yields_stdout_lines():
+    fmt = GenericFormatter()
+    lines = list(fmt.consume(_output("first line\nsecond line\n")))
+    assert lines == ["first line", "second line"]
+
+
+def test_generic_formatter_buffers_partial_lines():
+    fmt = GenericFormatter()
+    assert list(fmt.consume(_output("partial"))) == []
+    assert list(fmt.consume(_output(" continued\n"))) == ["partial continued"]
+
+
+def test_generic_formatter_flush_emits_unterminated():
+    fmt = GenericFormatter()
+    list(fmt.consume(_output("dangling")))
+    assert list(fmt.flush()) == ["dangling"]
+
+
+def test_generic_formatter_skips_stderr():
+    fmt = GenericFormatter()
+    assert list(fmt.consume(_output("err\n", stream="stderr"))) == []
+
+
+def test_generic_formatter_skips_non_output_events():
+    fmt = GenericFormatter()
+    start = StreamEvent.from_payload({"type": "start", "id": None, "session_id": "s"})
+    assert list(fmt.consume(start)) == []
+
+
+def test_formatter_protocol_satisfied_by_both():
+    """Both shipping formatters duck-type as Formatter."""
+    assert isinstance(ClaudeFormatter(), Formatter)
+    assert isinstance(GenericFormatter(), Formatter)

--- a/clients/python/tests/test_pretty_factory.py
+++ b/clients/python/tests/test_pretty_factory.py
@@ -21,6 +21,11 @@ def test_formatter_for_unknown_returns_generic():
     assert isinstance(formatter_for(""), GenericFormatter)
 
 
+def test_formatter_for_none_returns_generic():
+    assert isinstance(formatter_for(None), GenericFormatter)
+    assert isinstance(formatter_for(), GenericFormatter)
+
+
 def test_generic_formatter_yields_stdout_lines():
     fmt = GenericFormatter()
     lines = list(fmt.consume(_output("first line\nsecond line\n")))
@@ -39,6 +44,15 @@ def test_generic_formatter_flush_emits_unterminated():
     assert list(fmt.flush()) == ["dangling"]
 
 
+def test_generic_formatter_flush_strips_trailing_carriage_return():
+    # feed() strips \r off complete lines; flush() must do the same so a
+    # trailing "dangling\r" (no \n) doesn't smuggle a stray CR into the
+    # last yielded line. Regression guard for the bug fixed in this PR.
+    fmt = GenericFormatter()
+    list(fmt.consume(_output("dangling\r")))
+    assert list(fmt.flush()) == ["dangling"]
+
+
 def test_generic_formatter_skips_stderr():
     fmt = GenericFormatter()
     assert list(fmt.consume(_output("err\n", stream="stderr"))) == []
@@ -51,6 +65,15 @@ def test_generic_formatter_skips_non_output_events():
 
 
 def test_formatter_protocol_satisfied_by_both():
-    """Both shipping formatters duck-type as Formatter."""
+    """Both shipping formatters duck-type as Formatter.
+
+    NOTE: `@runtime_checkable` Protocols only check method *presence*, not
+    signatures or return types — so this guard catches a missing method but
+    not a method whose signature drifted. Real signature drift is caught by
+    mypy on `clients/python/` (see `[tool.mypy]` in pyproject.toml). There
+    is currently no CI job invoking mypy on the SDK package; until one is
+    added, run `uv run mypy` locally inside `clients/python/` before
+    landing changes here.
+    """
     assert isinstance(ClaudeFormatter(), Formatter)
     assert isinstance(GenericFormatter(), Formatter)


### PR DESCRIPTION
## Summary

Today the only way to use the Claude pretty-printer is \`from aod.pretty.claude import ClaudeFormatter\`. There's no factory that selects by runtime and no fallback for runtimes the SDK doesn't yet have a typed formatter for.

Add:

- **\`Formatter\` Protocol** pinning the shape every formatter implements (\`consume\`/\`feed\`/\`flush\`)
- **\`GenericFormatter\`** — runtime-agnostic passthrough emitting stdout lines verbatim (no JSON parsing). Suitable for any runtime whose output is human-readable text.
- **\`formatter_for(runtime)\`** — picks \`ClaudeFormatter\` for \`claude*\` runtimes, falls back to \`GenericFormatter\` for everything else. Adding a typed formatter for codex/gemini/opencode later is a one-line registry change here.

\`\`\`python
from aod.pretty import formatter_for
fmt = formatter_for(agent.runtime)
with client.sessions.stream(session_id) as events:
    for event in events:
        for line in fmt.consume(event):
            print(line)
\`\`\`

Part of the [SDK improvement backlog](https://github.com/ravi-hq/agent-on-demand/pull/291).

## Test plan

- [x] \`pytest\` — 67 pass (was 59; eight new tests cover the factory dispatch, GenericFormatter line buffering / flush / stderr skip / non-output skip, and the Formatter Protocol satisfaction)
- [x] \`ruff check\` clean