### PR TITLE
docs(python-sdk): add terminate/delete to feature summary table

### DIFF
--- a/site/docs/sdks/python.md
+++ b/site/docs/sdks/python.md
@@ -40,6 +40,7 @@ with Client(token="aod_...") as client:
 | Typed resources | `client.agents`, `client.environments`, `client.sessions` |
 | Typed models | `Agent`, `Environment`, `Session`, `SessionAck`, `SessionTurn`, `StreamEvent`, … |
 | Typed error hierarchy | `AodError` → `NotFoundError`, `ConflictError`, `ValidationError`, `RateLimitError`, `AuthError`, `ServerError` |
+| Session lifecycle | `client.sessions.terminate(id)`, `client.sessions.delete(id)` |
 | SSE stream (context manager, typed events) | `client.sessions.stream(session_id, since=None)` |
 | Claude `stream-json` pretty-printer | `aod.pretty.claude.ClaudeFormatter` (optional, runtime-scoped) |
 

--- a/site/docs/sdks/python.md
+++ b/site/docs/sdks/python.md
@@ -40,7 +40,7 @@ with Client(token="aod_...") as client:
 | Typed resources | `client.agents`, `client.environments`, `client.sessions` |
 | Typed models | `Agent`, `Environment`, `Session`, `SessionAck`, `SessionTurn`, `StreamEvent`, … |
 | Typed error hierarchy | `AodError` → `NotFoundError`, `ConflictError`, `ValidationError`, `RateLimitError`, `AuthError`, `ServerError` |
-| Session lifecycle | `client.sessions.terminate(id)`, `client.sessions.delete(id)` |
+| Session teardown | `client.sessions.terminate(session_id)`, `client.sessions.delete(session_id)` |
 | SSE stream (context manager, typed events) | `client.sessions.stream(session_id, since=None)` |
 | Claude `stream-json` pretty-printer | `aod.pretty.claude.ClaudeFormatter` (optional, runtime-scoped) |
 


### PR DESCRIPTION
## Summary

- Adds `client.sessions.terminate(id)` and `client.sessions.delete(id)` to the Feature summary table in the Python SDK docs
- Both methods are exercised in the Patterns docs (dashboard.md, batch-automation.md) but were invisible from the SDK page itself

## Test plan
- [ ] Verify feature summary table now lists session lifecycle methods
- [ ] Confirm no other SDK page entries were changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)