### PR TITLE
fix(ts-sdk): point CJS consumers at .d.cts via per-condition exports

### DIFF
--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -46,7 +46,8 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && npm run check:dual-types",
+    "check:dual-types": "node -e \"['dist/index.js','dist/index.cjs','dist/index.d.ts','dist/index.d.cts'].forEach(f=>require('fs').accessSync(f))\"",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -26,9 +26,14 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [


### PR DESCRIPTION
## Summary
- `tsup` emits both `dist/index.d.ts` and `dist/index.d.cts`, but `package.json#exports` only referenced the ESM `.d.ts` under a top-level `types` condition. CJS callers got ESM types — works today only because both files are byte-identical; a future tsup config change could diverge them and silently ship wrong CJS types.
- Move `types` into per-condition blocks (the modern dual-publish layout):

```json
"exports": { ".": {
  "import":  { "types": "./dist/index.d.ts",  "default": "./dist/index.js"  },
  "require": { "types": "./dist/index.d.cts", "default": "./dist/index.cjs" }
}}
```

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (28 tests pass)
- [x] `npm run build` (both `.d.ts` and `.d.cts` produced)
- [x] `npx @arethetypeswrong/cli` against `npm pack` output: 🟢 across node10 / node16 CJS / node16 ESM / bundler

🤖 Generated with [Claude Code](https://claude.com/claude-code)