### PR TITLE
docs(ts-sdk): add feature summary table

### DIFF
--- a/site/docs/sdks/typescript.md
+++ b/site/docs/sdks/typescript.md
@@ -69,10 +69,10 @@ try {
 | Typed models | `Agent`, `Environment`, `Session`, `SessionAck`, `SessionTurn`, `StreamEvent`, … |
 | Typed error hierarchy | `AodHTTPError` → `NotFoundError`, `ConflictError`, `ValidationError`, `RateLimitError`, `AuthError`, `ServerError` |
 | Multi-turn | `client.sessions.prompt(sessionId, { prompt })` → `SessionAck` |
-| Session lifecycle | `client.sessions.terminate(id)`, `client.sessions.delete(id)` |
+| Session teardown | `client.sessions.terminate(sessionId)`, `client.sessions.delete(sessionId)` |
 | Turn history | `client.sessions.turns(sessionId)` → `SessionTurn[]` |
 | SSE stream (`AsyncIterable`, `close()`) | `client.sessions.stream(sessionId, { since?, signal? })` |
-| Version history | `client.agents.versions(agentId)` / `client.environments.versions(envId)` |
+| Version history | `client.agents.versions(agentId)` / `client.environments.versions(environmentId)` |
 
 ## Errors
 

--- a/site/docs/sdks/typescript.md
+++ b/site/docs/sdks/typescript.md
@@ -61,6 +61,19 @@ try {
 | `fetch`     | `globalThis.fetch`              | Inject a custom fetch for tests or proxies.                |
 | `timeoutMs` | `30000`                         | Per-request timeout. Streaming requests use `AbortSignal`. |
 
+## Feature summary
+
+| Capability | Where it lives |
+|------------|----------------|
+| Typed resources | `client.agents`, `client.environments`, `client.sessions` |
+| Typed models | `Agent`, `Environment`, `Session`, `SessionAck`, `SessionTurn`, `StreamEvent`, … |
+| Typed error hierarchy | `AodHTTPError` → `NotFoundError`, `ConflictError`, `ValidationError`, `RateLimitError`, `AuthError`, `ServerError` |
+| Multi-turn | `client.sessions.prompt(sessionId, { prompt })` → `SessionAck` |
+| Session lifecycle | `client.sessions.terminate(id)`, `client.sessions.delete(id)` |
+| Turn history | `client.sessions.turns(sessionId)` → `SessionTurn[]` |
+| SSE stream (`AsyncIterable`, `close()`) | `client.sessions.stream(sessionId, { since?, signal? })` |
+| Version history | `client.agents.versions(agentId)` / `client.environments.versions(envId)` |
+
 ## Errors
 
 Non-2xx responses throw a typed subclass of `AodHTTPError`. All share `.statusCode`, `.detail`, `.method`, `.url`:


### PR DESCRIPTION
## Summary

- Adds a Feature summary table to the TypeScript SDK docs, parallel to the Python SDK page
- Surfaces six capabilities that existed in the SDK but were invisible from the docs:
  - `client.sessions.prompt()` for multi-turn
  - `client.sessions.terminate()` and `client.sessions.delete()` for session lifecycle
  - `client.sessions.turns()` for turn history
  - `client.agents.versions()` / `client.environments.versions()` for version history

## Test plan
- [ ] Verify table renders correctly in MkDocs
- [ ] Confirm all referenced methods exist in `clients/typescript/src/resources/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)