### PR TITLE
docs(readme): add SDKs section after quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ SESS_ID=$(curl -s -X POST "$BASE/sessions" \
 curl -N -H "Authorization: Bearer $TOKEN" "$BASE/sessions/$SESS_ID/stream"
 ```
 
+## SDKs
+
+Official client libraries for common runtimes:
+
+- **Python** ([`aod-sdk`](https://pypi.org/p/aod-sdk)): sync + async, typed SSE stream, pydantic models — `pip install aod-sdk`
+- **TypeScript/Node** ([`@ravi-hq/aod-sdk`](https://www.npmjs.com/package/@ravi-hq/aod-sdk)): zero-dep, async-iterable SSE stream — `npm install @ravi-hq/aod-sdk`
+
+See [`clients/python/`](clients/python/) and [`clients/typescript/`](clients/typescript/) for source and full API surface.
+
 ## Self-hosting
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ curl -N -H "Authorization: Bearer $TOKEN" "$BASE/sessions/$SESS_ID/stream"
 
 Official client libraries for common runtimes:
 
-- **Python** ([`aod-sdk`](https://pypi.org/p/aod-sdk)): sync + async, typed SSE stream, pydantic models — `pip install aod-sdk`
+- **Python** ([`aod-sdk`](https://pypi.org/project/aod-sdk/)): sync + async, typed SSE stream, pydantic models — `pip install aod-sdk`
 - **TypeScript/Node** ([`@ravi-hq/aod-sdk`](https://www.npmjs.com/package/@ravi-hq/aod-sdk)): zero-dep, async-iterable SSE stream — `npm install @ravi-hq/aod-sdk`
 
 See [`clients/python/`](clients/python/) and [`clients/typescript/`](clients/typescript/) for source and full API surface.


### PR DESCRIPTION
## Summary

- The README quickstart showed curl only
- SDKs were only mentioned in the Layout section at the bottom — invisible to API consumers who read the first half of the README
- Added a brief **SDKs** section immediately after the quickstart with install commands (`pip install aod-sdk`, `npm install @ravi-hq/aod-sdk`), a one-line capability summary for each, and links to the source directories

## Why placement matters

A developer who sees the curl quickstart and decides "I'd rather use Python" should find the SDK right there — not have to scroll to the bottom or click through to the docs site. This also aligns the README with the OSS docs site, which has tabbed curl/Python examples throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)