### PR TITLE
docs(index): surface multi-turn capability and missing nav sections

### DIFF
--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -4,7 +4,7 @@ Agent on Demand is a REST API for running AI coding agents on [Sprites](https://
 
 - **Agents** — reusable templates that define the model, runtime, system prompt, MCP servers, and skills for an AI coding agent.
 - **Environments** — Sprite sandbox configurations: packages to install, environment variables to export, a setup script, and a network policy.
-- **Sessions** — one execution of an agent inside a Sprite. Sessions are async; output is consumed via a Server-Sent Events stream.
+- **Sessions** — one execution of an agent inside a Sprite. Sessions are async; output is consumed via a Server-Sent Events stream. After a session completes, send a follow-up prompt to continue in the same Sprite with the same filesystem and history.
 
 Local dev runs on `http://localhost:8777` (`make dev`). Every request except `GET /health` requires a Bearer token.
 
@@ -73,3 +73,5 @@ Three calls to go from zero to a running agent:
 | [Streaming](api/streaming.md) | SSE event types, reconnect, replay |
 | [Errors](api/errors.md) | Every status code and when it fires |
 | [Pagination](api/pagination.md) | List envelope format |
+| [Patterns](patterns/chat-bot.md) | Chat bot, CI bot, batch automation, CLI wrapper, dashboard |
+| [Deploy Guide](operators/deploy.md) | Self-hosting: env vars, worker, production setup |

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -73,5 +73,5 @@ Three calls to go from zero to a running agent:
 | [Streaming](api/streaming.md) | SSE event types, reconnect, replay |
 | [Errors](api/errors.md) | Every status code and when it fires |
 | [Pagination](api/pagination.md) | List envelope format |
-| [Patterns](patterns/chat-bot.md) | Chat bot, CI bot, batch automation, CLI wrapper, dashboard |
+| [Patterns](patterns/index.md) | Chat bot, CI bot, batch automation, CLI wrapper, dashboard |
 | [Deploy Guide](operators/deploy.md) | Self-hosting: env vars, worker, production setup |

--- a/site/docs/patterns/index.md
+++ b/site/docs/patterns/index.md
@@ -1,0 +1,17 @@
+# Patterns
+
+Common shapes for building on top of Agent on Demand. Each pattern is a
+self-contained recipe — pick the one that matches what you're building and
+adapt the example to your stack.
+
+| Pattern | When to use it |
+|---------|----------------|
+| [CLI Wrapper](cli-wrapper.md) | A one-liner that kicks off an agent task from the terminal — create a session, stream output, exit. |
+| [Chat Bot](chat-bot.md) | Slack, Discord, or in-app chat where each thread maps to one multi-turn session. |
+| [CI Bot](ci-bot.md) | GitHub Actions or other CI runs that review PRs, suggest fixes, or post analysis comments without a human in the loop. |
+| [Internal Dashboard](dashboard.md) | A web UI that lets multiple users kick off and monitor sessions through your own auth layer. |
+| [Batch Automation](batch-automation.md) | Run the same agent task across many inputs concurrently, staying within Sprites and runtime quotas. |
+
+Python examples in these patterns use the official
+[`aod-sdk`](../sdks/python.md) package (`pip install aod-sdk`). TypeScript
+equivalents use [`@ravi-hq/aod-sdk`](../sdks/typescript.md).

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
     - Python: sdks/python.md
     - TypeScript: sdks/typescript.md
   - Patterns:
+    - Overview: patterns/index.md
     - CLI Wrapper: patterns/cli-wrapper.md
     - Chat Bot: patterns/chat-bot.md
     - CI Bot: patterns/ci-bot.md


### PR DESCRIPTION
## Summary

Two homepage gaps in `site/docs/index.md`:

### 1. Sessions description omitted multi-turn

The opening resource list described sessions as *"one execution of an agent inside a Sprite"* — technically true for turn 1, but says nothing about the follow-up prompt capability that keeps the Sprite alive. Multi-turn is a key differentiator; someone reading the homepage for the first time would not know it exists.

**Before:** "Sessions are async; output is consumed via a Server-Sent Events stream."
**After:** adds "After a session completes, send a follow-up prompt to continue in the same Sprite with the same filesystem and history."

### 2. Explore the docs table missing Patterns and Deploy Guide

The nav table listed 10 API/SDK sections but had no row for:
- **Patterns** — chat bot, CI bot, batch automation, CLI wrapper, dashboard
- **Deploy Guide** — self-hosting env vars, worker setup, production config

A self-hoster landing on the homepage had to discover the deploy guide through the footer or sidebar — it wasn't in the "where to go next" table at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)