### PR TITLE
test(ts-sdk): pin exported VERSION to package.json on every PR

### DIFF
--- a/clients/typescript/tests/client.test.ts
+++ b/clients/typescript/tests/client.test.ts
@@ -1,6 +1,7 @@
+import { readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { Client } from "../src/index.js";
+import { Client, VERSION } from "../src/index.js";
 import { MockServer, makeAgent } from "./helpers.js";
 
 describe("Client", () => {
@@ -66,5 +67,15 @@ describe("Client", () => {
     });
     await client.health();
     expect(server.requests[0]?.path).toBe("/health");
+  });
+
+  // Catches the easy mistake of bumping `package.json` without bumping the
+  // exported `VERSION` constant (the README's release checklist requires both,
+  // and the publish workflow only checks the tag against `package.json`).
+  it("exports a VERSION matching package.json", () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+    ) as { version: string };
+    expect(VERSION).toBe(pkg.version);
   });
 });

--- a/clients/typescript/tests/client.test.ts
+++ b/clients/typescript/tests/client.test.ts
@@ -68,7 +68,9 @@ describe("Client", () => {
     await client.health();
     expect(server.requests[0]?.path).toBe("/health");
   });
+});
 
+describe("module exports", () => {
   // Catches the easy mistake of bumping `package.json` without bumping the
   // exported `VERSION` constant (the README's release checklist requires both,
   // and the publish workflow only checks the tag against `package.json`).


### PR DESCRIPTION
## Summary
- The README's release checklist requires bumping *both* `package.json` and the `VERSION` constant in `src/index.ts`. The publish workflow only verifies the GitHub tag against `package.json`, so a release where the maintainer forgets `index.ts` would ship fine and `import { VERSION }` would return a stale value.
- Adds a vitest assertion that pins `VERSION === require('package.json').version` on every PR and during the release workflow's `npm test` step.

## Test plan
- [x] `npm test` (29 tests pass; new assertion holds)
- [x] Sanity-checked the assertion fails on a deliberate mismatch.
- [x] `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)