### PR TITLE
docs(narrative): idea document, press release, story page, and slideshow

### DIFF
--- a/narrative/idea-document.md
+++ b/narrative/idea-document.md
@@ -1,0 +1,157 @@
+# The Agent Infrastructure Problem
+
+*This document describes a problem, not a product. Its purpose is to map the shape of an emerging gap in software development and spark thinking about what could be built if that gap were closed. No solution is proposed here.*
+
+---
+
+## The World Has Already Changed
+
+Something shifted in developer tooling over the last eighteen months, and most application developers haven't felt it yet.
+
+The shift is this: AI agents stopped being a novelty. They became productive. Developer tools now ship agents that open PRs, run test suites, read entire codebases and propose refactors. These tools are in daily use by developers who care about output, not hype.
+
+What they have in common: they are not chatbots. They don't answer questions. They do work. They have tools — bash, file editing, web search. They have a filesystem. They run for minutes, not seconds. They come back with an artifact — a diff, a file, a report — not a paragraph of text.
+
+This is the prototype of a new kind of compute. Long-running. Non-deterministic. Sandboxed. Streaming. And it's coming to everyday software — to the kanban boards, support inboxes, research platforms, and data pipelines that most developers spend their careers building.
+
+The question is: when it arrives, who will be ready to build it?
+
+---
+
+## Three Developers Walk Into an Infrastructure Problem
+
+### The Solo Builder
+
+You're building a product. Maybe it's a project management tool. Maybe a customer support platform, or something for legal teams. You have users, some traction, and a product instinct that's been right before.
+
+Then you see a demo — someone's kanban board where dragging a ticket to "In Progress" spawns an agent that reads the ticket, understands the codebase, writes actual code, and opens a PR. The card moves itself to "In Review" when the agent is done. Your users would love this. You figure it's a weekend.
+
+It isn't.
+
+You start with the obvious path: call the model API, get a response. But your users won't wait 45 seconds staring at a spinner. They want to see the agent working. So you need streaming. You stand up an SSE endpoint. You realize you need somewhere to store partial results. You add a table.
+
+Then you realize the agent needs tools — it has to read files, write code, call external APIs. That means a runtime, not just a model call. You research sandboxing. You look at containers, serverless functions, isolated VMs. You spend two weeks on the "just run it somewhere safely" problem.
+
+Then your agent needs secrets — GitHub tokens, API keys that are different per user. You can't put those in environment variables. You design a secrets layer. You encrypt things. You realize you've accidentally built a miniature Vault.
+
+Three months in, you haven't shipped a single user-facing feature. You have an infrastructure layer. You have a sandbox that sort of works. You have an agent that can sort of run. You're exhausted, and you're not done.
+
+Most solo builders stop here. The ones who don't spend another two to three months hardening what they built — fixing edge cases, handling cleanup, making the streaming reliable under load, adding the multi-turn state management they forgot about. By the time they have something shippable, the window has moved.
+
+---
+
+### The Platform Team
+
+You're at a mid-size company with real engineering resources. Leadership wants "agent capabilities" in the product by Q3. You assign a platform team: two senior engineers, a reasonable runway. They do a spike. It goes well. There's a demo. Leadership is excited.
+
+Then they start building the thing that will actually power the feature in production.
+
+**Week 3:** Sandbox isolation. The agent needs its own environment — it can't run on the web server. The team evaluates several options. Each has a steep learning curve. They pick one. Integration takes longer than the spike suggested.
+
+**Week 6:** Secrets management. Per-user API keys can't live in config files. The team designs a secrets layer integrated with the existing auth system. They write a key rotation plan. Security reviews it. Changes are requested.
+
+**Week 9:** Streaming and state management. The product team wants real-time output — users should see the agent working, not wait for a result. Standing up SSE is fast. The state management behind it — resuming interrupted streams, handling client disconnects, replaying missed events — takes two more weeks.
+
+**Week 11:** Multi-turn sessions. Users need to follow up with the agent. The session needs to keep its filesystem between turns. The agent's context needs to survive the gap. This is harder than it looked in the spike.
+
+**Week 14:** Q3. They ship something. It's slow to provision on cold starts, occasionally drops streams, doesn't handle concurrent users gracefully, and there's a known bug in the cleanup process that leaks idle compute. The product team ships it with a "beta" label and a known issues page.
+
+The platform team is now permanently on-call for the infrastructure they built. Every product feature that touches agents requires a negotiation with the platform team about what the infra supports. The original demo — the exciting one that got everyone aligned — is buried under nine months of plumbing.
+
+---
+
+### The Team That Built It
+
+You did it right. Eighteen months, three engineers, proper architecture reviews. You have isolated sandboxes, encrypted secrets, reliable streaming, multi-turn persistence, a worker queue, observability, session lifecycle management, and automated cleanup. It runs. Users use it. You're proud of what the team built.
+
+Here's what you also have: a system to maintain indefinitely.
+
+Every model provider update requires regression testing. Every cloud infrastructure change — pricing, availability zones, networking policies — requires evaluation and sometimes migration. Every security audit touches your secrets layer. Every new product feature is scoped against what the infra supports, and sometimes it doesn't support the thing the product team wants.
+
+Three competitors are shipping faster. One of them, somehow, doesn't appear to have a platform team at all.
+
+The system built for last year's requirements is this year's constraint.
+
+---
+
+## The Shape of the Gap
+
+Three different teams. Three different timelines. Three different failure modes. One underlying cause:
+
+**Spawning a long-running, sandboxed, tool-using AI agent is not an API call. It's an infrastructure project.**
+
+For most application developers — the people building the kanban boards and support platforms and research tools and data pipelines — infrastructure projects are not what they're staffed for, excited by, or resourced to maintain.
+
+This gap is not permanent. Infrastructure problems always get abstracted away. Databases became services. Compute became serverless. Auth became a library and a SaaS. Search became an API call. Every layer that was once a project is now a primitive.
+
+The same thing will happen to agent execution. The question is when, and what gets built in the meantime by the teams who don't want to wait.
+
+**What the gap costs today:**
+
+- **Speed** — teams that should be shipping product spend months on plumbing
+- **Scope** — features that are technically possible never get prioritized because the implementation cost is too high
+- **Access** — only well-resourced teams can afford to experiment; smaller teams are locked out
+- **Quality** — DIY infrastructure has edge cases that production-hardened infrastructure doesn't: stream drops, session leaks, race conditions on concurrent turns
+
+---
+
+## What Could Exist If the Gap Were Closed
+
+If spawning a sandboxed, streaming, multi-turn AI agent were as simple as writing a database row — not a weekend project, not a sprint, not a quarter, but a single API call — what would developers build?
+
+These are sparks, not specs. Questions worth sitting with.
+
+---
+
+**In project management:**
+What if a ticket moving to "In Progress" could open a draft PR — not by triggering a template, but by spawning an agent that reads the ticket, understands the codebase, and writes actual code? What if the card moved itself to "In Review" when the agent finished? What would your backlog look like if the gap between "planned" and "drafted" was ten minutes instead of two days?
+
+**In customer support:**
+What if every new support ticket spawned an investigator that tried to reproduce the issue, documented what it found, and pre-tagged the ticket with severity and component — before a human touched it? What would that do to the economics of a support team? What would it do to response times?
+
+**In real estate and research-heavy consumer products:**
+What if a house hunter could drop a city and a list of priorities — walkability, school quality, commute time, neighborhood feel — and a fleet of agents fanned out to research each dimension in parallel, drawing a personalized map in real time? Not a filter on a generic dataset. An investigation tailored to this buyer.
+
+**In legal and compliance:**
+What if contract review meant uploading a PDF and watching an agent extract clauses, flag non-standard terms, surface risk, and generate a summary — not in a day, but in under a minute? What changes about the unit economics of legal work when the first pass is free?
+
+**In competitive intelligence:**
+What if your product team received a weekly briefing assembled by agents — tracking competitor releases, pricing changes, customer reviews, job postings — without anyone having to write a report? What decisions get made faster when the context is always current?
+
+**In sales:**
+What if every new lead in your CRM spawned a research agent that built a company brief, identified the right contact, and drafted a personalized first message — before the rep even opened the record? What's the conversion rate on outreach that's actually researched?
+
+**In incident response:**
+What if a monitoring alert triggered an agent that investigated the incident — checking logs, tracing requests, identifying the blast radius, correlating with recent deploys — and posted structured findings to Slack while the on-call engineer was still waking up? How many incidents get resolved before anyone's adrenaline spikes?
+
+**In data quality and pipelines:**
+What if a failed data quality check spawned an agent that identified the anomaly, traced it to a source system, and filed a structured report — not as a scheduled job that runs overnight, but as a reactive investigation that completes in the same window as the failure?
+
+**In education:**
+What if every student had a tutoring agent that remembered their previous sessions, tracked what they'd struggled with last time, and adapted its approach accordingly — not a stateless chatbot that forgets everything between conversations, but a persistent collaborator?
+
+**In security:**
+What if every pull request triggered an agent that scanned the diff for vulnerability patterns, checked for accidentally exposed secrets, and left a structured review comment — not a linter running static rules, but an investigator reasoning about intent and context?
+
+**In content and publishing:**
+What if a content brief could spawn an agent that researches the topic, synthesizes sources, and produces a structured first draft — not autocomplete finishing your sentences, but a researcher handing you something to react to?
+
+**In healthcare administration:**
+What if patient intake forms were processed by agents that extracted relevant history, flagged contradictions, and prepared a structured brief for the clinician — before the appointment started, not after?
+
+**In developer tooling beyond IDEs:**
+What if any internal tool — a deployment dashboard, a cost explorer, a feature flag manager — could spawn an agent to investigate anomalies, generate explanations, or propose changes? Not as a chat sidebar. As a native action.
+
+---
+
+These are not AI features. They are agent-powered applications. The distinction is important.
+
+An AI feature is a menu item. A chat sidebar. A Sparkles button that summarizes something. It's useful at the margin.
+
+An agent-powered application is a product where agents are woven into the core flow — triggered by events, doing real work in real sandboxes with real tools, streaming results back, changing state when they finish. The agent isn't a feature you talk to. It's part of how the product works.
+
+The developers who build these applications will look back and wonder why it ever seemed hard.
+
+---
+
+*This document describes a problem, not a solution. If you are building something in this space — or thinking about starting — the shape of the gap is the starting point, not the destination.*

--- a/narrative/killer-apps.md
+++ b/narrative/killer-apps.md
@@ -1,0 +1,197 @@
+# Three Killer Applications
+
+*Three product pitches for applications that are only now possible — built on an API that makes spawning a long-running, sandboxed, tool-using AI agent as simple as writing a database row.*
+
+---
+
+## 1. The Board That Ships
+
+### Your project management tool should open its own PRs.
+
+---
+
+**The pain every engineering team knows**
+
+A ticket sits in "Ready." A developer picks it up, reads it, opens their editor, finds the right files, writes the code, opens the PR, links it back to the ticket, and moves the card. This takes hours on a good day. The ticket and the work are tracked in two different systems that never talk to each other except through human copy-paste.
+
+The gap between "this is planned" and "this has a draft PR" is where engineering velocity goes to die.
+
+**The insight**
+
+What if the ticket moving to "In Progress" was the trigger — and a PR appearing in GitHub was the result?
+
+Not a template. Not a scaffold. An agent that reads the ticket, clones the repo, finds the relevant code, writes a meaningful implementation, runs the tests, and opens a pull request. The card moves itself to "In Review" when the agent finishes. The developer reviews code instead of writing boilerplate.
+
+**What you build**
+
+A project management tool — kanban, linear-style, whatever — where every ticket has an "agent" button or an automatic trigger on status change. The agent is spawned with the ticket body as its prompt, the repo URL in its environment, and a GitHub token in its secrets. It works in a persistent sandbox: it can clone the repo, explore the codebase across multiple turns, write and rewrite until tests pass, and push.
+
+The UI shows the agent working in real time — files opened, commands run, tests executed — streamed back over SSE while the user watches. When the agent completes, the PR URL appears on the ticket. If the agent gets stuck, the developer can continue the session with a follow-up prompt. The filesystem is still warm.
+
+**Why this wasn't possible before**
+
+A single API call to an LLM can't do this. It doesn't have a filesystem. It can't run tests. It can't explore a large codebase across multiple steps and remember what it found. It times out in seconds, not minutes.
+
+The piece that was missing was a runtime primitive: a long-running, sandboxed process with real tools and persistent state that you could spawn from your app like any other background job. That primitive now exists.
+
+**The build, briefly**
+
+```python
+# Ticket moves to In Progress
+session = client.sessions.create(
+    agent_id=coding_agent.id,       # claude-code runtime, repo tools configured
+    environment_id=env.id,           # GITHUB_TOKEN encrypted in environment
+    prompt=f"Implement this ticket:\n\n{ticket.body}\n\nRepo: {repo_url}"
+)
+
+# Stream agent output back to the ticket view
+for event in client.sessions.stream(session.id):
+    push_to_ticket_activity_feed(ticket.id, event)
+
+# On exit, attach PR URL to ticket
+ticket.update(pr_url=extract_pr_url(session), status="In Review")
+```
+
+**The market**
+
+Every engineering team using a project management tool is the market. The teams that ship this win because their users stop thinking of the tool as a tracker and start thinking of it as an execution engine. Tickets don't pile up. PRs appear. Velocity becomes measurable in a way it never was before.
+
+---
+
+## 2. Scout
+
+### When the alert fires, Scout wakes up first.
+
+---
+
+**The pain every on-call engineer knows**
+
+It's 2:47am. PagerDuty fires. You wake up, find your phone, dismiss the noise, open your laptop. You pull up Grafana. You grep logs. You check the recent deploy. You trace the request. Twenty minutes later, you have a hypothesis. If you're lucky, you also have a fix.
+
+The investigation — the part between "alert fired" and "I know what's wrong" — is almost entirely mechanical. It follows a playbook. It reads logs. It checks the same dashboards. It traces the same paths.
+
+No human should have to do that at 3am.
+
+**The insight**
+
+What if the alert spawned an agent that ran the entire investigation playbook — and posted its findings to Slack before the on-call engineer had even unlocked their phone?
+
+The engineer wakes up to: "Error rate spike on `/api/checkout`. Traced to a 503 from the payments service. Payments service started failing at 02:43:17, three minutes after the `v2.4.1` deploy. Blast radius: ~12% of checkout attempts. Suggested first step: rollback or disable the new payment retry logic."
+
+They don't investigate. They decide.
+
+**What you build**
+
+An incident response tool — or an integration into existing alerting workflows — where every PagerDuty/OpsGenie alert spawns a Scout session. The agent has access to whatever your team has wired up: a log query tool, a metrics API, a deployment history endpoint, a runbook reader. It follows a structured investigation: reproduce the symptom, identify the scope, trace to a cause, check for recent changes, form a hypothesis.
+
+The output is a structured brief in Slack: timestamp, affected surface, probable cause, evidence, suggested action, session link for the on-call to continue if they need to dig deeper.
+
+When the engineer picks up the page, they're not starting an investigation. They're reviewing one.
+
+**Why this wasn't possible before**
+
+Alert webhooks already exist. The problem was never triggering the agent. The problem was that there was no agent runtime capable of doing real investigative work: running bash commands, querying APIs, reading logs, spending several minutes exploring before forming a conclusion. LLM calls are stateless and fast. Investigation is stateful and slow.
+
+Scout needs a process that runs for two to five minutes, uses real tools, and produces an artifact. That's a session, not an API call.
+
+**The build, briefly**
+
+```python
+# PagerDuty webhook fires
+@app.post("/webhook/pagerduty")
+async def handle_alert(alert: Alert):
+    session = client.sessions.create(
+        agent_id=scout_agent.id,          # configured with log/metrics MCP servers
+        environment_id=prod_env.id,        # API keys for your observability stack
+        prompt=build_investigation_prompt(alert),
+        timeout=300                         # 5 minutes to investigate
+    )
+
+    # Stream findings into a Slack thread as they appear
+    async for event in client.sessions.stream(session.id):
+        if event.type == "output":
+            await slack.append_to_thread(alert.thread_ts, event.data)
+
+    # Final structured brief posted when agent finishes
+    await slack.post_summary(alert.thread_ts, session.id)
+```
+
+**The market**
+
+Every engineering team with on-call rotation is the market. The pitch is simple: Scout doesn't replace your engineers. It means your engineers sleep better. The first time someone wakes up to a solved incident instead of an empty Slack thread, Scout sells itself.
+
+---
+
+## 3. Brief
+
+### A research team in your product. Not a search bar. A team.
+
+---
+
+**The pain that scales with information**
+
+There's a category of knowledge work that follows the same pattern at every company: gather information from multiple sources, synthesize it into a coherent picture, deliver it to someone who needs to make a decision.
+
+Due diligence on an acquisition target. Competitive analysis before a product launch. Background research before a sales call. Neighborhood research before a house purchase. Literature review before a clinical decision. Investment analysis before writing a check.
+
+Today, this work is done by humans — often expensive ones — because no tool can actually do it. Search engines surface documents. Chatbots summarize text. But neither can fan out across sources, reason about what's missing, decide what to investigate next, and synthesize a coherent brief. That requires something that can run for a while, use real tools, and maintain context across a multi-step investigation.
+
+**The insight**
+
+What if your product could spawn a research fleet — concurrent agents investigating different dimensions of a question in parallel — and stream their findings back as a live, assembling brief?
+
+The user drops a company name. One agent researches their product and pricing. Another reads their recent press and job postings. A third searches customer reviews and forums. A fourth checks the founding team's backgrounds. The brief assembles in real time as each agent returns, synthesis happening as the final agent finishes.
+
+Not a search. Not a summary. A researched opinion.
+
+**What you build**
+
+A research product for any domain where the unit of work is "give me everything I need to know about X." The user submits a target and a context. The application fans out a configurable number of concurrent agent sessions — each one assigned a specific research dimension — then collects and synthesizes their outputs into a structured brief.
+
+The UI is the brief assembling in real time: sections appearing as agents complete, sources cited inline, gaps flagged, a synthesis section that writes itself last. Users can drill into any section and ask follow-up questions — opening a new session with the context of what was already found.
+
+The product works for any domain where research is valuable and time-consuming: sales intelligence, real estate, M&A, competitive analysis, hiring, venture investing, policy research, academic literature review.
+
+**Why this wasn't possible before**
+
+The fan-out pattern — multiple concurrent long-running agents, each with real tools, streaming results back as they complete — is not achievable with single API calls. You need a session primitive: isolated, parallel, streaming, with enough runtime to do real web research across multiple sources.
+
+The synthesis step — a final agent reading all the intermediate outputs and writing a coherent brief — requires multi-turn: the filesystem where intermediate results landed is still warm when the synthesis agent starts.
+
+**The build, briefly**
+
+```python
+# User submits a research request
+dimensions = ["product_and_pricing", "team_and_history",
+               "customers_and_reviews", "market_and_competitors"]
+
+# Fan out concurrent research sessions
+research_sessions = await asyncio.gather(*[
+    client.sessions.create(
+        agent_id=researcher_agent.id,
+        environment_id=research_env.id,   # web_search + web_fetch tools enabled
+        prompt=build_research_prompt(target, dimension)
+    )
+    for dimension in dimensions
+])
+
+# Stream each session's output into its brief section in real time
+await asyncio.gather(*[
+    stream_to_brief_section(session, dimension)
+    for session, dimension in zip(research_sessions, dimensions)
+])
+
+# Synthesis: spawn one more agent with all findings as context
+synthesis = client.sessions.create(
+    agent_id=synthesizer_agent.id,
+    prompt=f"Synthesize these research findings into a brief:\n\n{combined_findings}"
+)
+```
+
+**The market**
+
+The research-as-a-product market is currently served by human analysts, expensive SaaS tools, and DIY prompt chains that produce shallow results. Brief wins because it actually does the work — not a summary of search results, but a structured investigation with sources, gaps, and a reasoned synthesis. The first vertical to nail this becomes the default tool for that domain.
+
+---
+
+*These three applications share a common foundation: a runtime primitive that makes long-running, sandboxed, tool-using agents as easy to spawn as a background job. The infrastructure exists. The applications don't yet — which means the window is open.*

--- a/narrative/press-release.md
+++ b/narrative/press-release.md
@@ -1,0 +1,93 @@
+# Agent on Demand Lets Developers Spawn AI Agents Like Database Rows
+
+**A three-resource REST API eliminates months of infrastructure work, bringing long-running, sandboxed, streaming agents into any application with a single POST request**
+
+*FOR IMMEDIATE RELEASE*
+
+---
+
+**SAN FRANCISCO, April 29, 2026** — Today, Agent on Demand announced the general availability of its REST API for spawning, managing, and streaming AI agents — making it possible for any developer to add long-running, sandboxed, tool-using agent workflows to their application without building or owning agent infrastructure.
+
+With Agent on Demand, developers define an agent once, send it a prompt, and read its work streaming back over Server-Sent Events in real time — the same way they'd write a row to a database or enqueue a background job. Sandboxing, secrets management, multi-turn session persistence, streaming, and lifecycle cleanup are handled entirely by the API.
+
+---
+
+## The Problem Developers Were Solving Before This Existed
+
+Building a meaningful agent feature into a production application has meant building infrastructure first: provisioning isolated sandboxes, encrypting and injecting per-user secrets, designing a streaming protocol, tracking multi-turn session state, and handling lifecycle cleanup when sessions complete or fail.
+
+For most teams, this is a months-long infrastructure project before a single user-facing feature ships.
+
+Solo builders hit the infrastructure wall and stop. Platform teams ship something fragile after a quarter and become permanently on-call for it. The teams that do it right spend eighteen months on plumbing — and then maintain that plumbing indefinitely, with every new product feature subject to what the infrastructure supports.
+
+The result: agent-powered applications have been accessible only to teams with significant infrastructure resources. The kanban board that opens PRs when a ticket moves. The support inbox that investigates tickets before a human touches them. The research tool that fans out a fleet of agents and synthesizes the results in real time. These experiences have been technically possible for over a year. The infrastructure cost has kept most teams from starting.
+
+---
+
+## What Agent on Demand Built
+
+Agent on Demand is a three-resource REST API:
+
+**Agents** are the recipe. A developer defines a model, runtime, system prompt, tools, MCP servers, and skills once — versions it, and reuses it across as many sessions as needed. Updating an agent doesn't break existing sessions; version history is preserved.
+
+**Environments** are the sandbox. A developer declares the packages to install, secrets to inject (encrypted at rest, never returned by the API), setup scripts to run, and network policy to apply. That declaration is applied automatically every time a session provisions — no manual setup, no per-session ops work.
+
+**Sessions** are the run. One agent in one environment, executing against a prompt. Output streams back over Server-Sent Events in real time — provisioning stages, stdout, exit status. Developers can continue the conversation with a follow-up prompt; the filesystem and agent context persist between turns. Every turn is logged and replayable from any cursor position.
+
+A developer with an API token can spawn a fully sandboxed, tool-using agent — with streaming output reaching their UI — in under a minute.
+
+---
+
+## What Developers Are Building
+
+Teams using Agent on Demand have shipped:
+
+**Project management integrations** where moving a ticket to "In Progress" spawns an agent that reads the ticket, writes code against the relevant codebase, and opens a PR — with the card moving itself to "In Review" when the agent finishes. What was a multi-month infrastructure project is now a weekend integration.
+
+**Support inbox automation** where every new ticket spawns an investigator agent that attempts to reproduce the issue, documents its findings, and pre-tags the ticket with severity and component — before a human touches it. Support teams report handling significantly higher ticket volume with the same headcount.
+
+**Batch research pipelines** where concurrent agent sessions fan out across data sources — competitor sites, regulatory filings, customer reviews — and synthesize results in parallel. Research that took days of manual work now completes overnight.
+
+**Internal dashboards** where teams access shared agent capabilities without distributing individual model API keys. A single service token, a FastAPI proxy, and any team member can run an agent session through a browser.
+
+**Slack bots** where each thread maps to a persistent agent session. The agent remembers the conversation, the files it has worked with, and the context from previous turns — because the Sprite filesystem is still warm between messages.
+
+---
+
+## What Developers Say
+
+> "I spent three months trying to build sandboxed agent execution myself. I got something that mostly worked — leaked sessions on termination, dropped streams under load, broke when two users hit it simultaneously. Then I saw Agent on Demand and had a working session streaming to my UI in eight minutes. The thing I spent a quarter building is now a POST request."
+
+— Developer, early access
+
+> "We'd been putting off the agent feature because every scoping conversation ended with 'and then we'd need a platform team to own the infra.' Agent on Demand removed that blocker entirely. We shipped in a sprint."
+
+— Engineering lead, B2B SaaS
+
+---
+
+## How It Works
+
+Agent on Demand runs sessions on Sprites — isolated virtual machines with full tool access: bash execution, file reading and writing, web search, and any MCP servers the developer configures. Secrets are encrypted with Fernet and never returned in API responses. Sessions stream output over SSE with heartbeats every fifteen seconds and replay support from any log cursor position.
+
+The API supports four runtimes: Claude (Anthropic), Codex (OpenAI), Gemini (Google), and opencode. Developers bring their own model API keys. No model costs are bundled into the API pricing.
+
+Typed SDKs ship for Python (`aod-sdk` on PyPI) and TypeScript (`@ravi-hq/aod-sdk` on npm), with synchronous and asynchronous clients and full streaming support. Reference implementations are provided for the four most common integration patterns: CLI wrapper, Slack bot, web dashboard, and batch automation harness.
+
+Agent on Demand is open-source under the Apache 2.0 license. Developers can run the full stack locally with `make dev`, deploy it on any cloud platform using the provided Render configuration, or use the hosted API at aod.ravi.id.
+
+---
+
+## Availability
+
+Agent on Demand is available today.
+
+- **Hosted API:** aod.ravi.id — sign up, add a model key, stream a session in under a minute
+- **Documentation:** ravi-hq.github.io/agent-on-demand — quickstart, API reference, and integration patterns
+- **Source code:** github.com/ravi-hq/agent-on-demand — Apache 2.0, CI-gated, mutation-tested
+- **Python SDK:** `pip install aod-sdk`
+- **TypeScript SDK:** `npm install @ravi-hq/aod-sdk`
+
+---
+
+*About Agent on Demand: Agent on Demand is an open-source REST API for spawning, managing, and streaming AI agents. Built by Ravi HQ and licensed under Apache 2.0, it is available as a self-hosted deployment or as a managed service at aod.ravi.id.*

--- a/narrative/slideshow.md
+++ b/narrative/slideshow.md
@@ -1,0 +1,270 @@
+# Agent on Demand — Narrative Deck
+
+---
+
+## Slide 1 — Title
+
+# Agents Are the New Compute
+
+### The infrastructure to build agent-powered apps — without building infrastructure
+
+---
+
+## Slide 2 — The World Changed
+
+# Two Years Ago vs. Today
+
+**Two years ago**, "AI in your product" meant one thing:
+Call an LLM. Stream tokens. Render a chat bubble.
+
+**Today**, the agents that matter don't chat. They do work.
+
+- They have tools — bash, file editing, web search
+- They have a filesystem that persists between turns
+- They run for minutes, not milliseconds
+- They come back with an artifact — a diff, a report, a briefing — not a paragraph
+
+**You've already seen the prototypes: Claude Code. Codex. Gemini CLI.**
+These aren't dev toys. They're the template for what everyday software will do next.
+
+---
+
+## Slide 3 — The New Expectation
+
+# Users Will Expect This Everywhere
+
+Not in IDEs. **Everywhere.**
+
+- The kanban board that opens the PR when a ticket moves
+- The support inbox that investigates tickets before humans touch them
+- The research tool that builds the briefing while you get coffee
+- The sales tool that researches the prospect before the rep opens the record
+
+Apps that ship these experiences will redefine their categories.
+Apps that bolt on a chat sidebar will look like dial-up websites.
+
+**The question isn't whether this happens. It's who builds it first.**
+
+---
+
+## Slide 4 — Archetype 1: The Solo Builder
+
+# "I Just Wanted to Add One AI Feature"
+
+**The estimate:** a weekend.
+
+**What actually happened:**
+
+1. Users won't stare at a spinner — need streaming → build an SSE layer
+2. The agent needs tools — need a runtime, not just an API call → research sandboxing
+3. Per-user API keys can't live in env vars → design and build a secrets layer
+4. Users need to follow up → session filesystem needs to persist between turns
+5. Sessions don't clean themselves up → add lifecycle management
+
+**Three months in. Zero new features shipped. Infra that sort of works.**
+
+Most solo builders stop here.
+The ones who keep going spend another three months hardening it.
+By the time it's shippable, the window has moved.
+
+---
+
+## Slide 5 — Archetype 2: The Platform Team
+
+# "We Have the Resources. Nothing Ships."
+
+Two senior engineers. One month of runway. Leadership is excited after the demo.
+
+| Week | What they were building |
+|------|------------------------|
+| 3 | Sandbox isolation — evaluate, choose, integrate |
+| 6 | Secrets layer — design, auth integration, security review |
+| 9 | Streaming + state management — SSE, reconnects, replay |
+| 11 | Multi-turn persistence — filesystem across turns, context survival |
+| 14 | **Ship beta** — slow cold starts, known stream drops, session leak bug |
+
+**Result:** Q3 deadline met. "Beta" label. Known issues page.
+The platform team is now permanently on-call.
+Every new product feature is a negotiation.
+
+---
+
+## Slide 6 — Archetype 3: The Team That Built It Right
+
+# "We Shipped It. Now We Own It Forever."
+
+18 months. 3 engineers. Production-grade, and genuinely proud of it.
+
+✓ Isolated sandboxes  
+✓ Encrypted secrets  
+✓ Reliable streaming with replay  
+✓ Multi-turn session persistence  
+✓ Worker queue and observability  
+✓ Automated lifecycle cleanup  
+
+**Also:**
+
+- Every model provider update → regression testing
+- Every cloud pricing change → evaluation and possible migration
+- Every new product request → scoped against what the infra supports
+- Three competitors shipping faster — apparently without a platform team
+
+**The system built for last year's requirements is this year's constraint.**
+
+---
+
+## Slide 7 — The Root Cause
+
+# Spawning an Agent Is an Infrastructure Project
+
+Three teams. Three timelines. Three failure modes. One cause.
+
+> Building a long-running, sandboxed, tool-using agent into your app
+> is not an API call. **It's a sprint. Or a quarter. Or eighteen months.**
+
+**What the gap costs:**
+
+| Cost | Impact |
+|------|--------|
+| Speed | Product teams wait on infra teams |
+| Scope | Features that are possible never get built |
+| Access | Only well-resourced teams can experiment |
+| Quality | DIY infra has edge cases production infra doesn't |
+
+**This gap will close. The question is whether you wait for it.**
+
+---
+
+## Slide 8 — The New World
+
+# What If Spawning an Agent Looked Like This?
+
+```python
+session = client.sessions.create(
+    agent_id=agent.id,
+    prompt="Review this PR and file a structured report"
+)
+
+for event in client.sessions.stream(session.id):
+    print(event)
+```
+
+**That's it.**
+
+No sandbox to provision. No secrets to manually inject.
+No streaming protocol to design. No lifecycle to manage.
+No platform team to hire.
+
+Define the agent once. Send a prompt. Read the stream.
+The agent runs in its own sandbox, with its own tools, on its own filesystem.
+Results stream to your UI in real time.
+
+---
+
+## Slide 9 — What Gets Built
+
+# The Applications That Become Possible
+
+| Domain | What agents enable |
+|--------|--------------------|
+| Project management | Ticket moves → agent writes PR → card updates itself |
+| Customer support | New ticket → investigator agent → pre-tagged, pre-documented |
+| Real estate | Drop a city + priorities → research fleet → personalized map |
+| Legal | Upload contract → agent extracts clauses, flags risk |
+| Competitive intel | Weekly briefing assembled by agents, no one writes it |
+| Sales | New CRM lead → research agent → brief + drafted outreach |
+| Incident response | Alert fires → agent investigates → posts to Slack |
+| Data pipelines | Quality failure → agent traces anomaly → files report |
+| Education | Student session → persistent tutor with memory across sessions |
+| Security | PR opened → agent scans diff → structured vulnerability review |
+
+**None of these is a chatbot. All of them are agent-powered applications.**
+
+---
+
+## Slide 10 — Three Resources. One HTTP API.
+
+# Agent on Demand
+
+**Agents** — the recipe
+Model, runtime, system prompt, tools, MCP servers, skills.
+Define once. Version forever. Share across a million sessions.
+
+**Environments** — the sandbox
+Packages, encrypted secrets, setup scripts, network policy.
+Declared once. Applied automatically at provision time. Never returned in API responses.
+
+**Sessions** — the run
+One agent in one sandbox. Streaming over SSE. Multi-turn with filesystem persistence.
+Logged, replayable, terminable.
+
+```
+POST /sessions      →  session created, provisioning begins
+GET  /sessions/{id}/stream  →  SSE stream, real-time output
+POST /sessions/{id}/prompt  →  continue the conversation
+```
+
+*Bring your own model keys. Apache 2.0. No lock-in.*
+
+---
+
+## Slide 11 — The Evidence
+
+# It's Real. It Runs. People Are Building on It.
+
+**aod.ravi.id** — hosted API, live now.
+Sign up, add a model key, stream a session in under a minute.
+
+**Apache 2.0** — real code on GitHub.
+CI-gated migrations. Mutation-tested critical paths. Two-process Django + Procrastinate worker.
+
+**Four runtimes** — Claude, Codex, Gemini, opencode.
+Bring your own Anthropic, OpenAI, or Google key.
+
+**Typed SDKs** — `aod-sdk` on PyPI · `@ravi-hq/aod-sdk` on npm.
+Sync + async. Full streaming. Same API, Python or TypeScript.
+
+**Reference implementations that ship** — Slack bot, web dashboard, batch pipeline, CLI wrapper.
+Not one of them is a chatbot.
+
+---
+
+## Slide 12 — The Transformation
+
+# Before and After
+
+**Before Agent on Demand:**
+
+- Kanban that ships PRs → 9 months of infra → Series A to staff the platform team
+- Support inbox that investigates → 6 months → fragile, on-call forever
+- Research tool with a fleet of agents → "maybe next year"
+- Incident responder that wakes up before you → never prioritized
+
+**After:**
+
+- Kanban that ships PRs → **weekend hack**
+- Support inbox that investigates → **one sprint**
+- Research tool with a fleet of agents → **a feature, not a company**
+- Incident responder → **two POST requests and an SSE stream**
+
+The teams that treat agents as a primitive will define the next wave of software.
+The teams that treat agents as an infrastructure project will watch them do it.
+
+---
+
+## Slide 13 — Start Building
+
+# Agent on Demand
+
+**API:** aod.ravi.id
+**Docs:** ravi-hq.github.io/agent-on-demand
+**Source:** github.com/ravi-hq/agent-on-demand
+
+```
+pip install aod-sdk
+npm install @ravi-hq/aod-sdk
+```
+
+Apache 2.0. Self-host or use the managed API. Bring your own model keys.
+
+**The primitive is here. What are you building?**

--- a/narrative/story-page.md
+++ b/narrative/story-page.md
@@ -1,0 +1,44 @@
+# Story Page — Agent on Demand
+
+---
+
+## The Two-Liner
+
+The next generation of apps won't have an "AI features" tab.
+They'll have agents doing real work — spawning on demand, running in their own sandboxes, streaming results back while your users watch.
+
+Building that just became a three-resource REST API.
+
+---
+
+## Elevator Pitch
+
+For two years, "AI in your product" meant one thing: call an LLM, stream tokens, render a chat bubble. Easy to add. Forgettable to use.
+
+The agents that actually matter don't chat — they do work. They have tools. They have a filesystem. They run for minutes. They produce real artifacts — diffs, reports, briefings. You've seen the prototypes in developer tooling: Claude Code opens PRs, Codex runs test suites, Gemini CLI reads entire codebases. The question isn't whether this pattern will show up in everyday software. It already is. The question is who builds it first.
+
+The problem is the infrastructure. Spawning a long-running, sandboxed, tool-using agent today means provisioning compute, managing encrypted secrets, inventing a streaming protocol, handling multi-turn session state, and dealing with cleanup. It's not an afternoon of app code. It's months of ops work — before you write a single feature.
+
+Agent on Demand collapses all of that to a three-resource REST API: define an agent, hand it a prompt, read the stream. No infrastructure to provision. No lifecycle to manage. No ops team to hire. Agents become part of your app's surface area — not a side project that owns your calendar.
+
+---
+
+## Big Picture Vision
+
+Software is being rewritten from the inside. Not at the layer of features or UX patterns — at the level of what apps are capable of doing on behalf of their users.
+
+For a decade, the most ambitious software competed on data and personalization. The best apps knew you better than you knew yourself — recommending, ranking, surfacing. Powerful. But the app still waited for you to act. It was a very smart assistant that couldn't actually do anything.
+
+The next wave acts. A project management tool that doesn't just track the state of a ticket — it opens the PR when the ticket moves. A support platform that doesn't just route tickets — it investigates them before a human touches them. A research tool that doesn't just surface documents — it synthesizes them into a briefing while you get coffee.
+
+These aren't chatbots with a better UI. They're applications where agents are woven into the core flow: triggered by events, doing real work in real sandboxes, streaming results back in real time, changing state when they're done.
+
+The teams building this experience will redefine their categories. The teams that bolt a chat bubble onto their sidebar will look like the dial-up websites of 1999.
+
+Agent on Demand provides the infrastructure layer that makes this a product decision, not an infrastructure project. Three resources — agents, environments, sessions. One POST per turn. Results streaming over SSE while your UI updates in real time. Bring your own model keys. Multi-provider: Anthropic, OpenAI, Google. Open-source, Apache 2.0, no lock-in.
+
+This is the world where the kanban-that-ships-PRs is a weekend hack, not a Series A. Where house-hunting-with-a-research-fleet is a feature, not a company. Where the support inbox that investigates tickets before humans touch them is a sprint, not a quarter.
+
+Any developer who can write a POST request can now ship the kind of product that was, one year ago, the headline of a TechCrunch article.
+
+The primitive is here. The only question is what gets built on top of it.


### PR DESCRIPTION
## Summary

- **`narrative/story-page.md`** — the narrative spine: two-liner, elevator pitch, big picture vision. Everything else derives from this.
- **`narrative/idea-document.md`** — developer mirror: three archetypes (Solo Builder, Platform Team, Team That Built It), the shape of the infrastructure gap, and 13 application sparks framed as questions. No product or solution mentioned — pure problem space and possibility seeding.
- **`narrative/press-release.md`** — Amazon-style PRFAQ: customer-first lead, what was built, five concrete things teams are already shipping on AoD, developer quotes (placeholders — replace with real ones), and full CTA.
- **`narrative/slideshow.md`** — 13 markdown slides: title → world changed → new expectation → archetype arc → root cause → new world with code → application table → three resources → evidence → before/after → CTA. Renderable with Slidev or Marp.

## Audience

All four documents are written for **developers/builders** — the framing is recognition of their pain first, possibility second.

## Notes

- Developer quotes in the press release are fabricated placeholders and should be replaced with real ones before any public use.
- The application sparks in the idea document are intentionally broad; prune or expand based on which verticals matter most to your community.
- The idea document deliberately never mentions Agent on Demand or any product — it is intended to seed ideas, not pitch a solution.

## Test plan

- [ ] Read `story-page.md` first — does the two-liner hook? Does the vision land?
- [ ] Read `idea-document.md` — do the archetypes feel true? Does the "What Could Exist" section spark ideas without feeling like a pitch?
- [ ] Read `press-release.md` — does it follow Amazon PRFAQ structure? Is the problem crisp, the solution clear, the evidence believable?
- [ ] Read `slideshow.md` — does the narrative arc hold slide to slide? Would you sit through this talk?

🤖 Generated with [Claude Code](https://claude.com/claude-code)