### PR TITLE
docs(sdks): add Multi-turn sessions section to Python and TypeScript docs

### DIFF
--- a/site/docs/sdks/python.md
+++ b/site/docs/sdks/python.md
@@ -130,10 +130,21 @@ with Client() as client:
     try:
         ack2 = client.sessions.prompt(ack.id, prompt="Now summarise what each file does.")
     except ConflictError as e:
-        if "failed" in e.detail or "terminated" in e.detail:
-            pass  # session ended — start a new one
-        else:
-            pass  # session is still running — retry after it completes
+        detail = str(e.detail)
+        if "failed" in detail or "terminated" in detail:
+            # session ended — start a new one (or surface to the caller)
+            raise
+        # session is pending or running — wait and retry, e.g.:
+        #   time.sleep(2); ack2 = client.sessions.prompt(ack.id, prompt=...)
+        raise
+
+    turn2 = ack2.current_turn
+    with client.sessions.stream(ack.id) as events:
+        for event in events:
+            if event.type == "output" and event.extra.get("turn") == turn2:
+                print(event.extra["data"], end="")
+            elif event.type in ("exit", "error", "terminated", "stale"):
+                break
 ```
 
 `prompt()` returns a `SessionAck` with the updated `current_turn`. Only `completed` sessions accept a prompt — `running`, `pending`, `failed`, and `terminated` all raise `ConflictError` (409). See [Core Concepts → Session state machine](../api/concepts.md#session-state-machine).

--- a/site/docs/sdks/python.md
+++ b/site/docs/sdks/python.md
@@ -108,6 +108,36 @@ with client.sessions.stream(session_id) as events:
 
 Other runtimes emit plain text — no formatter needed.
 
+## Multi-turn sessions
+
+After a session reaches `completed`, call `client.sessions.prompt()` to send a follow-up. The agent resumes in the same Sprite with the same filesystem and conversation history.
+
+```python
+from aod import Client, ConflictError
+
+with Client() as client:
+    # Turn 1
+    ack = client.sessions.create(agent_id=agent_id, prompt="List the Python files here.")
+    turn1 = ack.current_turn
+    with client.sessions.stream(ack.id) as events:
+        for event in events:
+            if event.type == "output" and event.extra.get("turn") == turn1:
+                print(event.extra["data"], end="")
+            elif event.type in ("exit", "error", "terminated", "stale"):
+                break
+
+    # Turn 2 — only valid once session is `completed`
+    try:
+        ack2 = client.sessions.prompt(ack.id, prompt="Now summarise what each file does.")
+    except ConflictError as e:
+        if "failed" in e.detail or "terminated" in e.detail:
+            pass  # session ended — start a new one
+        else:
+            pass  # session is still running — retry after it completes
+```
+
+`prompt()` returns a `SessionAck` with the updated `current_turn`. Only `completed` sessions accept a prompt — `running`, `pending`, `failed`, and `terminated` all raise `ConflictError` (409). See [Core Concepts → Session state machine](../api/concepts.md#session-state-machine).
+
 ## Async
 
 Every method has an async counterpart on `AsyncClient`:

--- a/site/docs/sdks/typescript.md
+++ b/site/docs/sdks/typescript.md
@@ -135,6 +135,45 @@ Pass `since: lastSeenId` to resume after a disconnect. Pass `signal: abortContro
 
 Event types: `start`, `turn_start`, `output`, `stage`, `exit`, `error`, `terminated`, `stale`. Everything except `type` and `id` lands in `event.extra`. See [Streaming reference](../api/streaming.md) for the full event schema.
 
+## Multi-turn sessions
+
+After a session reaches `completed`, call `client.sessions.prompt()` to send a follow-up. The agent resumes in the same Sprite with the same filesystem and conversation history.
+
+```ts
+import { Client, ConflictError } from "@ravi-hq/aod-sdk";
+
+const client = new Client({ token: "aod_..." });
+
+// Turn 1
+const ack = await client.sessions.create({
+  agent_id: agentId,
+  prompt: "List the TypeScript files here.",
+});
+const stream = await client.sessions.stream(ack.id);
+try {
+  for await (const event of stream) {
+    if (event.type === "output") process.stdout.write(event.extra.data ?? "");
+    else if (event.type === "exit" || event.type === "error") break;
+  }
+} finally {
+  await stream.close();
+}
+
+// Turn 2 — only valid once session is `completed`
+try {
+  const ack2 = await client.sessions.prompt(ack.id, {
+    prompt: "Now summarise what each file does.",
+  });
+  console.log("turn", ack2.current_turn);
+} catch (err) {
+  if (err instanceof ConflictError) {
+    // session is running, failed, or terminated — check err.detail
+  }
+}
+```
+
+`prompt()` returns a `SessionAck` with the updated `current_turn`. Only `completed` sessions accept a prompt — `running`, `pending`, `failed`, and `terminated` all throw `ConflictError` (409). See [Core Concepts → Session state machine](../api/concepts.md#session-state-machine).
+
 ## Browser use
 
 The SDK has no Node-only dependencies — it uses built-in `fetch`, `ReadableStream`, and `AbortController`. Pass `baseUrl` and `token` explicitly in browser code; the `AOD_API_URL` / `AOD_API_TOKEN` env fallbacks are Node-only.

--- a/site/docs/sdks/typescript.md
+++ b/site/docs/sdks/typescript.md
@@ -141,6 +141,7 @@ After a session reaches `completed`, call `client.sessions.prompt()` to send a f
 
 ```ts
 import { Client, ConflictError } from "@ravi-hq/aod-sdk";
+import type { SessionAck } from "@ravi-hq/aod-sdk";
 
 const client = new Client({ token: "aod_..." });
 
@@ -149,26 +150,58 @@ const ack = await client.sessions.create({
   agent_id: agentId,
   prompt: "List the TypeScript files here.",
 });
-const stream = await client.sessions.stream(ack.id);
+const turn1 = ack.current_turn;
+const stream1 = await client.sessions.stream(ack.id);
 try {
-  for await (const event of stream) {
-    if (event.type === "output") process.stdout.write(event.extra.data ?? "");
-    else if (event.type === "exit" || event.type === "error") break;
+  for await (const event of stream1) {
+    if (event.type === "output" && event.extra.turn === turn1) {
+      process.stdout.write((event.extra.data as string) ?? "");
+    } else if (
+      event.type === "exit" ||
+      event.type === "error" ||
+      event.type === "terminated" ||
+      event.type === "stale"
+    ) {
+      break;
+    }
   }
 } finally {
-  await stream.close();
+  await stream1.close();
 }
 
 // Turn 2 — only valid once session is `completed`
+let ack2: SessionAck;
 try {
-  const ack2 = await client.sessions.prompt(ack.id, {
+  ack2 = await client.sessions.prompt(ack.id, {
     prompt: "Now summarise what each file does.",
   });
-  console.log("turn", ack2.current_turn);
 } catch (err) {
   if (err instanceof ConflictError) {
-    // session is running, failed, or terminated — check err.detail
+    // session is pending, running, failed, or terminated — inspect err.detail
+    // and either retry (pending/running) or start a new session (failed/terminated)
+    throw err;
+  } else {
+    throw err;
   }
+}
+
+const turn2 = ack2.current_turn;
+const stream2 = await client.sessions.stream(ack.id);
+try {
+  for await (const event of stream2) {
+    if (event.type === "output" && event.extra.turn === turn2) {
+      process.stdout.write((event.extra.data as string) ?? "");
+    } else if (
+      event.type === "exit" ||
+      event.type === "error" ||
+      event.type === "terminated" ||
+      event.type === "stale"
+    ) {
+      break;
+    }
+  }
+} finally {
+  await stream2.close();
 }
 ```
 


### PR DESCRIPTION
## Summary

Both SDK doc pages showed how to create a session and stream output, but `client.sessions.prompt()` — the method needed for multi-turn conversations — was never mentioned. Multi-turn is a core feature (the whole point of keeping a session alive), but a developer reading the SDK docs would have no idea how to do it.

## What was added

A **Multi-turn sessions** section in both `site/docs/sdks/python.md` and `site/docs/sdks/typescript.md`, placed after the Streaming section. Each includes:

- A minimal working example calling `sessions.prompt(session_id, prompt="...")`
- Capture of `ack.current_turn` for stream filtering (avoids replaying previous turns)
- `ConflictError` handling — only `completed` sessions accept a prompt
- Link to the session state machine in `concepts.md`

## Verified against

- `clients/python/src/aod/resources/sessions.py` lines 73-83 — `prompt(self, session_id, *, prompt, timeout)` → `SessionAck`
- `clients/typescript/src/resources/sessions.ts` lines 58-66 — `prompt(sessionId, params)` → `Promise<SessionAck>`
- `site/docs/api/concepts.md` — state machine confirms only `completed` accepts `POST /sessions/{id}/prompt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)