### PR TITLE
fix(ts-sdk): cancel the underlying fetch when stream iteration ends

### DIFF
--- a/clients/typescript/src/stream.ts
+++ b/clients/typescript/src/stream.ts
@@ -41,57 +41,59 @@ async function* iterateSSE(
   url: string,
   onDone: () => void,
 ): AsyncGenerator<StreamEvent, void, unknown> {
-  if (response.status >= 400) {
-    const text = await response.text();
-    let parsed: unknown = text || null;
-    if (text) {
-      try {
-        parsed = JSON.parse(text);
-      } catch {
-        parsed = text;
-      }
-    }
-    onDone();
-    raiseForStatus(response.status, parsed, "GET", url);
-    return;
-  }
-
-  if (!response.body) {
-    onDone();
-    return;
-  }
-
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder("utf-8");
-  let buffer = "";
-
+  // Outer try/finally ensures onDone() runs on every exit path — including
+  // when response.text() throws on the >=400 branch, which would otherwise
+  // leak the underlying fetch.
   try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
+    if (response.status >= 400) {
+      const text = await response.text();
+      let parsed: unknown = text || null;
+      if (text) {
+        try {
+          parsed = JSON.parse(text);
+        } catch {
+          parsed = text;
+        }
+      }
+      raiseForStatus(response.status, parsed, "GET", url);
+      return;
+    }
 
-      let newlineIndex: number;
-      while ((newlineIndex = buffer.indexOf("\n")) !== -1) {
-        const rawLine = buffer.slice(0, newlineIndex);
-        buffer = buffer.slice(newlineIndex + 1);
-        const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
-        const event = parseDataLine(line);
+    if (!response.body) return;
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder("utf-8");
+    let buffer = "";
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        let newlineIndex: number;
+        while ((newlineIndex = buffer.indexOf("\n")) !== -1) {
+          const rawLine = buffer.slice(0, newlineIndex);
+          buffer = buffer.slice(newlineIndex + 1);
+          const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+          const event = parseDataLine(line);
+          if (event) yield event;
+        }
+      }
+
+      buffer += decoder.decode();
+      if (buffer.length > 0) {
+        const event = parseDataLine(buffer);
         if (event) yield event;
       }
-    }
-
-    buffer += decoder.decode();
-    if (buffer.length > 0) {
-      const event = parseDataLine(buffer);
-      if (event) yield event;
+    } finally {
+      try {
+        reader.releaseLock();
+      } catch {
+        // reader already released
+      }
     }
   } finally {
-    try {
-      reader.releaseLock();
-    } catch {
-      // reader already released
-    }
     onDone();
   }
 }

--- a/clients/typescript/src/stream.ts
+++ b/clients/typescript/src/stream.ts
@@ -10,13 +10,23 @@ export function createStreamHandle(
   url: string,
   controller: AbortController,
 ): StreamHandle {
-  const iterator = iterateSSE(response, url);
+  // Releasing the reader's lock leaves the response body unconsumed; the
+  // socket can outlive the for-await loop unless we abort the fetch. Run
+  // abort on every iteration-end path (natural completion, break, throw,
+  // or explicit close) and guard it with an idempotency flag.
+  let aborted = false;
+  const abortOnce = () => {
+    if (aborted) return;
+    aborted = true;
+    controller.abort();
+  };
+  const iterator = iterateSSE(response, url, abortOnce);
   return {
     [Symbol.asyncIterator]() {
       return iterator;
     },
     async close() {
-      controller.abort();
+      abortOnce();
       try {
         await iterator.return?.(undefined);
       } catch {
@@ -29,6 +39,7 @@ export function createStreamHandle(
 async function* iterateSSE(
   response: Response,
   url: string,
+  onDone: () => void,
 ): AsyncGenerator<StreamEvent, void, unknown> {
   if (response.status >= 400) {
     const text = await response.text();
@@ -40,11 +51,15 @@ async function* iterateSSE(
         parsed = text;
       }
     }
+    onDone();
     raiseForStatus(response.status, parsed, "GET", url);
     return;
   }
 
-  if (!response.body) return;
+  if (!response.body) {
+    onDone();
+    return;
+  }
 
   const reader = response.body.getReader();
   const decoder = new TextDecoder("utf-8");
@@ -77,6 +92,7 @@ async function* iterateSSE(
     } catch {
       // reader already released
     }
+    onDone();
   }
 }
 

--- a/clients/typescript/tests/stream.test.ts
+++ b/clients/typescript/tests/stream.test.ts
@@ -134,6 +134,36 @@ describe("stream", () => {
     expect(abortObserved).toBe(true);
   });
 
+  it("aborts the fetch even when response.text() throws on the error branch", async () => {
+    // Pin: if reading the error body throws, the outer try/finally still
+    // fires onDone() (and therefore controller.abort()). Without the outer
+    // finally, the throw would skip the abort and leak the connection.
+    const server = new MockServer();
+    const sid = uuid();
+    let abortObserved = false;
+    server.register("GET", `/sessions/${sid}/stream`, (req) => {
+      req.signal.addEventListener("abort", () => {
+        abortObserved = true;
+      });
+      const response = new Response(null, {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      });
+      Object.defineProperty(response, "text", {
+        value: () => Promise.reject(new Error("body read failed")),
+      });
+      return response;
+    });
+    const stream = await newClient(server).sessions.stream(sid);
+    const iterate = async () => {
+      for await (const _ of stream) {
+        // drain
+      }
+    };
+    await expect(iterate()).rejects.toThrow("body read failed");
+    expect(abortObserved).toBe(true);
+  });
+
   it("ignores non-data lines", async () => {
     const server = new MockServer();
     const sid = uuid();

--- a/clients/typescript/tests/stream.test.ts
+++ b/clients/typescript/tests/stream.test.ts
@@ -107,6 +107,33 @@ describe("stream", () => {
     await stream.close();
   });
 
+  it("aborts the underlying fetch when the iteration ends without close()", async () => {
+    // Pre-fix, breaking out of `for await` only released the reader's lock —
+    // the fetch's underlying connection stayed open until socket idle-out.
+    // Pin: the iterator's finally aborts the controller, which propagates
+    // the abort to the request signal observed by the server.
+    const server = new MockServer();
+    const sid = uuid();
+    let abortObserved = false;
+    server.register("GET", `/sessions/${sid}/stream`, (req) => {
+      req.signal.addEventListener("abort", () => {
+        abortObserved = true;
+      });
+      const body =
+        'data: {"type":"start"}\n\n' +
+        'data: {"type":"output","id":1,"stream":"stdout","data":"hi"}\n\n';
+      return new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    });
+    const stream = await newClient(server).sessions.stream(sid);
+    for await (const event of stream) {
+      if (event.type === "output") break;
+    }
+    expect(abortObserved).toBe(true);
+  });
+
   it("ignores non-data lines", async () => {
     const server = new MockServer();
     const sid = uuid();


### PR DESCRIPTION
## Summary
- Pre-fix, the iterator's finally only released the body reader's lock — `controller.abort()` was only called from explicit `stream.close()`. Breaking out of `for await` (or letting it finish naturally without close) left the response body unconsumed and the socket open until the server idled it out. That's the exact leak the README and TS-SDK skill currently warn callers about.
- Move the cancel into the iterator's finally via an `abortOnce()` callback shared with `close()`. Every iteration-end path — natural exhaust, `break`, thrown error mid-loop, or explicit `close()` — now aborts the controller exactly once.
- Caller pattern is unchanged: try/finally with `await stream.close()` still works (and is still a fine habit), but it's no longer load-bearing.

## Test plan
- [x] `npm test` (29 tests; new test asserts the server-side abort listener fires when the consumer just `break`s without `close()`)
- [x] Sanity check: reverting the source change makes the new test fail.
- [x] `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)