### PR TITLE
docs: document GET /sessions/{id}/turns across all surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ route table. Authentication: `Authorization: Bearer <token>`.
   `DELETE /environments/{id}/delete`, `GET /environments/{id}/versions`
 - `POST /sessions`, `GET /sessions`, `GET /sessions/{id}`,
   `POST /sessions/{id}/prompt`, `POST /sessions/{id}/terminate`,
-  `DELETE /sessions/{id}/delete`, `GET /sessions/{id}/stream` (SSE)
+  `DELETE /sessions/{id}/delete`, `GET /sessions/{id}/stream` (SSE),
+  `GET /sessions/{id}/turns`
 
 ## Runtimes
 

--- a/site/docs/api/concepts.md
+++ b/site/docs/api/concepts.md
@@ -32,7 +32,7 @@ A **session** is one execution of an agent inside a Sprite. Sessions are:
 - **Async** — `POST /sessions` returns `202` immediately; the agent runs in the background.
 - **Streamable** — `GET /sessions/{id}/stream` delivers output as Server-Sent Events.
 - **Multi-turn** — after `completed`, you can `POST /sessions/{id}/prompt` to continue in the same Sprite with the same filesystem and runtime history. (`failed` and `terminated` sessions cannot be continued.)
-- **Auditable** — `GET /sessions/{id}/turns` returns the full turn history: each turn's prompt, status, exit code, and timestamps.
+- **Auditable** — `GET /sessions/{id}/turns` returns the full turn history: each turn's prompt, status, exit code, and timestamps (`started_at` / `ended_at` are nullable until the turn reaches that state).
 
 ## Session state machine
 

--- a/site/docs/api/concepts.md
+++ b/site/docs/api/concepts.md
@@ -32,6 +32,7 @@ A **session** is one execution of an agent inside a Sprite. Sessions are:
 - **Async** — `POST /sessions` returns `202` immediately; the agent runs in the background.
 - **Streamable** — `GET /sessions/{id}/stream` delivers output as Server-Sent Events.
 - **Multi-turn** — after `completed`, you can `POST /sessions/{id}/prompt` to continue in the same Sprite with the same filesystem and runtime history. (`failed` and `terminated` sessions cannot be continued.)
+- **Auditable** — `GET /sessions/{id}/turns` returns the full turn history: each turn's prompt, status, exit code, and timestamps.
 
 ## Session state machine
 

--- a/site/docs/sdks/python.md
+++ b/site/docs/sdks/python.md
@@ -41,6 +41,7 @@ with Client(token="aod_...") as client:
 | Typed models | `Agent`, `Environment`, `Session`, `SessionAck`, `SessionTurn`, `StreamEvent`, … |
 | Typed error hierarchy | `AodError` → `NotFoundError`, `ConflictError`, `ValidationError`, `RateLimitError`, `AuthError`, `ServerError` |
 | SSE stream (context manager, typed events) | `client.sessions.stream(session_id, since=None)` |
+| Turn history (prompt, status, timestamps) | `client.sessions.turns(session_id)` → `list[SessionTurn]` |
 | Claude `stream-json` pretty-printer | `aod.pretty.claude.ClaudeFormatter` (optional, runtime-scoped) |
 
 ## Errors


### PR DESCRIPTION
## Summary

`GET /sessions/{id}/turns` has been live since launch but was invisible in all three documentation surfaces.

### What it returns

```json
{
  "data": [
    {
      "turn_number": 1,
      "prompt": "Say hello.",
      "status": "completed",
      "exit_code": 0,
      "created_at": "2026-04-17T14:00:00+00:00",
      "started_at": "2026-04-17T14:00:01+00:00",
      "ended_at": "2026-04-17T14:00:05+00:00"
    }
  ]
}
```

Python SDK: `client.sessions.turns(session_id)` → `list[SessionTurn]` (sync and async).

### Changes

| File | Change |
|------|--------|
| `README.md` | Added `GET /sessions/{id}/turns` to the sessions endpoint list |
| `site/docs/api/concepts.md` | New "Auditable" bullet under Sessions — links to the endpoint |
| `site/docs/sdks/python.md` | New row in the feature summary table showing `client.sessions.turns()` |

### Verified against

- `src/agent_on_demand/urls.py` line 25 — route exists
- `src/agent_on_demand/views/sessions/lifecycle.py` lines 137–145 — implementation
- `clients/python/src/aod/resources/sessions.py` lines 81–83 — SDK method

🤖 Generated with [Claude Code](https://claude.com/claude-code)