### PR TITLE
fix(docs): point API viewer at ../openapi.json (directory-URL resolution)

### DIFF
--- a/site/docs/api/reference.md
+++ b/site/docs/api/reference.md
@@ -8,7 +8,7 @@ This page provides an interactive API reference powered by [Stoplight Elements](
 
 <div>
   <elements-api
-    apiDescriptionUrl="openapi.json"
+    apiDescriptionUrl="../openapi.json"
     router="hash"
     layout="stacked"
     tryItCredentialsPolicy="include"


### PR DESCRIPTION
## What

The hosted AOD API viewer (Stoplight Elements page at `site/docs/api/reference.md`) renders empty.

## Why

MkDocs uses directory URLs by default, so `api/reference.md` is served at `…/api/reference/`. The viewer's relative `apiDescriptionUrl="openapi.json"` therefore resolves to `…/api/reference/openapi.json` — a 404. The spec is exported by `docs.yml` to `…/api/openapi.json`, so the viewer fetched nothing.

Verified against the live site:

```
200  /agent-on-demand/api/openapi.json
404  /agent-on-demand/api/reference/openapi.json
```

## Fix

Use `../openapi.json`, which resolves to `…/api/openapi.json` on both GitHub Pages and local `mkdocs serve` (an absolute path would break locally since the Pages base path isn't present in dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)